### PR TITLE
Bump version to 1.4.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
     alias(libs.plugins.androidx.baselineprofile)
 }
 
-val currentVersion = "1.3.4"
+val currentVersion = "1.4.0"
 
 /**
  * Reads CLIENT_SECRET from local.properties or system environment variable


### PR DESCRIPTION
## Summary
- Prepare the next minor Puber release: `1.4.0`.
- Bump `currentVersion` in `app/build.gradle.kts` from `1.3.4` to `1.4.0`.
- Release branch: `release/1.4.0`; intended post-merge tag: `v1.4.0`.

## Compliance Review
- Compliance Review passed for release `1.4.0` on commit `f618c0b11b7d7bc5262ca3e67e0a1657a42896b8`.
- Reviewed diff contains only the version bump in `app/build.gradle.kts`.
- No compliance violations were found.

## Verification
- `./tools/agentw :app:compileDevDebugKotlin :app:compileProdReleaseKotlin` completed successfully during release preparation.
- PR creation node re-checked repository state before pushing: clean `release/1.4.0` branch at `f618c0b11b7d7bc5262ca3e67e0a1657a42896b8`.

## Skipped Checks / Notes
- Production signing artifacts and environment variables are not present locally, so production packaging with signing secrets was not locally proven.
- Per the Puber release guidance, missing local signing secrets should be reported but do not block this version-bump PR.
- Do not merge this PR or create `v1.4.0` until the release workflow reaches the publication gate.