### PR TITLE
Fix held D-pad scrolling in nested rows

### DIFF
--- a/app/src/main/java/com/kino/puber/core/ui/uikit/component/PositionFocusedItemInLazyLayout.kt
+++ b/app/src/main/java/com/kino/puber/core/ui/uikit/component/PositionFocusedItemInLazyLayout.kt
@@ -1,5 +1,6 @@
 package com.kino.puber.core.ui.uikit.component
 
+import android.view.KeyEvent as AndroidKeyEvent
 import androidx.compose.foundation.gestures.BringIntoViewSpec
 import androidx.compose.foundation.gestures.LocalBringIntoViewSpec
 import androidx.compose.runtime.Composable
@@ -14,6 +15,11 @@ import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 
 internal val LocalRapidScrollActive = staticCompositionLocalOf<MutableState<Boolean>?> { null }
+
+enum class DpadScrollAxis {
+    Horizontal,
+    Vertical,
+}
 
 @Composable
 fun PositionFocusedItemInLazyLayout(
@@ -53,26 +59,29 @@ fun PositionFocusedItemInLazyLayout(
 }
 
 @Composable
-fun Modifier.dpadScrollOptimization(): Modifier {
+fun Modifier.dpadScrollOptimization(axis: DpadScrollAxis): Modifier {
     val rapidScrollActive = LocalRapidScrollActive.current ?: return this
     return this.onPreviewKeyEvent { event ->
-        when {
-            event.type == KeyEventType.KeyDown && event.nativeKeyEvent.repeatCount > 0 -> {
-                when (event.nativeKeyEvent.keyCode) {
-                    android.view.KeyEvent.KEYCODE_DPAD_RIGHT,
-                    android.view.KeyEvent.KEYCODE_DPAD_LEFT,
-                    android.view.KeyEvent.KEYCODE_DPAD_UP,
-                    android.view.KeyEvent.KEYCODE_DPAD_DOWN -> {
-                        rapidScrollActive.value = true
-                    }
-                }
+        val keyCode = event.nativeKeyEvent.keyCode
+        when (event.type) {
+            KeyEventType.KeyDown -> {
+                rapidScrollActive.value = event.nativeKeyEvent.repeatCount > 0 && axis.matches(keyCode)
                 false
             }
-            event.type == KeyEventType.KeyUp -> {
+            KeyEventType.KeyUp -> {
                 rapidScrollActive.value = false
                 false
             }
             else -> false
         }
+    }
+}
+
+private fun DpadScrollAxis.matches(keyCode: Int): Boolean {
+    return when (this) {
+        DpadScrollAxis.Horizontal -> keyCode == AndroidKeyEvent.KEYCODE_DPAD_LEFT ||
+            keyCode == AndroidKeyEvent.KEYCODE_DPAD_RIGHT
+        DpadScrollAxis.Vertical -> keyCode == AndroidKeyEvent.KEYCODE_DPAD_UP ||
+            keyCode == AndroidKeyEvent.KEYCODE_DPAD_DOWN
     }
 }

--- a/app/src/main/java/com/kino/puber/core/ui/uikit/component/moviesList/VideoGridUIState.kt
+++ b/app/src/main/java/com/kino/puber/core/ui/uikit/component/moviesList/VideoGridUIState.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import com.kino.puber.core.ui.uikit.component.DpadScrollAxis
 import com.kino.puber.core.ui.uikit.component.FadeGradient
 import com.kino.puber.core.ui.uikit.component.PositionFocusedItemInLazyLayout
 import com.kino.puber.core.ui.uikit.component.dpadScrollOptimization
@@ -144,7 +145,7 @@ private fun VideoGridItems(
                 modifier = Modifier
                     .fillMaxWidth()
                     .focusRequester(rowFocusRequester)
-                    .dpadScrollOptimization()
+                    .dpadScrollOptimization(axis = DpadScrollAxis.Horizontal)
                     .focusRestorer(savedItemFocusRequester),
                 state = listState,
                 horizontalArrangement = Arrangement.spacedBy(16.dp),

--- a/app/src/main/java/com/kino/puber/ui/feature/contentlist/content/SectionRow.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/contentlist/content/SectionRow.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.unit.dp
 import androidx.tv.material3.Button
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import com.kino.puber.core.ui.uikit.component.DpadScrollAxis
 import com.kino.puber.core.ui.uikit.component.FadeGradient
 import com.kino.puber.core.ui.uikit.component.LoadMoreHandler
 import com.kino.puber.core.ui.uikit.component.PositionFocusedItemInLazyLayout
@@ -116,7 +117,7 @@ private fun ContentSectionCards(
                     .fillMaxWidth()
                     .graphicsLayer { clip = false }
                     .focusRequester(contentFocusRequester)
-                    .dpadScrollOptimization()
+                    .dpadScrollOptimization(axis = DpadScrollAxis.Horizontal)
                     .focusRestorer(savedItemFocusRequester),
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
                 contentPadding = PaddingValues(16.dp),

--- a/app/src/main/java/com/kino/puber/ui/feature/home/component/HomeScreenContent.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/home/component/HomeScreenContent.kt
@@ -40,6 +40,7 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.kino.puber.R
 import com.kino.puber.core.ui.uikit.component.ApiDomainDialog
+import com.kino.puber.core.ui.uikit.component.DpadScrollAxis
 import com.kino.puber.core.ui.uikit.component.FullScreenProgressIndicator
 import com.kino.puber.core.ui.uikit.component.HeroCarousel
 import com.kino.puber.core.ui.uikit.component.PositionFocusedItemInLazyLayout
@@ -261,7 +262,7 @@ private fun HomeSectionRow(
         state = listState,
         modifier = Modifier
             .graphicsLayer { clip = false }
-            .dpadScrollOptimization()
+            .dpadScrollOptimization(axis = DpadScrollAxis.Horizontal)
             .focusRestorer(savedItemFocusRequester),
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         contentPadding = PaddingValues(horizontal = 16.dp),


### PR DESCRIPTION
## Task Summary

- Fixes PUB-3 held D-pad scrolling stalls in season/episode lists by making `dpadScrollOptimization` axis-aware.
- Existing `LazyRow` call sites now use horizontal mode, so repeated `DPAD_UP`/`DPAD_DOWN` no longer activates rapid-scroll suppression inside horizontal rows.
- Rapid-scroll state still resets on key-up and on non-repeat or non-matching key-down events.

## Compliance Review

Compliance Review passed with no violations. The reviewed diff is limited to:

- `app/src/main/java/com/kino/puber/core/ui/uikit/component/PositionFocusedItemInLazyLayout.kt`
- `app/src/main/java/com/kino/puber/core/ui/uikit/component/moviesList/VideoGridUIState.kt`
- `app/src/main/java/com/kino/puber/ui/feature/contentlist/content/SectionRow.kt`
- `app/src/main/java/com/kino/puber/ui/feature/home/component/HomeScreenContent.kt`

No project contracts, version catalogs, Compose stability config, or string resources were changed.

## Verification

- `git diff --check`: passed.
- `./tools/agentw :app:compileDevDebugKotlin --console=plain`: BUILD SUCCESSFUL.
- Compliance review confirmed no remaining no-argument `dpadScrollOptimization` call sites under `app/src/main/java`.

## Known Skipped Checks

- Full visual device verification on a many-season series was not repeated in this PR shipping step. Earlier investigation verified the affected `EpisodesPanel` / `VideoGrid` code path and long-press input path, but the local authenticated navigation/search path did not reliably reach a larger series fixture.