### PR TITLE
Fix episode context menu focus

### DIFF
--- a/app/src/main/java/com/kino/puber/ui/feature/details/component/DetailsScreenContent.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/details/component/DetailsScreenContent.kt
@@ -141,6 +141,7 @@ internal fun DetailsScreenContent(
                         onEpisodeSelected = { item -> onAction(DetailsAction.EpisodeSelected(item)) },
                         onEpisodeContextMenu = { episodeContextMenuItem = it },
                         onBackPressed = { onAction(DetailsAction.CloseSeasonsPanel) },
+                        allowFocusExit = episodeContextMenuItem != null,
                         modifier = Modifier.focusRequester(seasonsPanelFocusRequester),
                     )
                 }

--- a/app/src/main/java/com/kino/puber/ui/feature/player/component/EpisodesPanel.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/player/component/EpisodesPanel.kt
@@ -28,6 +28,7 @@ internal fun EpisodesPanel(
     onEpisodeSelected: (VideoItemUIState) -> Unit,
     onEpisodeContextMenu: ((VideoItemUIState) -> Unit)? = null,
     onBackPressed: (() -> Unit)? = null,
+    allowFocusExit: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
     AnimatedVisibility(
@@ -41,7 +42,13 @@ internal fun EpisodesPanel(
                 .fillMaxSize()
                 .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.9f))
                 .padding(top = 32.dp)
-                .focusProperties { onExit = { cancelFocusChange() } }
+                .focusProperties {
+                    onExit = {
+                        if (!allowFocusExit) {
+                            cancelFocusChange()
+                        }
+                    }
+                }
                 .focusGroup(),
         ) {
             if (episodes != null) {

--- a/app/src/main/java/com/kino/puber/ui/feature/player/component/PlayerSettingsPanels.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/player/component/PlayerSettingsPanels.kt
@@ -59,6 +59,7 @@ internal fun PlayerSettingsPanels(
         onEpisodeSelected = { item -> onAction(PlayerAction.SelectEpisodeById(item.id)) },
         onEpisodeContextMenu = { episodeContextMenuItem = it },
         onBackPressed = rememberAction(onAction, PlayerAction.ClosePanel),
+        allowFocusExit = episodeContextMenuItem != null,
     )
 
     EpisodeContextMenuDialog(


### PR DESCRIPTION
## Task Summary
- Fixes focus handoff for episode/season context menus in details and player episode panels.
- Keeps `EpisodesPanel` focus containment by default, and only allows focus to leave the panel while an episode context menu is open.
- Updated both `EpisodesPanel` call sites found by search: details seasons list and player settings episodes list.

## Compliance Review
Passed. Rule sources checked: root `AGENTS.md`, `.kent/commands/compliance-review.md`, `.kent/project-contract.md`, PUB-2 task body, and `.todo/bugfix-season-context-menu-focus/diagnosis.md`. Reviewed diff contains only:
- `app/src/main/java/com/kino/puber/ui/feature/player/component/EpisodesPanel.kt`
- `app/src/main/java/com/kino/puber/ui/feature/details/component/DetailsScreenContent.kt`
- `app/src/main/java/com/kino/puber/ui/feature/player/component/PlayerSettingsPanels.kt`

No compliance findings were reported.

## Verification
- `./tools/agentw :app:compileDevDebugKotlin` - passed (`BUILD SUCCESSFUL`, configuration cache reused).
- Post-fix UI evidence reviewed in `.todo/bugfix-season-context-menu-focus/`: menu focus lands on the context-menu action, DPAD down moves within the menu, dismissal returns focus to the episode card, and normal no-menu left containment remains active.
- `rg "EpisodesPanel\\(" app/src/main/java/com/kino/puber/ui/feature` confirmed both production call sites were updated.

## Skipped Checks / Blockers
- This PR shipping step did not rerun build or device smoke checks; it used the already completed implementation, verification, and mandatory Compliance Review evidence.
- `.kent/commands/ship-pr.md` was missing in this PUB-2 worktree. For shipping procedure, I followed the project contract and the equivalent command file present in sibling Puber worktrees.
