### PR TITLE
Revise Puber workflow waiting states

### DIFF
--- a/.kent/commands/compliance-review.md
+++ b/.kent/commands/compliance-review.md
@@ -32,7 +32,7 @@ The workflow prompt must provide the available inputs:
 - `commentary`: implementation/review/verification summary from the previous node.
 - `changed_files`: changed files, when known.
 
-If a required source is missing, report the review as blocked or incomplete and name the missing source.
+If a required source is missing, report the review as waiting for user action or incomplete and name the missing source.
 
 ## Work Mode
 
@@ -48,10 +48,13 @@ If a required source is missing, report the review as blocked or incomplete and 
 
 Complete with:
 
-- `done` when no compliance violations are found. Provide `compliance_report`.
+- The success transition named in the current workflow prompt when no compliance violations are found. New PR-producing
+  workflows use `ship_pr`; legacy no-PR release workflows may use `cleanup`. Provide `compliance_report`.
 - `needs_changes` when compliance violations require a fix/rework pass. Provide `compliance_report` and, when available,
   `workspace_path` and `changed_files`.
-- `blocked` when required rule/spec/task sources are missing or contradictory. Provide `blocker_reason`.
+- `needs_user_action` when required rule/spec/task sources are missing or contradictory. Provide `blocker_reason`.
+
+Do not hardcode `done` from this command; `done` is reserved for cleanup completion.
 
 For every finding include:
 

--- a/.kent/commands/feature-implement.md
+++ b/.kent/commands/feature-implement.md
@@ -191,7 +191,7 @@ After previews are ready, compare implementation with the Figma design screensho
 - If the implemented screen is now reachable (navigation wired):
   1. First check if an emulator is connected: call `.kent/adapters/mobile/emulator-resource-lock.sh adb-emulators`.
   2. If no emulator is found → skip smoke-test silently (don't ask the user). Physical devices are not eligible unless the
-     user explicitly named or allowed a physical serial.
+     user explicitly provided permission and an explicit physical serial.
   3. If an emulator is available → ask user: "Screen is reachable. Run smoke-test on emulator? (y/n)"
   4. If yes → **use Kent prompt command to invoke `/prompt:smoke-test`** with the screen name
   5. Save results to `.todo/<feature>/smoke-results/step-<N>.md`

--- a/.kent/commands/ship-pr.md
+++ b/.kent/commands/ship-pr.md
@@ -43,13 +43,19 @@ Desktop workflows.
    - Known skipped checks or blockers.
 6. Never merge the PR.
 7. Never push directly to `master`/`main`.
-8. If `gh` auth, remote, branch, or repository state prevents PR creation, complete `blocked` with a precise
-   `blocker_reason`.
+8. If recoverable repository, branch, or PR state prevents PR creation/update, complete `needs_changes` with
+   `workspace_path` and `blocker_reason`. Do not force-push unless the latest user comment explicitly permits force-push
+   for this exact PR/branch.
+9. If credentials, project policy, missing user input, or an unsafe repository state prevents progress, complete
+   `needs_user_action` with a precise `blocker_reason`.
 
 ## Completion Contract
 
 Complete with:
 
 - `monitor_ci` when a PR exists and CI should be monitored. Provide `pr_url`, `branch_name`, and `workspace_path`.
-- `done` only when PR is intentionally not applicable because there are no repository changes. Provide `pr_report`.
-- `blocked` when PR creation/update cannot be completed safely. Provide `blocker_reason`.
+- `no_pr` only when PR is intentionally not applicable because there are no repository changes. Provide `pr_report`.
+- `needs_changes` when task-scoped PR/branch issues can be fixed safely. Provide `workspace_path` and
+  `blocker_reason`.
+- `needs_user_action` when PR creation/update cannot be completed safely without user input, credentials, or a policy
+  decision. Provide `blocker_reason`.

--- a/.kent/commands/smoke-test.md
+++ b/.kent/commands/smoke-test.md
@@ -19,8 +19,8 @@ Runs smoke test for a feature via MCP mobile.
 
 1. Reads the MCP Mobile Testing section in `AGENTS.md` to understand the process
 2. **Acquire an emulator resource lock before touching any emulator/device**
-   - Physical devices, including a real TV, are forbidden unless the task/user explicitly names or allows that physical
-     device. Never rely on adb's default target selection.
+   - Physical devices, including a real TV, are forbidden unless the task/user explicitly provides permission and an
+     explicit serial for that physical device. Never rely on adb's default target selection.
    - Prefer already-running healthy emulators. Discover them with:
      ```bash
      EMULATORS=($(.kent/adapters/mobile/emulator-resource-lock.sh adb-emulators))
@@ -49,7 +49,7 @@ Runs smoke test for a feature via MCP mobile.
      .kent/adapters/mobile/emulator-resource-lock.sh release "$LOCK_RESOURCE" "$LOCK_TOKEN"
      ```
    - Before any install, launch, log, or shell command, verify `DEVICE_SERIAL` is non-empty and pass `adb -s
-     "$DEVICE_SERIAL"`. If `DEVICE_SERIAL` is empty, complete with `blocked` instead of running adb.
+     "$DEVICE_SERIAL"`. If `DEVICE_SERIAL` is empty, complete with `needs_user_action` instead of running adb.
    - If all running emulators are busy, inspect lock owners with:
      ```bash
      .kent/adapters/mobile/emulator-resource-lock.sh status <emulator-serial>
@@ -57,7 +57,8 @@ Runs smoke test for a feature via MCP mobile.
    - Start a second emulator only when the task/user explicitly allows parallel device usage and a suitable AVD/host
      capacity is available. If a second emulator is used, acquire a distinct lock name such as
      `emulator-5556` or `avd-<name>-<port>` before starting or using it.
-   - If no device can be safely acquired, complete the workflow with `blocked` and explain who/what holds the resource.
+   - If no device can be safely acquired, complete the workflow with `needs_user_action` and explain who/what holds the
+     resource.
 3. **Always builds and installs a fresh `devDebug` APK immediately before device testing**
    - Do this even if the user says the app is already running; stale APKs can hide or misattribute regressions.
    - Do not use Gradle `install*` tasks for smoke tests; they may invoke adb without the selected serial.

--- a/.kent/project-contract.md
+++ b/.kent/project-contract.md
@@ -15,10 +15,13 @@ Puber workflow commands must use explicit task artifacts. Do not infer a feature
 - Compliance Review produces `compliance_report`.
 - PR creation produces `pr_url`, `branch_name`, and `workspace_path`; no-diff/report-only PR skips produce `pr_report`.
 - PR/CI monitoring produces `ci_report`.
+- Waiting PR produces `waiting_reason` while the PR is open, `merge_report` after GitHub reports `state=MERGED`, or
+  `pr_report` when PR review/conflict/post-CI feedback must be fixed.
 - Release preparation produces `release_version`, `release_type`, `release_branch`, `release_tag`, `workspace_path`,
   `version_bump_commit`, and `verification_summary`.
 - Release publication produces `target_commit`, `tag_push_status`, and `release_report`.
-- Every blocked transition must provide `blocker_reason`.
+- Every recoverable wait transition must provide `blocker_reason` or `waiting_reason`.
+- Explicit task cancellation produces `closure_reason` or `cleanup_reason`.
 - Cleanup produces `cleanup_report`.
 
 ## Command Contract
@@ -62,8 +65,8 @@ to project-local capability roles:
   that serial with `adb -s`.
 - Starting another emulator is allowed only when the task/user explicitly permits parallel device usage and the agent
   acquires a distinct lock for it.
-- Physical devices, including a real TV, are forbidden unless the task/user explicitly names or allows that physical
-  device. Smoke agents must never rely on adb's default target selection.
+- Physical devices, including a real TV, are forbidden unless the task/user explicitly provides permission and an
+  explicit serial for that physical device. Smoke agents must never rely on adb's default target selection.
 - Device smoke tests must always install the freshly built dev APK before launch, even if the user says the app is already
   running.
 - Smoke agents must build with `:app:assembleDevDebug` and install with explicit
@@ -82,8 +85,11 @@ Default cleanup is conservative because deleting Kent-managed task worktrees can
 worktree metadata until Kent rebind behavior is fixed.
 
 - `cleanup_managed_task_worktrees`: `false` by default.
-- Code-producing workflow cleanup must happen after PR creation/update and CI monitoring, or after an explicit
-  no-diff/report-only `pr_report`.
+- Code-producing workflow cleanup must happen after `waiting_pr` confirms the PR is merged through GitHub state, or after
+  an explicit no-diff/report-only `pr_report`.
+- Release cleanup must happen after tag publication is monitored, or after explicit user cancellation.
+- Cleanup after a PR path must verify `gh pr view --json state,mergedAt,mergeCommit,headRefName,baseRefName,url` when
+  GitHub CLI is available. Do not rely only on git ancestry because squash merges are allowed.
 - Cleanup nodes should report safe-to-remove worktrees and branches unless explicit project/user policy enables removal.
 - Destructive cleanup requires proof that worktrees are clean and branch commits are recoverable from remote refs or a
   merged PR.
@@ -91,19 +97,31 @@ worktree metadata until Kent rebind behavior is fixed.
 
 ## Recoverable Blocking Policy
 
-`blocked` is a terminal sink and should be used only when continuing would be unsafe without changing task scope,
-credentials, or project policy. Temporary external problems must use recoverable transitions instead:
+Recoverable blockers must not use a terminal node. The workflow keeps the task in its current stage:
 
-- `retry_later`: CI/GitHub is still starting or unavailable, device/MCP/emulator access is temporarily unavailable, or
-  release automation is still starting. This transition must require user approval before retrying the same node.
-- `needs_changes`: the task branch, PR, CI fallout, or release branch needs recoverable fixes such as rebase, conflict
-  resolution, or branch metadata repair. This transition must require user approval before returning to `fix` or
-  `prepare`.
-- `not_ready`: release tag publication was approved before the PR was merged or visible on `origin/master`; return to
-  `ci_monitor` after user action instead of ending in terminal `blocked`.
+- `needs_user_action`: the current stage cannot safely continue until the user or an external system resolves a blocker.
+  The transition is approval-gated, loops back to the same node, and must provide `blocker_reason`.
+- `needs_changes`: audit/review/compliance/CI/PR feedback needs task-scoped fixes. Internal fix loops should not require
+  approval; `ship_pr -> needs_changes` stays approval-gated because branch recovery can involve rebase or force-push
+  policy.
 
-Already terminal-blocked tasks cannot be moved back to `backlog` with `kent task move`; create a replacement task with
-the previous task context when recovery is needed after the terminal transition was applied.
+Terminal `wont_do` is only for explicit user cancellation or "not planned" decisions and requires approval. It is not a
+recoverable blocker.
+
+## PR Waiting Policy
+
+`done` is reserved for delivered work, not "agent finished." For PR-producing workflows:
+
+- `ci_monitor` routes successful or intentionally skipped checks to `waiting_pr`.
+- `waiting_pr` checks the pull request through GitHub. It must not merge, push, tag, or clean up.
+- If the PR is still open, `waiting_pr` writes a task comment with the current PR status and takes the approval-gated
+  `needs_user_action` self-loop.
+- If the PR has review comments, conflicts, or post-CI regressions that fit the task scope, `waiting_pr` takes
+  `needs_changes` back to `fix` or `prepare`.
+- If GitHub reports `state=MERGED`, `waiting_pr` advances to cleanup for normal workflows.
+- Release workflows route `waiting_pr -> pr_merged -> publish` with human approval before tag publication.
+- `close_without_merge` is approval-gated and valid only when the latest user comment explicitly says to close, cancel, or
+  skip the PR.
 
 ## Release Policy
 
@@ -111,8 +129,9 @@ Use `Puber Release` for human-facing release tasks.
 
 - Default release type is next minor from `origin/master`.
 - Patch and major releases require explicit task wording.
-- The workflow prepares the version bump, runs Compliance Review, creates/updates a PR, monitors CI, then publishes the
-  tag only after explicit approval and after verifying the release PR is merged into `origin/master`.
+- The workflow prepares the version bump, runs Compliance Review, creates/updates a PR, monitors CI, waits in
+  `waiting_pr`, then publishes the tag only after explicit approval and after verifying the release PR is merged into
+  `origin/master`.
 - Never create or push a release tag before the version bump is present on `origin/master`.
 - Legacy split workflows (`Puber Release Preparation`, `Puber Release Publication`) are not intended for new tasks.
 
@@ -122,11 +141,12 @@ Use generic workflow graph keys and project-prefixed live workflow names:
 
 - Live workflow names: `Puber Feature Delivery`, `Puber Refactor With Audit`, `Puber Bugfix Investigation`,
   `Puber Dependency Update`, `Puber Test Coverage`, `Puber Smoke Test`, `Puber Release`.
-- Node keys: `plan`, `implement`, `audit`, `fix`, `smoke`, `prepare`, `compliance`, `ship_pr`, `ci_monitor`, `publish`,
-  `monitor`, `cleanup`, `done`, `blocked`.
-- Transition IDs: `implement`, `continue_implementation`, `audit`, `needs_changes`, `retry_later`, `not_ready`, `smoke`,
-  `ship_pr`, `monitor_ci`, `done`, `blocked`.
+- Node keys: `plan`, `implement`, `audit`, `fix`, `smoke`, `prepare`, `compliance`, `ship_pr`, `ci_monitor`,
+  `waiting_pr`, `publish`, `monitor`, `cleanup`, `done`, `wont_do`.
+- Transition IDs: `implement`, `continue_implementation`, `audit`, `needs_changes`, `needs_user_action`, `smoke`,
+  `compliance`, `ship_pr`, `monitor_ci`, `waiting_pr`, `pr_merged`, `close_without_merge`, `no_pr`,
+  `release_published`, `done`, `wont_do`.
 - Portable params: `workspace_path`, `plan_path`, `audit_report`, `review_report`, `verification_report`, `pr_url`,
-  `branch_name`, `pr_report`, `ci_report`, `compliance_report`, `release_version`, `release_type`, `release_branch`,
-  `release_tag`, `version_bump_commit`, `target_commit`, `tag_push_status`, `release_report`, `blocker_reason`,
-  `cleanup_report`.
+  `branch_name`, `pr_report`, `ci_report`, `compliance_report`, `waiting_reason`, `merge_report`, `cleanup_reason`,
+  `closure_reason`, `release_version`, `release_type`, `release_branch`, `release_tag`, `version_bump_commit`,
+  `target_commit`, `tag_push_status`, `release_report`, `blocker_reason`, `cleanup_report`.

--- a/.kent/workflows/README.md
+++ b/.kent/workflows/README.md
@@ -20,20 +20,20 @@ Kent Desktop workflow graph
 ## Puber Workflow Set
 
 - `Puber Feature Delivery` (default): plan -> implement loop -> audit -> fix loop -> optional smoke -> compliance ->
-  create/update PR -> monitor CI -> cleanup.
+  create/update PR -> monitor CI -> waiting PR -> cleanup -> done.
 - `Puber Refactor With Audit`: plan/audit -> implement loop -> read-only review -> fix loop -> compliance ->
-  create/update PR -> monitor CI -> cleanup.
-- `Puber Bugfix Investigation`: reproduce/diagnose -> approved fix or report-only -> verify/fix loop -> compliance ->
-  create/update PR when changes exist -> monitor CI -> cleanup.
-- `Puber Dependency Update`: update Gradle versions/tooling -> fallout verification -> approved fixes -> compliance ->
-  create/update PR -> monitor CI -> cleanup.
-- `Puber Test Coverage`: coverage gap plan -> approved test implementation loop -> review/fix loop -> compliance ->
-  create/update PR -> monitor CI -> cleanup.
-- `Puber Smoke Test`: focused device smoke test -> optional approved fix -> rerun smoke -> compliance ->
-  create/update PR when changes exist -> monitor CI -> cleanup.
+  create/update PR -> monitor CI -> waiting PR -> cleanup -> done.
+- `Puber Bugfix Investigation`: reproduce/diagnose -> fix or report-only -> verify/fix loop -> compliance ->
+  create/update PR when changes exist -> monitor CI -> waiting PR -> cleanup -> done.
+- `Puber Dependency Update`: update Gradle versions/tooling -> fallout verification -> fixes -> compliance ->
+  create/update PR -> monitor CI -> waiting PR -> cleanup -> done.
+- `Puber Test Coverage`: coverage gap plan -> test implementation loop -> review/fix loop -> compliance ->
+  create/update PR -> monitor CI -> waiting PR -> cleanup -> done.
+- `Puber Smoke Test`: focused device smoke test -> optional fix -> rerun smoke -> compliance ->
+  create/update PR when changes exist -> monitor CI -> waiting PR -> cleanup -> done.
 - `Puber Release`: default next minor release from `origin/master` -> version bump branch/PR -> CI -> approved tag
-  publication after the PR is merged -> optional automation monitor -> cleanup. Patch/major releases require explicit
-  task wording.
+  publication after the PR is merged -> optional automation monitor -> cleanup -> done. Patch/major releases require
+  explicit task wording.
 
 Only `Puber Feature Delivery` should be the project default. The other workflows are linked to the project for explicit
 task creation when the work type is known.
@@ -49,7 +49,8 @@ Legacy split release workflows (`Puber Release Preparation` and `Puber Release P
   `subagents/android-codebase-analyst.md`, even though there is no `subagents/project-researcher.md` file.
 - After adding or changing subagent roles in `.kent/config.toml`, restart Kent service/GUI before expecting execution
   validation or new workflow tasks to see the role.
-- Every edge to `blocked` must require `blocker_reason`.
+- Do not model recoverable blockers as terminal states. Use `needs_user_action` back to the same node with
+  `blocker_reason` and human approval.
 - Every successful work-product path must pass through `compliance` before `cleanup`. Compliance Review is not a
   replacement for audit/review/verify/smoke; it only checks adherence to AGENTS.md, project contracts, specs, plans,
   human-approved design decisions, and workflow transition contracts.
@@ -57,18 +58,25 @@ Legacy split release workflows (`Puber Release Preparation` and `Puber Release P
   no-diff/report-only/smoke-only cases and must explain that through `pr_report`.
 - `ci_monitor` never merges PRs and never pushes new commits. CI failures go back to fix/review/compliance before another
   PR/CI pass.
-- `blocked` is terminal and must be reserved for unrecoverable situations. Recoverable external waits should use
-  `retry_later` back to the same node with human approval; recoverable PR/branch/CI fallout should use `needs_changes`
-  back to `fix` or `prepare` with human approval; release publication that is approved before the PR is merged should
-  use `not_ready` back to `ci_monitor`.
+- `done` is terminal and must mean delivered: PR merged and cleanup completed, release published and cleanup completed,
+  explicit no-diff/report-only cleanup completed, or explicit `wont_do`.
+- `waiting_pr` is the normal post-CI state for PR workflows. It may only advance to cleanup after GitHub reports
+  `state=MERGED`, or to release publication after the release PR is merged and the publish transition is approved.
+- `wont_do` is terminal and approval-gated. Use it only for explicit user cancellation or "not planned"; do not use it as
+  a recoverable blocker.
+- Recoverable external waits should use `needs_user_action` back to the same node with human approval. Recoverable
+  PR/branch/CI fallout should use `needs_changes` back to `fix` or `prepare` without a manual approval, except
+  `ship_pr -> needs_changes`, which remains approval-gated because it can involve rebase/force-push policy.
 - Smoke workflows must acquire a shared mobile resource lock through
   `.kent/adapters/mobile/emulator-resource-lock.sh` before installing, launching, or controlling an emulator/device. When
   multiple `adb` emulators are already running, agents should acquire any free emulator-specific lock and pass that serial
   to `adb -s`. Starting another emulator is allowed only when the task/user explicitly permits parallel device usage and
   the agent acquires a distinct lock for that emulator. Physical devices must not be used unless the task/user explicitly
-  names or allows that physical device; agents must never rely on adb's default target selection. Smoke workflows must
-  build APKs and install with explicit `adb -s "$DEVICE_SERIAL"`; Gradle `install*` tasks are forbidden for smoke tests.
-- Every successful terminal path should pass through `cleanup`, but cleanup is conservative by default.
+  provides permission and an explicit serial for that physical device; agents must never rely on adb's default target
+  selection. Smoke workflows must build APKs and install with explicit `adb -s "$DEVICE_SERIAL"`; Gradle `install*` tasks
+  are forbidden for smoke tests.
+- Every successful terminal path should pass through `cleanup`, but cleanup is conservative by default. Cleanup after a PR
+  path must verify the PR through GitHub state rather than git ancestry alone because squash merges are allowed.
 - Pass explicit `workspace_path` and `plan_path`; never rely on `.todo/.current`.
 - Keep prompts project-neutral where possible: "run the project feature planning command" rather than naming another
   repository's skill path, Jira project, module graph, or release process.
@@ -90,7 +98,8 @@ and architecture rules.
 Before making a workflow default for the project:
 
 - Create a dummy task that reaches planning and emits `workspace_path`/`plan_path`.
-- Exercise a blocked path and verify `blocker_reason` is visible.
+- Exercise a `needs_user_action` self-loop and verify `blocker_reason` is visible.
+- Exercise a `waiting_pr` path and verify an unmerged PR waits instead of reaching `done`.
 - Exercise an implementation continuation path and verify params are re-emitted.
 - Exercise cleanup in conservative mode and verify `cleanup_report`.
 - Validate with `kent workflow validate "<workflow>" --mode execution`.

--- a/.kent/workflows/puber-bugfix-investigation.json
+++ b/.kent/workflows/puber-bugfix-investigation.json
@@ -3,7 +3,7 @@
     "id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
     "name": "Puber Bugfix Investigation",
     "description": "Reproduce, diagnose, fix, verify, and conservatively clean up a Puber Android bugfix.",
-    "version": 66
+    "version": 146
   },
   "nodes": [
     {
@@ -52,9 +52,9 @@
     {
       "id": "node-03d0e60b-3cd1-4ffe-a9ba-a4f0054a4c9d",
       "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
-      "key": "blocked",
+      "key": "wont_do",
       "kind": "terminal",
-      "display_name": "Blocked"
+      "display_name": "Won't Do"
     },
     {
       "id": "node-fd20f168-a890-44c0-9a6b-a4f7d6627e3d",
@@ -80,6 +80,15 @@
       "key": "ci_monitor",
       "kind": "agent",
       "display_name": "Monitor CI",
+      "subagent_role": "default",
+      "completion_mode": "shell_command"
+    },
+    {
+      "id": "node-3443e921-f400-4375-abcb-9bee5e6be0e8",
+      "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
+      "key": "waiting_pr",
+      "kind": "agent",
+      "display_name": "Waiting PR",
       "subagent_role": "default",
       "completion_mode": "shell_command"
     },
@@ -112,17 +121,17 @@
       "id": "group-1a1d547c-c457-4aa4-b2e2-1d82111ec2bc",
       "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
       "source_node_id": "node-213caff1-4a63-4b66-9d2e-b06ac051749b",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "Report-only diagnosis is complete; run mandatory compliance review before cleanup."
+      "transition_id": "compliance",
+      "display_name": "Compliance",
+      "description": "Work passed this stage; run mandatory compliance review before any PR/cleanup path."
     },
     {
       "id": "group-49fc52b6-a690-4d50-8329-dd2026c4e833",
       "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
       "source_node_id": "node-213caff1-4a63-4b66-9d2e-b06ac051749b",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Diagnosis is blocked by missing reproduction details, credentials, device access, or source context."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "diagnose cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-e95dc252-4151-44b9-85a4-873b5fe949d8",
@@ -136,9 +145,9 @@
       "id": "group-b7631a36-07d7-4ee1-87e6-ca2462df8a38",
       "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
       "source_node_id": "node-c41f562e-465b-4296-99db-63fb61376288",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Fixing is blocked by missing input, unsafe state, or verification failure."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "fix cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-c56eca1d-12ea-4385-9aed-0a8bbbbfc9e1",
@@ -152,17 +161,17 @@
       "id": "group-c6853f46-5291-4256-84c1-f8b5b1ba60c5",
       "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
       "source_node_id": "node-98304bcc-e638-4461-80b6-3e33a2ea0daa",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "Bugfix verification passed; run mandatory compliance review before cleanup."
+      "transition_id": "compliance",
+      "display_name": "Compliance",
+      "description": "Work passed this stage; run mandatory compliance review before any PR/cleanup path."
     },
     {
       "id": "group-0b08b713-d3b8-464b-9e43-55037dabf3ba",
       "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
       "source_node_id": "node-98304bcc-e638-4461-80b6-3e33a2ea0daa",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Verification is blocked by missing device, credentials, or failing external dependencies."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "verify cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-71b97af2-f25d-4759-a5de-6fd87a3c0d25",
@@ -176,9 +185,9 @@
       "id": "group-cb752cef-94ea-41b2-ba03-8236e2cdc35f",
       "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
       "source_node_id": "node-fd20f168-a890-44c0-9a6b-a4f7d6627e3d",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "Compliance review passed; create or update the task pull request before cleanup."
+      "transition_id": "ship_pr",
+      "display_name": "Ship PR",
+      "description": "Compliance passed; create or update the task PR before any terminal completion."
     },
     {
       "id": "group-5a1c639e-e746-4010-8f36-8e4899387488",
@@ -192,9 +201,9 @@
       "id": "group-b2d8f6b9-d051-4e9a-b837-f6c9d070918e",
       "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
       "source_node_id": "node-fd20f168-a890-44c0-9a6b-a4f7d6627e3d",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Compliance review is blocked by missing or contradictory required sources."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "compliance cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-c5b79abd-158f-4cbf-9e84-7a455a92b88f",
@@ -208,25 +217,25 @@
       "id": "group-f989f77c-ce9f-4294-a93a-9dfa4cba6d12",
       "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
       "source_node_id": "node-db8f389d-9764-4a8d-9c77-edf70644f483",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "PR is intentionally not applicable because there are no repository changes; run cleanup."
+      "transition_id": "no_pr",
+      "display_name": "No PR",
+      "description": "No PR is applicable because there are no repository changes or the task is explicitly report-only; cleanup can finish the task."
     },
     {
       "id": "group-8aecd199-55ea-485d-a116-27cc3718e305",
       "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
       "source_node_id": "node-db8f389d-9764-4a8d-9c77-edf70644f483",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "PR creation or update is blocked by git state, auth, remote, branch, or unsafe repository state."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "ship_pr cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-11915aa1-8973-4011-a42b-479767306bc2",
       "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
       "source_node_id": "node-8cfedf0a-355b-43d8-a2d6-e9bf02dd2c5e",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "PR checks passed or are intentionally skipped; run conservative cleanup."
+      "transition_id": "waiting_pr",
+      "display_name": "Waiting PR",
+      "description": "PR checks passed or were intentionally skipped; wait until the PR is merged before cleanup/done."
     },
     {
       "id": "group-ad0fac9b-5cd6-4909-be3c-afb6621699a9",
@@ -240,9 +249,9 @@
       "id": "group-996613f2-c002-428c-90a6-2115769f48d9",
       "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
       "source_node_id": "node-8cfedf0a-355b-43d8-a2d6-e9bf02dd2c5e",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "CI monitoring is blocked by GitHub access, missing check data, or unsafe repository state."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "ci_monitor cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-45f7bf57-5517-4732-a3c9-42b4eacf209f",
@@ -253,12 +262,44 @@
       "description": "PR creation/update hit a recoverable branch, rebase, conflict, or metadata issue; user approval required before recovery work."
     },
     {
-      "id": "group-1ff045c0-3774-4a8a-acdc-3b20c26129f0",
+      "id": "group-862ff043-8545-4cbe-87a1-5e117cf1aebd",
       "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
-      "source_node_id": "node-8cfedf0a-355b-43d8-a2d6-e9bf02dd2c5e",
-      "transition_id": "retry_later",
-      "display_name": "Retry Later",
-      "description": "CI or GitHub is temporarily unavailable, still starting, or missing an expected run; user approval required before retrying monitoring."
+      "source_node_id": "node-3443e921-f400-4375-abcb-9bee5e6be0e8",
+      "transition_id": "pr_merged",
+      "display_name": "Pr Merged",
+      "description": "PR is confirmed merged; cleanup can finish the task."
+    },
+    {
+      "id": "group-332d2150-d52c-4d81-a9c7-ce470299cba0",
+      "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
+      "source_node_id": "node-3443e921-f400-4375-abcb-9bee5e6be0e8",
+      "transition_id": "needs_changes",
+      "display_name": "Needs Changes",
+      "description": "PR review, conflicts, or post-CI regressions need task-scoped fixes."
+    },
+    {
+      "id": "group-b3b61102-1e90-4c2e-9625-4536245b0277",
+      "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
+      "source_node_id": "node-3443e921-f400-4375-abcb-9bee5e6be0e8",
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "PR is still waiting on a human or external process; remain in Waiting PR."
+    },
+    {
+      "id": "group-33d0348b-0e3f-475c-8b72-23f32d7b95fa",
+      "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
+      "source_node_id": "node-3443e921-f400-4375-abcb-9bee5e6be0e8",
+      "transition_id": "close_without_merge",
+      "display_name": "Close Without Merge",
+      "description": "User explicitly closed/canceled the PR without merge; cleanup can finish."
+    },
+    {
+      "id": "group-82314a44-aad6-45f9-9f37-60ff3ec9eb99",
+      "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
+      "source_node_id": "node-213caff1-4a63-4b66-9d2e-b06ac051749b",
+      "transition_id": "wont_do",
+      "display_name": "Wont Do",
+      "description": "Latest user comment explicitly cancels this task or declares it not planned; finish without treating it as a recoverable blocker."
     }
   ],
   "edges": [
@@ -273,7 +314,7 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Run Puber bug reproduction and diagnosis for this Kent task.\n\nRead .kent/project-contract.md first. Treat the task title/body as the bug report. Create an explicit .todo/bugfix-<name> workspace; do not infer or create .todo/.current. Reproduce when possible, inspect relevant code, identify likely root cause, and write a concise diagnosis artifact in the workspace. Do not edit production code in this node.\n\nComplete with fix when the root cause and fix plan are clear and provide workspace_path, diagnosis_report, reproduction_steps, and candidate_files. Complete with done if this is intentionally report-only and no code change should be made. Complete with blocked if reproduction or diagnosis is blocked and provide blocker_reason."
+      "prompt_template": "Run Puber bug reproduction and diagnosis for this Kent task.\n\nRead .kent/project-contract.md first. Treat the task title/body as the bug report. Create an explicit .todo/bugfix-<name> workspace; do not infer or create .todo/.current. Reproduce when possible, inspect relevant code, identify likely root cause, and write a concise diagnosis artifact in the workspace. Do not edit production code in this node.\n\nComplete with fix when the root cause and fix plan are clear and provide workspace_path, diagnosis_report, reproduction_steps, and candidate_files. Complete with compliance if this is intentionally report-only and no code change should be made. Complete with needs_user_action if reproduction or diagnosis is needs_user_action and provide blocker_reason."
     },
     {
       "id": "edge-5cb1c9b3-845e-4481-a888-bae0600002df",
@@ -281,16 +322,16 @@
       "transition_group_id": "group-d7bf883d-dfc1-41e3-aa3e-4eb5e2b1809d",
       "key": "approve_fix",
       "target_node_id": "node-c41f562e-465b-4296-99db-63fb61376288",
-      "requires_approval": true,
+      "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Implement the approved Puber bugfix.\n\nRead .kent/project-contract.md first. Use workspace {{.Params.workspace_path}} and diagnosis {{.Params.diagnosis_report}}. Apply the smallest robust fix, preserve project architecture, and verify with the narrowest relevant Gradle/test command. Use ./tools/agentw in .kent/worktrees and ./gradlew in the main checkout.\n\nComplete with verify and provide workspace_path, diagnosis_report, reproduction_steps, changed_files, and verification_summary. Complete with blocked if unsafe or missing input and provide blocker_reason.",
+      "prompt_template": "Implement the approved Puber bugfix.\n\nRead .kent/project-contract.md first. Use workspace {{.Params.workspace_path}} and diagnosis {{.Params.diagnosis_report}}. Apply the smallest robust fix, preserve project architecture, and verify with the narrowest relevant Gradle/test command. Use ./tools/agentw in .kent/worktrees and ./gradlew in the main checkout.\n\nComplete with verify and provide workspace_path, diagnosis_report, reproduction_steps, changed_files, and verification_summary. Complete with needs_user_action if unsafe or missing input and provide blocker_reason.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/bugfix-* workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "diagnosis_report",
@@ -310,18 +351,18 @@
       "id": "edge-a75d8af1-fe75-40a6-be4b-94c91ca12008",
       "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
       "transition_group_id": "group-1a1d547c-c457-4aa4-b2e2-1d82111ec2bc",
-      "key": "report_done",
+      "key": "report_compliance",
       "target_node_id": "node-fd20f168-a890-44c0-9a6b-a4f7d6627e3d",
       "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Run mandatory Puber Compliance Review before cleanup.\n\nRead .kent/commands/compliance-review.md, .kent/project-contract.md, and AGENTS.md first. Reviewed scope: report-only bug diagnosis in workspace {{.Params.workspace_path}} with diagnosis {{.Params.diagnosis_report}}. Review only compliance with task requirements, specs, AGENTS.md, and workflow contract. Do not edit files.\n\nComplete with done and provide compliance_report when no compliance violations are found. Complete with needs_changes and provide workspace_path plus compliance_report when fixes/rework are required. Complete with blocked and provide blocker_reason if required sources are missing or contradictory.",
+      "prompt_template": "Run mandatory Puber Compliance Review before cleanup.\n\nRead .kent/commands/compliance-review.md, .kent/project-contract.md, and AGENTS.md first. Reviewed scope: report-only bug diagnosis in workspace {{.Params.workspace_path}} with diagnosis {{.Params.diagnosis_report}}. Review only compliance with task requirements, specs, AGENTS.md, and workflow contract. Do not edit files.\n\nComplete with ship_pr and provide compliance_report when no compliance violations are found. Complete with needs_changes and provide workspace_path plus compliance_report when fixes/rework are required. Complete with needs_user_action and provide blocker_reason if required sources are missing or contradictory.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/bugfix-* workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "diagnosis_report",
@@ -333,17 +374,18 @@
       "id": "edge-48440fa4-ceb3-4331-bf1b-950ce02703c7",
       "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
       "transition_group_id": "group-49fc52b6-a690-4d50-8329-dd2026c4e833",
-      "key": "diagnose_blocked",
-      "target_node_id": "node-03d0e60b-3cd1-4ffe-a9ba-a4f0054a4c9d",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "diagnose_needs_user_action",
+      "target_node_id": "node-213caff1-4a63-4b66-9d2e-b06ac051749b",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why diagnosis cannot continue, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -358,11 +400,11 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Verify the Puber bugfix read-only.\n\nRead .kent/project-contract.md first. Compare the implementation against {{.Params.diagnosis_report}}, reproduce or reason through {{.Params.reproduction_steps}} when available from prior context, and run focused verification if practical. Do not edit files in this node.\n\nComplete with done if accepted. Complete with needs_changes if the fix is incomplete and provide workspace_path, verification_report, and changed_files. Complete with blocked if verification cannot complete and provide blocker_reason.",
+      "prompt_template": "Verify the Puber bugfix read-only.\n\nRead .kent/project-contract.md first. Compare the implementation against {{.Params.diagnosis_report}}, reproduce or reason through {{.Params.reproduction_steps}} when available from prior context, and run focused verification if practical. Do not edit files in this node.\n\nComplete with compliance if accepted. Complete with needs_changes if the fix is incomplete and provide workspace_path, verification_report, and changed_files. Complete with needs_user_action if verification cannot complete and provide blocker_reason.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/bugfix-* workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "diagnosis_report",
@@ -386,17 +428,18 @@
       "id": "edge-5c331080-da92-4071-9456-2fc425b2502b",
       "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
       "transition_group_id": "group-b7631a36-07d7-4ee1-87e6-ca2462df8a38",
-      "key": "fix_blocked",
-      "target_node_id": "node-03d0e60b-3cd1-4ffe-a9ba-a4f0054a4c9d",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "fix_needs_user_action",
+      "target_node_id": "node-c41f562e-465b-4296-99db-63fb61376288",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why fixing cannot continue, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -406,20 +449,20 @@
       "transition_group_id": "group-c56eca1d-12ea-4385-9aed-0a8bbbbfc9e1",
       "key": "verification_fix",
       "target_node_id": "node-c41f562e-465b-4296-99db-63fb61376288",
-      "requires_approval": true,
+      "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Fix the remaining Puber bugfix verification findings. Apply only the changes requested in {{.Params.verification_report}}, verify narrowly, and complete with verify or blocked.",
+      "prompt_template": "Fix the remaining Puber bugfix verification findings. Apply only the changes requested in {{.Params.verification_report}}, verify narrowly, and complete with verify or needs_user_action.\n\nFor any needs_user_action transition, provide blocker_reason with the exact next user or external action needed.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/bugfix-* workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "verification_report",
-          "description": "Verification findings and remaining issues to fix."
+          "description": "Commands/tests run and their results, or path to a verification report."
         },
         {
           "key": "changed_files",
@@ -431,18 +474,18 @@
       "id": "edge-b912a0ba-99de-4e09-8c06-48887ade72ba",
       "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
       "transition_group_id": "group-c6853f46-5291-4256-84c1-f8b5b1ba60c5",
-      "key": "verify_done",
+      "key": "verify_compliance",
       "target_node_id": "node-fd20f168-a890-44c0-9a6b-a4f7d6627e3d",
       "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Run mandatory Puber Compliance Review before cleanup.\n\nRead .kent/commands/compliance-review.md, .kent/project-contract.md, and AGENTS.md first. Reviewed scope: completed bugfix in workspace {{.Params.workspace_path}}. Changed files: {{.Params.changed_files}}. Review only compliance with task requirements, specs, AGENTS.md, and workflow contract. Do not edit files.\n\nComplete with done and provide compliance_report when no compliance violations are found. Complete with needs_changes and provide workspace_path plus compliance_report when fixes are required. Complete with blocked and provide blocker_reason if required sources are missing or contradictory.",
+      "prompt_template": "Run mandatory Puber Compliance Review before cleanup.\n\nRead .kent/commands/compliance-review.md, .kent/project-contract.md, and AGENTS.md first. Reviewed scope: completed bugfix in workspace {{.Params.workspace_path}}. Changed files: {{.Params.changed_files}}. Review only compliance with task requirements, specs, AGENTS.md, and workflow contract. Do not edit files.\n\nComplete with ship_pr and provide compliance_report when no compliance violations are found. Complete with needs_changes and provide workspace_path plus compliance_report when fixes are required. Complete with needs_user_action and provide blocker_reason if required sources are missing or contradictory.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/bugfix-* workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "changed_files",
@@ -454,17 +497,18 @@
       "id": "edge-57108fec-8335-4c59-bc46-fca2b7a2bc56",
       "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
       "transition_group_id": "group-0b08b713-d3b8-464b-9e43-55037dabf3ba",
-      "key": "verify_blocked",
-      "target_node_id": "node-03d0e60b-3cd1-4ffe-a9ba-a4f0054a4c9d",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "verify_needs_user_action",
+      "target_node_id": "node-98304bcc-e638-4461-80b6-3e33a2ea0daa",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why verification cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -490,18 +534,18 @@
       "id": "edge-5d38342d-c311-4c28-9400-b06db72ef3f8",
       "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
       "transition_group_id": "group-cb752cef-94ea-41b2-ba03-8236e2cdc35f",
-      "key": "compliance_done",
+      "key": "compliance_ship_pr",
       "target_node_id": "node-db8f389d-9764-4a8d-9c77-edf70644f483",
       "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Create or update the Puber pull request for this completed task.\n\nRead .kent/project-contract.md, .kent/commands/ship-pr.md, and AGENTS.md first. Compliance result: {{.Params.compliance_report}}.\n\nIf this task produced repository changes, commit only task-related files, push the current task branch to origin, and create or update a GitHub PR. Do not merge the PR. Do not push directly to master/main. If there are no repository changes and the task is report-only or smoke-only, complete with done and provide pr_report explaining why PR is not applicable.\n\nComplete with monitor_ci when a PR exists and provide pr_url, branch_name, and workspace_path. Complete with needs_changes when PR creation/update is blocked by recoverable repository, branch, or PR state such as merge conflicts, non-fast-forward push, branch needing rebase, or missing PR metadata that can be fixed in the task worktree; provide workspace_path and blocker_reason. Complete with done only for PR-not-applicable/no-diff cases and provide pr_report. Complete with blocked only when continuing would be unsafe without changing task scope, credentials, or project policy; provide blocker_reason.",
+      "prompt_template": "Create or update the Puber pull request for this completed task.\n\nRead .kent/project-contract.md, .kent/commands/ship-pr.md, and AGENTS.md first. Compliance result: {{.Params.compliance_report}}.\n\nIf this task produced repository changes, commit only task-related files, push the current task branch to origin, and create or update a GitHub PR. Do not merge the PR. Do not push directly to master/main. If there are no repository changes and the task is report-only or smoke-only, complete with no_pr and provide pr_report explaining why PR is not applicable.\n\nComplete with monitor_ci when a PR exists and provide pr_url, branch_name, and workspace_path. Complete with needs_changes when PR creation/update is needs_user_action by recoverable repository, branch, or PR state such as merge conflicts, non-fast-forward push, branch needing rebase, or missing PR metadata that can be fixed in the task worktree; provide workspace_path and blocker_reason. Complete with no_pr only for PR-not-applicable/no-diff cases and provide pr_report. Complete with needs_user_action only when continuing would be unsafe without changing task scope, credentials, or project policy; provide blocker_reason.",
       "parameters": [
         {
           "key": "compliance_report",
-          "description": "Compliance review report, including rule sources checked and any findings."
+          "description": "Compliance review report or summary."
         }
       ]
     },
@@ -511,20 +555,20 @@
       "transition_group_id": "group-5a1c639e-e746-4010-8f36-8e4899387488",
       "key": "compliance_fix",
       "target_node_id": "node-c41f562e-465b-4296-99db-63fb61376288",
-      "requires_approval": true,
+      "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Fix or rework Puber bugfix compliance violations only.\n\nRead .kent/project-contract.md and .kent/commands/compliance-review.md first. Apply only the minimum changes required by compliance findings in {{.Params.compliance_report}} for workspace {{.Params.workspace_path}}. If this was report-only, update only report/workspace artifacts unless the user-approved compliance finding requires code. Verify narrowly, then complete with verify and provide workspace_path, diagnosis_report, reproduction_steps, changed_files, and verification_summary. Complete with blocked and provide blocker_reason if unsafe or missing input.",
+      "prompt_template": "Fix or rework Puber bugfix compliance violations only.\n\nRead .kent/project-contract.md and .kent/commands/compliance-review.md first. Apply only the minimum changes required by compliance findings in {{.Params.compliance_report}} for workspace {{.Params.workspace_path}}. If this was report-only, update only report/workspace artifacts unless the user-approved compliance finding requires code. Verify narrowly, then complete with verify and provide workspace_path, diagnosis_report, reproduction_steps, changed_files, and verification_summary. Complete with needs_user_action and provide blocker_reason if unsafe or missing input.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/bugfix-* workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "compliance_report",
-          "description": "Compliance review report, including rule sources checked and any findings."
+          "description": "Compliance review report or summary."
         }
       ]
     },
@@ -532,17 +576,18 @@
       "id": "edge-639cb9cd-058a-4e07-8049-988d5a9baee1",
       "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
       "transition_group_id": "group-b2d8f6b9-d051-4e9a-b837-f6c9d070918e",
-      "key": "compliance_blocked",
-      "target_node_id": "node-03d0e60b-3cd1-4ffe-a9ba-a4f0054a4c9d",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "compliance_needs_user_action",
+      "target_node_id": "node-fd20f168-a890-44c0-9a6b-a4f7d6627e3d",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why compliance review cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -557,19 +602,19 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Monitor Puber PR checks.\n\nRead .kent/project-contract.md and AGENTS.md first. Inspect PR {{.Params.pr_url}} on branch {{.Params.branch_name}}. Use GitHub CLI when available. Do not merge the PR. Do not push new commits from this node.\n\nComplete with done if CI/checks pass, are absent, or are intentionally skipped with a clear reason; provide ci_report and pr_url. Complete with needs_changes if CI failed due to task changes and provide workspace_path plus ci_report. Complete with retry_later when checks cannot be inspected because GitHub/CI is still starting, rate-limited, temporarily unavailable, or an expected run has not appeared yet; provide pr_url, branch_name, workspace_path, and ci_report. Complete with blocked only if checks cannot be inspected and retrying would be unsafe or misleading; provide blocker_reason.",
+      "prompt_template": "Monitor Puber PR checks.\n\nRead .kent/project-contract.md and AGENTS.md first. Inspect PR {{.Params.pr_url}} on branch {{.Params.branch_name}}. Use GitHub CLI when available. Do not merge the PR. Do not push new commits from this node.\n\nComplete with waiting_pr if CI/checks pass, are absent, or are intentionally skipped with a clear reason; provide ci_report and pr_url. Complete with needs_changes if CI failed due to task changes and provide workspace_path plus ci_report. Complete with needs_user_action for temporary external waits; provide blocker_reason. Complete with needs_user_action only if checks cannot be inspected and retrying would be unsafe or misleading; provide blocker_reason.",
       "parameters": [
         {
           "key": "pr_url",
-          "description": "URL of the pull request."
+          "description": "URL of the created, updated, or monitored pull request."
         },
         {
           "key": "branch_name",
-          "description": "Name of the pushed task branch."
+          "description": "Name of the task or release branch associated with the pull request."
         },
         {
           "key": "workspace_path",
-          "description": "Path to the worktree or checkout used for PR creation."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         }
       ]
     },
@@ -588,7 +633,7 @@
       "parameters": [
         {
           "key": "pr_report",
-          "description": "Why no pull request was created or updated."
+          "description": "PR creation, review, conflict, or post-CI regression report."
         }
       ]
     },
@@ -596,17 +641,18 @@
       "id": "edge-3190ffcc-7132-4d9e-8733-0ce82f80b3fd",
       "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
       "transition_group_id": "group-8aecd199-55ea-485d-a116-27cc3718e305",
-      "key": "pr_blocked",
-      "target_node_id": "node-03d0e60b-3cd1-4ffe-a9ba-a4f0054a4c9d",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "ship_pr_needs_user_action",
+      "target_node_id": "node-db8f389d-9764-4a8d-9c77-edf70644f483",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why PR creation/update cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -614,22 +660,30 @@
       "id": "edge-83e44179-0e13-44a2-8406-c8f7f9f7eb1d",
       "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
       "transition_group_id": "group-11915aa1-8973-4011-a42b-479767306bc2",
-      "key": "ci_done",
-      "target_node_id": "node-fdcc2cd0-9737-4db4-829b-3d2851c1ac81",
+      "key": "ci_waiting_pr",
+      "target_node_id": "node-3443e921-f400-4375-abcb-9bee5e6be0e8",
       "requires_approval": false,
       "context_mode": "new_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Run conservative Puber task cleanup after PR/CI.\n\nRead .kent/project-contract.md first, then use .kent/commands/cleanup-task.md. PR: {{.Params.pr_url}}. CI report: {{.Params.ci_report}}. Do not delete any worktree containing unpushed or uncommitted user changes. Complete with done and provide cleanup_report.",
+      "prompt_template": "Hold this Puber task until its pull request is actually merged.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, PR {{.Params.pr_url}}, branch {{.Params.branch_name}}, workspace {{.Params.workspace_path}}, and CI report {{.Params.ci_report}}.\n\nUse `gh pr view --json state,mergedAt,mergeCommit,headRefName,baseRefName,url` when available. Do not merge the PR. Do not push commits from this node. Do not clean up while the PR is still open.\n\nComplete with pr_merged only when GitHub reports state=MERGED; provide pr_url, branch_name, and merge_report. Complete with needs_changes when PR review comments, merge conflicts, or post-CI regressions can be fixed within the task scope; provide workspace_path and pr_report. Complete with needs_user_action when the PR is still open, waiting for human review/approval/merge, or needs_user_action by an external process; add a task comment with the current PR status and exact human action, then provide pr_url, branch_name, workspace_path, and waiting_reason. Complete with close_without_merge only if the latest user comment explicitly says to close/cancel/skip this PR; provide pr_url, branch_name, and cleanup_reason.",
       "parameters": [
+        {
+          "key": "pr_url",
+          "description": "URL of the created, updated, or monitored pull request."
+        },
+        {
+          "key": "branch_name",
+          "description": "Name of the task or release branch associated with the pull request."
+        },
+        {
+          "key": "workspace_path",
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
+        },
         {
           "key": "ci_report",
           "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
-        },
-        {
-          "key": "pr_url",
-          "description": "URL of the created or updated pull request."
         }
       ]
     },
@@ -639,16 +693,16 @@
       "transition_group_id": "group-ad0fac9b-5cd6-4909-be3c-afb6621699a9",
       "key": "ci_fix",
       "target_node_id": "node-c41f562e-465b-4296-99db-63fb61376288",
-      "requires_approval": true,
+      "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Fix Puber bugfix CI failures only.\n\nRead .kent/project-contract.md first. Apply only the minimum changes required by CI report {{.Params.ci_report}} in workspace {{.Params.workspace_path}}. Verify narrowly, then complete with verify and provide workspace_path, diagnosis_report, reproduction_steps, changed_files, and verification_summary. Complete with blocked and provide blocker_reason if unsafe or missing input.",
+      "prompt_template": "Fix Puber bugfix CI failures only.\n\nRead .kent/project-contract.md first. Apply only the minimum changes required by CI report {{.Params.ci_report}} in workspace {{.Params.workspace_path}}. Verify narrowly, then complete with verify and provide workspace_path, diagnosis_report, reproduction_steps, changed_files, and verification_summary. Complete with needs_user_action and provide blocker_reason if unsafe or missing input.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/bugfix-* workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "ci_report",
@@ -660,17 +714,18 @@
       "id": "edge-623277bf-9684-46b6-a47a-e7e9487f376a",
       "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
       "transition_group_id": "group-996613f2-c002-428c-90a6-2115769f48d9",
-      "key": "ci_blocked",
-      "target_node_id": "node-03d0e60b-3cd1-4ffe-a9ba-a4f0054a4c9d",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "ci_monitor_needs_user_action",
+      "target_node_id": "node-8cfedf0a-355b-43d8-a2d6-e9bf02dd2c5e",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why CI monitoring cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -685,46 +740,141 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Fix recoverable Puber PR creation/update issues only.\n\nRead .kent/project-contract.md, .kent/commands/ship-pr.md, and AGENTS.md first. Previous PR blocker: {{.Params.blocker_reason}}. Work in {{.Params.workspace_path}}. Apply only the minimum changes needed to make the task branch/PR shippable, such as rebasing, resolving merge conflicts, fixing branch metadata, or repairing the PR-ready commit set. Do not expand product scope. Verify narrowly, then continue through the workflow's normal review/compliance path. Complete with blocked only if the recovery is unsafe or requires user credentials/policy changes.",
+      "prompt_template": "Fix recoverable Puber PR creation/update issues only.\n\nRead .kent/project-contract.md, .kent/commands/ship-pr.md, and AGENTS.md first. Previous PR blocker: {{.Params.blocker_reason}}. Work in {{.Params.workspace_path}}. Apply only the minimum changes needed to make the task branch/PR shippable, such as rebasing, resolving merge conflicts, fixing branch metadata, or repairing the PR-ready commit set. Do not expand product scope. Verify narrowly, then continue through the workflow's normal review/compliance path. Complete with needs_user_action only if the recovery is unsafe or requires user credentials/policy changes.\n\nFor any needs_user_action transition, provide blocker_reason with the exact next user or external action needed.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the worktree or checkout used for PR creation."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "blocker_reason",
-          "description": "Why PR creation/update cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
     {
-      "id": "edge-9dc72a39-bece-4a49-a9cf-81465c335d4e",
+      "id": "edge-b47df5cf-dbed-4d84-9aac-b90d8ae3de59",
       "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
-      "transition_group_id": "group-1ff045c0-3774-4a8a-acdc-3b20c26129f0",
-      "key": "ci_retry",
-      "target_node_id": "node-8cfedf0a-355b-43d8-a2d6-e9bf02dd2c5e",
+      "transition_group_id": "group-862ff043-8545-4cbe-87a1-5e117cf1aebd",
+      "key": "cleanup_after_merge",
+      "target_node_id": "node-fdcc2cd0-9737-4db4-829b-3d2851c1ac81",
+      "requires_approval": false,
+      "context_mode": "new_session",
+      "context_source": {
+        "kind": "immediate_source"
+      },
+      "prompt_template": "Run conservative Puber task cleanup after the pull request was confirmed merged.\n\nRead AGENTS.md, .kent/project-contract.md, .kent/commands/cleanup-task.md, PR {{.Params.pr_url}}, branch {{.Params.branch_name}}, and merge report {{.Params.merge_report}}. Verify the PR is merged with GitHub state, not only git ancestry, because squash merges are allowed. Do not delete any worktree containing unpushed commits, uncommitted user changes, or unclear ownership. Complete with done and provide cleanup_report.",
+      "parameters": [
+        {
+          "key": "pr_url",
+          "description": "URL of the created, updated, or monitored pull request."
+        },
+        {
+          "key": "branch_name",
+          "description": "Name of the task or release branch associated with the pull request."
+        },
+        {
+          "key": "merge_report",
+          "description": "GitHub PR state, mergedAt, mergeCommit, and cleanup or release notes."
+        }
+      ]
+    },
+    {
+      "id": "edge-54024176-7ab4-4ca0-8311-a106f57461db",
+      "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
+      "transition_group_id": "group-332d2150-d52c-4d81-a9c7-ce470299cba0",
+      "key": "pr_feedback",
+      "target_node_id": "node-c41f562e-465b-4296-99db-63fb61376288",
+      "requires_approval": false,
+      "context_mode": "compact_and_continue_session",
+      "context_source": {
+        "kind": "immediate_source"
+      },
+      "prompt_template": "Fix Puber PR feedback only.\n\nRead AGENTS.md, .kent/project-contract.md, latest task comments, workspace {{.Params.workspace_path}}, and PR feedback report {{.Params.pr_report}}. Apply only task-scoped changes needed for PR review comments, merge conflicts, or post-CI regressions. Do not force-push unless the latest user comment explicitly permits force-push for this exact PR/branch. Verify narrowly, then return through the workflow's normal review/verify/compliance path with an updated report. If user input is required, complete with needs_user_action and provide blocker_reason.",
+      "parameters": [
+        {
+          "key": "workspace_path",
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
+        },
+        {
+          "key": "pr_report",
+          "description": "PR creation, review, conflict, or post-CI regression report."
+        }
+      ]
+    },
+    {
+      "id": "edge-90a717af-43d1-4405-a695-8e78dd132a7c",
+      "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
+      "transition_group_id": "group-b3b61102-1e90-4c2e-9625-4536245b0277",
+      "key": "waiting_pr_needs_user_action",
+      "target_node_id": "node-3443e921-f400-4375-abcb-9bee5e6be0e8",
       "requires_approval": true,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Retry Puber PR check monitoring after an approved temporary CI/GitHub wait.\n\nRead .kent/project-contract.md and AGENTS.md first. Previous CI status: {{.Params.ci_report}}. Inspect PR {{.Params.pr_url}} on branch {{.Params.branch_name}} again. Do not merge the PR. Do not push new commits from this node.\n\nComplete with done if CI/checks pass, are absent, or are intentionally skipped with a clear reason; provide ci_report and pr_url. Complete with needs_changes if CI failed due to task changes and provide workspace_path plus ci_report. Complete with retry_later if CI/GitHub is still temporarily unavailable and provide pr_url, branch_name, workspace_path, and ci_report. Complete with blocked only if retrying is no longer useful or safe; provide blocker_reason.",
+      "prompt_template": "Re-check the Puber pull request after the user resolved the external wait or approved another check.\n\nRead AGENTS.md, .kent/project-contract.md, latest task comments, PR {{.Params.pr_url}}, branch {{.Params.branch_name}}, workspace {{.Params.workspace_path}}, and previous waiting reason {{.Params.waiting_reason}}. Do not merge, push, or clean up unless the PR is confirmed merged.\n\nComplete with pr_merged only when GitHub reports state=MERGED. Complete with needs_changes for task-scoped PR review/conflict/regression fixes. Complete with needs_user_action again if the PR is still waiting externally. Complete with close_without_merge only on explicit latest user instruction.",
       "parameters": [
         {
           "key": "pr_url",
-          "description": "URL of the created or updated pull request."
+          "description": "URL of the created, updated, or monitored pull request."
         },
         {
           "key": "branch_name",
-          "description": "Name of the pushed task branch."
+          "description": "Name of the task or release branch associated with the pull request."
         },
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/bugfix-* workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
-          "key": "ci_report",
-          "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+          "key": "waiting_reason",
+          "description": "Why the PR cannot advance yet and the exact user or external action needed."
+        }
+      ]
+    },
+    {
+      "id": "edge-0ba20037-4c30-4094-b932-0861fb5fe438",
+      "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
+      "transition_group_id": "group-33d0348b-0e3f-475c-8b72-23f32d7b95fa",
+      "key": "cancel_cleanup",
+      "target_node_id": "node-fdcc2cd0-9737-4db4-829b-3d2851c1ac81",
+      "requires_approval": true,
+      "context_mode": "new_session",
+      "context_source": {
+        "kind": "immediate_source"
+      },
+      "prompt_template": "Run conservative Puber task cleanup after the user explicitly closed/canceled the PR without merge.\n\nRead AGENTS.md, .kent/project-contract.md, .kent/commands/cleanup-task.md, PR {{.Params.pr_url}}, branch {{.Params.branch_name}}, and cleanup reason {{.Params.cleanup_reason}}. Do not delete any worktree containing unpushed commits, uncommitted user changes, or unclear ownership. Complete with done and provide cleanup_report.",
+      "parameters": [
+        {
+          "key": "pr_url",
+          "description": "URL of the created, updated, or monitored pull request."
+        },
+        {
+          "key": "branch_name",
+          "description": "Name of the task or release branch associated with the pull request."
+        },
+        {
+          "key": "cleanup_reason",
+          "description": "Explicit user instruction or reason for cleanup without merge."
+        }
+      ]
+    },
+    {
+      "id": "edge-8e054dd8-fa17-4a5e-97a6-ea0b2123d683",
+      "workflow_id": "workflow-d80d00fc-529a-41b5-8668-c4851002fb44",
+      "transition_group_id": "group-82314a44-aad6-45f9-9f37-60ff3ec9eb99",
+      "key": "diagnose_wont_do",
+      "target_node_id": "node-03d0e60b-3cd1-4ffe-a9ba-a4f0054a4c9d",
+      "requires_approval": true,
+      "context_mode": "new_session",
+      "context_source": {
+        "kind": "immediate_source"
+      },
+      "parameters": [
+        {
+          "key": "closure_reason",
+          "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
         }
       ]
     }
@@ -739,7 +889,7 @@
         "possible_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/bugfix-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "diagnosis_report",
@@ -755,7 +905,11 @@
           },
           {
             "name": "blocker_reason",
-            "description": "Why diagnosis cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          },
+          {
+            "name": "closure_reason",
+            "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
           }
         ]
       },
@@ -764,7 +918,7 @@
         "possible_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/bugfix-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "diagnosis_report",
@@ -784,7 +938,7 @@
           },
           {
             "name": "blocker_reason",
-            "description": "Why fixing cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -793,11 +947,11 @@
         "possible_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/bugfix-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "verification_report",
-            "description": "Verification findings and remaining issues to fix."
+            "description": "Commands/tests run and their results, or path to a verification report."
           },
           {
             "name": "changed_files",
@@ -805,7 +959,7 @@
           },
           {
             "name": "blocker_reason",
-            "description": "Why verification cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -826,15 +980,15 @@
         "possible_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/bugfix-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -843,23 +997,23 @@
         "possible_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "pr_report",
-            "description": "Why no pull request was created or updated."
+            "description": "PR creation, review, conflict, or post-CI regression report."
           },
           {
             "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -867,24 +1021,57 @@
         "node_id": "node-8cfedf0a-355b-43d8-a2d6-e9bf02dd2c5e",
         "possible_provision_fields": [
           {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
             "name": "ci_report",
             "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
           },
           {
-            "name": "pr_url",
-            "description": "URL of the created or updated pull request."
-          },
-          {
-            "name": "workspace_path",
-            "description": "Path to the explicit .todo/bugfix-* workspace."
-          },
-          {
             "name": "blocker_reason",
-            "description": "Why CI monitoring cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          }
+        ]
+      },
+      {
+        "node_id": "node-3443e921-f400-4375-abcb-9bee5e6be0e8",
+        "possible_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "merge_report",
+            "description": "GitHub PR state, mergedAt, mergeCommit, and cleanup or release notes."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "pr_report",
+            "description": "PR creation, review, conflict, or post-CI regression report."
+          },
+          {
+            "name": "waiting_reason",
+            "description": "Why the PR cannot advance yet and the exact user or external action needed."
+          },
+          {
+            "name": "cleanup_reason",
+            "description": "Explicit user instruction or reason for cleanup without merge."
           }
         ]
       },
@@ -901,7 +1088,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/bugfix-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "diagnosis_report",
@@ -922,7 +1109,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/bugfix-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "diagnosis_report",
@@ -935,7 +1122,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why diagnosis cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -944,7 +1131,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/bugfix-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "diagnosis_report",
@@ -969,7 +1156,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why fixing cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -978,11 +1165,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/bugfix-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "verification_report",
-            "description": "Verification findings and remaining issues to fix."
+            "description": "Commands/tests run and their results, or path to a verification report."
           },
           {
             "name": "changed_files",
@@ -995,7 +1182,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/bugfix-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "changed_files",
@@ -1008,7 +1195,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why verification cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1026,7 +1213,7 @@
         "required_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -1035,11 +1222,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/bugfix-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -1048,7 +1235,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1057,15 +1244,15 @@
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           }
         ]
       },
@@ -1074,7 +1261,7 @@
         "required_provision_fields": [
           {
             "name": "pr_report",
-            "description": "Why no pull request was created or updated."
+            "description": "PR creation, review, conflict, or post-CI regression report."
           }
         ]
       },
@@ -1083,7 +1270,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1091,12 +1278,20 @@
         "transition_group_id": "group-11915aa1-8973-4011-a42b-479767306bc2",
         "required_provision_fields": [
           {
-            "name": "ci_report",
-            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
-            "name": "pr_url",
-            "description": "URL of the created or updated pull request."
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "ci_report",
+            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
           }
         ]
       },
@@ -1105,7 +1300,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/bugfix-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "ci_report",
@@ -1118,7 +1313,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why CI monitoring cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1127,32 +1322,88 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
       {
-        "transition_group_id": "group-1ff045c0-3774-4a8a-acdc-3b20c26129f0",
+        "transition_group_id": "group-862ff043-8545-4cbe-87a1-5e117cf1aebd",
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the created or updated pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "merge_report",
+            "description": "GitHub PR state, mergedAt, mergeCommit, and cleanup or release notes."
+          }
+        ]
+      },
+      {
+        "transition_group_id": "group-332d2150-d52c-4d81-a9c7-ce470299cba0",
+        "required_provision_fields": [
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "pr_report",
+            "description": "PR creation, review, conflict, or post-CI regression report."
+          }
+        ]
+      },
+      {
+        "transition_group_id": "group-b3b61102-1e90-4c2e-9625-4536245b0277",
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/bugfix-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
-            "name": "ci_report",
-            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+            "name": "waiting_reason",
+            "description": "Why the PR cannot advance yet and the exact user or external action needed."
+          }
+        ]
+      },
+      {
+        "transition_group_id": "group-33d0348b-0e3f-475c-8b72-23f32d7b95fa",
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "cleanup_reason",
+            "description": "Explicit user instruction or reason for cleanup without merge."
+          }
+        ]
+      },
+      {
+        "transition_group_id": "group-82314a44-aad6-45f9-9f37-60ff3ec9eb99",
+        "required_provision_fields": [
+          {
+            "name": "closure_reason",
+            "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
           }
         ]
       }
@@ -1188,7 +1439,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/bugfix-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "diagnosis_report",
@@ -1221,7 +1472,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/bugfix-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "diagnosis_report",
@@ -1241,7 +1492,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why diagnosis cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1277,7 +1528,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/bugfix-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "diagnosis_report",
@@ -1309,7 +1560,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why fixing cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1335,11 +1586,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/bugfix-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "verification_report",
-            "description": "Verification findings and remaining issues to fix."
+            "description": "Commands/tests run and their results, or path to a verification report."
           },
           {
             "name": "changed_files",
@@ -1364,7 +1615,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/bugfix-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "changed_files",
@@ -1384,7 +1635,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why verification cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1416,7 +1667,7 @@
         "required_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -1437,11 +1688,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/bugfix-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -1457,7 +1708,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1483,15 +1734,15 @@
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           }
         ]
       },
@@ -1507,7 +1758,7 @@
         "required_provision_fields": [
           {
             "name": "pr_report",
-            "description": "Why no pull request was created or updated."
+            "description": "PR creation, review, conflict, or post-CI regression report."
           }
         ]
       },
@@ -1523,103 +1774,12 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
       {
         "edge_id": "edge-83e44179-0e13-44a2-8406-c8f7f9f7eb1d",
-        "input_bindings": [
-          {
-            "name": "ci_report",
-            "source": "transition_output",
-            "field": "ci_report"
-          },
-          {
-            "name": "pr_url",
-            "source": "transition_output",
-            "field": "pr_url"
-          }
-        ],
-        "required_provision_fields": [
-          {
-            "name": "ci_report",
-            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
-          },
-          {
-            "name": "pr_url",
-            "description": "URL of the created or updated pull request."
-          }
-        ]
-      },
-      {
-        "edge_id": "edge-36056eb4-47b4-4492-a1d1-72cf051ff900",
-        "input_bindings": [
-          {
-            "name": "workspace_path",
-            "source": "transition_output",
-            "field": "workspace_path"
-          },
-          {
-            "name": "ci_report",
-            "source": "transition_output",
-            "field": "ci_report"
-          }
-        ],
-        "required_provision_fields": [
-          {
-            "name": "workspace_path",
-            "description": "Path to the explicit .todo/bugfix-* workspace."
-          },
-          {
-            "name": "ci_report",
-            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
-          }
-        ]
-      },
-      {
-        "edge_id": "edge-623277bf-9684-46b6-a47a-e7e9487f376a",
-        "input_bindings": [
-          {
-            "name": "blocker_reason",
-            "source": "transition_output",
-            "field": "blocker_reason"
-          }
-        ],
-        "required_provision_fields": [
-          {
-            "name": "blocker_reason",
-            "description": "Why CI monitoring cannot complete, in the task language when practical."
-          }
-        ]
-      },
-      {
-        "edge_id": "edge-763e1d90-e640-4ca5-9022-96c02b9c0b6c",
-        "input_bindings": [
-          {
-            "name": "workspace_path",
-            "source": "transition_output",
-            "field": "workspace_path"
-          },
-          {
-            "name": "blocker_reason",
-            "source": "transition_output",
-            "field": "blocker_reason"
-          }
-        ],
-        "required_provision_fields": [
-          {
-            "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
-          },
-          {
-            "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
-          }
-        ]
-      },
-      {
-        "edge_id": "edge-9dc72a39-bece-4a49-a9cf-81465c335d4e",
         "input_bindings": [
           {
             "name": "pr_url",
@@ -1645,19 +1805,237 @@
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the created or updated pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/bugfix-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "ci_report",
             "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-36056eb4-47b4-4492-a1d1-72cf051ff900",
+        "input_bindings": [
+          {
+            "name": "workspace_path",
+            "source": "transition_output",
+            "field": "workspace_path"
+          },
+          {
+            "name": "ci_report",
+            "source": "transition_output",
+            "field": "ci_report"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "ci_report",
+            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-623277bf-9684-46b6-a47a-e7e9487f376a",
+        "input_bindings": [
+          {
+            "name": "blocker_reason",
+            "source": "transition_output",
+            "field": "blocker_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "blocker_reason",
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-763e1d90-e640-4ca5-9022-96c02b9c0b6c",
+        "input_bindings": [
+          {
+            "name": "workspace_path",
+            "source": "transition_output",
+            "field": "workspace_path"
+          },
+          {
+            "name": "blocker_reason",
+            "source": "transition_output",
+            "field": "blocker_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "blocker_reason",
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-b47df5cf-dbed-4d84-9aac-b90d8ae3de59",
+        "input_bindings": [
+          {
+            "name": "pr_url",
+            "source": "transition_output",
+            "field": "pr_url"
+          },
+          {
+            "name": "branch_name",
+            "source": "transition_output",
+            "field": "branch_name"
+          },
+          {
+            "name": "merge_report",
+            "source": "transition_output",
+            "field": "merge_report"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "merge_report",
+            "description": "GitHub PR state, mergedAt, mergeCommit, and cleanup or release notes."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-54024176-7ab4-4ca0-8311-a106f57461db",
+        "input_bindings": [
+          {
+            "name": "workspace_path",
+            "source": "transition_output",
+            "field": "workspace_path"
+          },
+          {
+            "name": "pr_report",
+            "source": "transition_output",
+            "field": "pr_report"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "pr_report",
+            "description": "PR creation, review, conflict, or post-CI regression report."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-90a717af-43d1-4405-a695-8e78dd132a7c",
+        "input_bindings": [
+          {
+            "name": "pr_url",
+            "source": "transition_output",
+            "field": "pr_url"
+          },
+          {
+            "name": "branch_name",
+            "source": "transition_output",
+            "field": "branch_name"
+          },
+          {
+            "name": "workspace_path",
+            "source": "transition_output",
+            "field": "workspace_path"
+          },
+          {
+            "name": "waiting_reason",
+            "source": "transition_output",
+            "field": "waiting_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "waiting_reason",
+            "description": "Why the PR cannot advance yet and the exact user or external action needed."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-0ba20037-4c30-4094-b932-0861fb5fe438",
+        "input_bindings": [
+          {
+            "name": "pr_url",
+            "source": "transition_output",
+            "field": "pr_url"
+          },
+          {
+            "name": "branch_name",
+            "source": "transition_output",
+            "field": "branch_name"
+          },
+          {
+            "name": "cleanup_reason",
+            "source": "transition_output",
+            "field": "cleanup_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "cleanup_reason",
+            "description": "Explicit user instruction or reason for cleanup without merge."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-8e054dd8-fa17-4a5e-97a6-ea0b2123d683",
+        "input_bindings": [
+          {
+            "name": "closure_reason",
+            "source": "transition_output",
+            "field": "closure_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "closure_reason",
+            "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
           }
         ]
       }

--- a/.kent/workflows/puber-dependency-update.json
+++ b/.kent/workflows/puber-dependency-update.json
@@ -3,7 +3,7 @@
     "id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
     "name": "Puber Dependency Update",
     "description": "Update Puber Gradle dependencies or tooling, verify fallout, fix issues, and clean up safely.",
-    "version": 59
+    "version": 135
   },
   "nodes": [
     {
@@ -52,9 +52,9 @@
     {
       "id": "node-8e0cfb7b-5034-448b-9921-7b830c6b358c",
       "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
-      "key": "blocked",
+      "key": "wont_do",
       "kind": "terminal",
-      "display_name": "Blocked"
+      "display_name": "Won't Do"
     },
     {
       "id": "node-46820ad9-67b1-4eb6-9a7c-8ed568e28e45",
@@ -80,6 +80,15 @@
       "key": "ci_monitor",
       "kind": "agent",
       "display_name": "Monitor CI",
+      "subagent_role": "default",
+      "completion_mode": "shell_command"
+    },
+    {
+      "id": "node-5e2b9f5c-eed5-4639-8d38-8c4ee750662a",
+      "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
+      "key": "waiting_pr",
+      "kind": "agent",
+      "display_name": "Waiting PR",
       "subagent_role": "default",
       "completion_mode": "shell_command"
     },
@@ -112,9 +121,9 @@
       "id": "group-dffb599b-7fca-43c2-a5ac-f314df007db9",
       "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
       "source_node_id": "node-27dab828-f09b-4bd9-973b-2dc45ebcec8e",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Dependency update is blocked by package lookup, credentials, build setup, or unsafe version choices."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "update cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-14351958-a9d9-4a65-9629-2d8c9056364a",
@@ -128,17 +137,17 @@
       "id": "group-668062f2-60d6-47f5-ad18-c80520aa0b2b",
       "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
       "source_node_id": "node-299c4802-4ea7-4dd7-8c47-36e269e5fc91",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "Dependency update verification passed; run mandatory compliance review before cleanup."
+      "transition_id": "compliance",
+      "display_name": "Compliance",
+      "description": "Work passed this stage; run mandatory compliance review before any PR/cleanup path."
     },
     {
       "id": "group-e52d04af-dfbd-4a58-9841-0254a894b7ff",
       "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
       "source_node_id": "node-299c4802-4ea7-4dd7-8c47-36e269e5fc91",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Dependency fallout verification is blocked."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "verify cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-5bdb9306-de5a-47f8-832f-b163dec4655c",
@@ -152,9 +161,9 @@
       "id": "group-78717f8d-cb76-4a49-b8fd-d5665581a8e6",
       "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
       "source_node_id": "node-d51d551d-30cb-4948-8cbe-62d4d34fda9e",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Fallout fixing is blocked."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "fix cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-9f9d67f9-c1cd-4f8f-8f1f-15c7c94e5feb",
@@ -168,9 +177,9 @@
       "id": "group-5f92cf54-e07b-41db-a84d-c7787268e20d",
       "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
       "source_node_id": "node-46820ad9-67b1-4eb6-9a7c-8ed568e28e45",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "Compliance review passed; create or update the task pull request before cleanup."
+      "transition_id": "ship_pr",
+      "display_name": "Ship PR",
+      "description": "Compliance passed; create or update the task PR before any terminal completion."
     },
     {
       "id": "group-aeb735e7-b761-4f66-8a9e-12fd47cfeea5",
@@ -184,9 +193,9 @@
       "id": "group-bf582f19-d767-44aa-bedb-03f7f9de85c7",
       "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
       "source_node_id": "node-46820ad9-67b1-4eb6-9a7c-8ed568e28e45",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Compliance review is blocked by missing or contradictory required sources."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "compliance cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-6c80e5f7-1b4a-49d5-be2e-bd309286647e",
@@ -200,25 +209,25 @@
       "id": "group-85f0b875-2960-4e84-b415-0d2d2832998a",
       "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
       "source_node_id": "node-e3459660-22bc-4ad2-bd8e-190745ecc83e",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "PR is intentionally not applicable because there are no repository changes; run cleanup."
+      "transition_id": "no_pr",
+      "display_name": "No PR",
+      "description": "No PR is applicable because there are no repository changes or the task is explicitly report-only; cleanup can finish the task."
     },
     {
       "id": "group-f6124d99-570f-4f64-8db5-f42b479d6e4f",
       "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
       "source_node_id": "node-e3459660-22bc-4ad2-bd8e-190745ecc83e",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "PR creation or update is blocked by git state, auth, remote, branch, or unsafe repository state."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "ship_pr cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-b9a0562a-42d9-4c83-82ae-a8a0001e17a8",
       "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
       "source_node_id": "node-09339573-c966-460d-aad9-82d0f53ef9fc",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "PR checks passed or are intentionally skipped; run conservative cleanup."
+      "transition_id": "waiting_pr",
+      "display_name": "Waiting PR",
+      "description": "PR checks passed or were intentionally skipped; wait until the PR is merged before cleanup/done."
     },
     {
       "id": "group-065b900c-c5fc-446c-8d01-97407158ce3a",
@@ -232,9 +241,9 @@
       "id": "group-be8f0286-2f2d-464a-bf83-905baf5e9491",
       "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
       "source_node_id": "node-09339573-c966-460d-aad9-82d0f53ef9fc",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "CI monitoring is blocked by GitHub access, missing check data, or unsafe repository state."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "ci_monitor cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-cdf973e7-cab4-4a13-83bd-1a615dc642e2",
@@ -245,12 +254,44 @@
       "description": "PR creation/update hit a recoverable branch, rebase, conflict, or metadata issue; user approval required before recovery work."
     },
     {
-      "id": "group-5a27510e-031f-4255-a500-59d190274e44",
+      "id": "group-e03a83ac-c98a-46c8-81a8-c9d88ff95c7f",
       "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
-      "source_node_id": "node-09339573-c966-460d-aad9-82d0f53ef9fc",
-      "transition_id": "retry_later",
-      "display_name": "Retry Later",
-      "description": "CI or GitHub is temporarily unavailable, still starting, or missing an expected run; user approval required before retrying monitoring."
+      "source_node_id": "node-5e2b9f5c-eed5-4639-8d38-8c4ee750662a",
+      "transition_id": "pr_merged",
+      "display_name": "Pr Merged",
+      "description": "PR is confirmed merged; cleanup can finish the task."
+    },
+    {
+      "id": "group-05ba971b-6bff-49fd-88ec-75d86ddd2199",
+      "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
+      "source_node_id": "node-5e2b9f5c-eed5-4639-8d38-8c4ee750662a",
+      "transition_id": "needs_changes",
+      "display_name": "Needs Changes",
+      "description": "PR review, conflicts, or post-CI regressions need task-scoped fixes."
+    },
+    {
+      "id": "group-284c689d-3e77-460b-8dc3-125178512bce",
+      "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
+      "source_node_id": "node-5e2b9f5c-eed5-4639-8d38-8c4ee750662a",
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "PR is still waiting on a human or external process; remain in Waiting PR."
+    },
+    {
+      "id": "group-06502ce4-5072-4b6c-a3e2-a2d0857e32c9",
+      "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
+      "source_node_id": "node-5e2b9f5c-eed5-4639-8d38-8c4ee750662a",
+      "transition_id": "close_without_merge",
+      "display_name": "Close Without Merge",
+      "description": "User explicitly closed/canceled the PR without merge; cleanup can finish."
+    },
+    {
+      "id": "group-e8fdd2bf-b3c0-4c75-893d-3144a8f7bbae",
+      "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
+      "source_node_id": "node-27dab828-f09b-4bd9-973b-2dc45ebcec8e",
+      "transition_id": "wont_do",
+      "display_name": "Wont Do",
+      "description": "Latest user comment explicitly cancels this task or declares it not planned; finish without treating it as a recoverable blocker."
     }
   ],
   "edges": [
@@ -265,7 +306,7 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Run the Puber dependency update flow for this Kent task.\n\nRead .kent/project-contract.md first, then use .kent/commands/dependency-update.md. Treat the task body as the filter/security/risk instruction. Create an explicit .todo/dependency-update-<date-or-scope> workspace; do not infer or create .todo/.current.\n\nUpdate gradle/libs.versions.toml and related build files only as needed. Prefer patch/minor safe batches; keep major updates isolated or report them as skipped if too risky for this task. Verify with focused Gradle commands using ./tools/agentw in .kent/worktrees and ./gradlew in the main checkout.\n\nComplete with verify and provide workspace_path, plan_path, updated_dependencies, changed_files, and verification_summary. Complete with blocked if package lookup, credentials, or build setup is blocked and provide blocker_reason."
+      "prompt_template": "Run the Puber dependency update flow for this Kent task.\n\nRead .kent/project-contract.md first, then use .kent/commands/dependency-update.md. Treat the task body as the filter/security/risk instruction. Create an explicit .todo/dependency-update-<date-or-scope> workspace; do not infer or create .todo/.current.\n\nUpdate gradle/libs.versions.toml and related build files only as needed. Prefer patch/minor safe batches; keep major updates isolated or report them as skipped if too risky for this task. Verify with focused Gradle commands using ./tools/agentw in .kent/worktrees and ./gradlew in the main checkout.\n\nComplete with verify and provide workspace_path, plan_path, updated_dependencies, changed_files, and verification_summary. Complete with needs_user_action if package lookup, credentials, or build setup is needs_user_action and provide blocker_reason."
     },
     {
       "id": "edge-e145c648-1e44-41d3-9a8b-924a337d3dd0",
@@ -278,15 +319,15 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Verify Puber dependency update fallout read-only.\n\nRead .kent/project-contract.md first. Inspect {{.Params.changed_files}}, updated dependencies {{.Params.updated_dependencies}}, and {{.Params.verification_summary}}. Run focused verification if practical. Do not edit files in this node.\n\nComplete with done if accepted. Complete with needs_changes if fallout fixes are needed and provide workspace_path, verification_report, and changed_files. Complete with blocked if verification cannot complete and provide blocker_reason.",
+      "prompt_template": "Verify Puber dependency update fallout read-only.\n\nRead .kent/project-contract.md first. Inspect {{.Params.changed_files}}, updated dependencies {{.Params.updated_dependencies}}, and {{.Params.verification_summary}}. Run focused verification if practical. Do not edit files in this node.\n\nComplete with compliance if accepted. Complete with needs_changes if fallout fixes are needed and provide workspace_path, verification_report, and changed_files. Complete with needs_user_action if verification cannot complete and provide blocker_reason.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/dependency-update-* workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "plan_path",
-          "description": "Path to the dependency update plan.md or report artifact."
+          "description": "Path to the plan.md used by this workflow transition."
         },
         {
           "key": "updated_dependencies",
@@ -306,17 +347,18 @@
       "id": "edge-c135ffad-0f49-4c92-afc3-a10457abc9ab",
       "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
       "transition_group_id": "group-dffb599b-7fca-43c2-a5ac-f314df007db9",
-      "key": "update_blocked",
-      "target_node_id": "node-8e0cfb7b-5034-448b-9921-7b830c6b358c",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "update_needs_user_action",
+      "target_node_id": "node-27dab828-f09b-4bd9-973b-2dc45ebcec8e",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why dependency update cannot continue, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -326,20 +368,20 @@
       "transition_group_id": "group-14351958-a9d9-4a65-9629-2d8c9056364a",
       "key": "fix_fallout",
       "target_node_id": "node-d51d551d-30cb-4948-8cbe-62d4d34fda9e",
-      "requires_approval": true,
+      "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Fix Puber dependency update fallout. Apply only fixes requested in {{.Params.verification_report}}, verify narrowly, and complete with verify or blocked.",
+      "prompt_template": "Fix Puber dependency update fallout. Apply only fixes requested in {{.Params.verification_report}}, verify narrowly, and complete with verify or needs_user_action.\n\nFor any needs_user_action transition, provide blocker_reason with the exact next user or external action needed.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/dependency-update-* workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "verification_report",
-          "description": "Verification findings and fallout to fix."
+          "description": "Commands/tests run and their results, or path to a verification report."
         },
         {
           "key": "changed_files",
@@ -351,18 +393,18 @@
       "id": "edge-955a1d32-2382-405c-ad0a-2e2a65878118",
       "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
       "transition_group_id": "group-668062f2-60d6-47f5-ad18-c80520aa0b2b",
-      "key": "verify_done",
+      "key": "verify_compliance",
       "target_node_id": "node-46820ad9-67b1-4eb6-9a7c-8ed568e28e45",
       "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Run mandatory Puber Compliance Review before cleanup.\n\nRead .kent/commands/compliance-review.md, .kent/project-contract.md, and AGENTS.md first. Reviewed scope: completed dependency update in workspace {{.Params.workspace_path}}. Changed files: {{.Params.changed_files}}. Review only compliance with task requirements, specs, AGENTS.md, dependency update rules, and workflow contract. Do not edit files.\n\nComplete with done and provide compliance_report when no compliance violations are found. Complete with needs_changes and provide workspace_path plus compliance_report when fixes are required. Complete with blocked and provide blocker_reason if required sources are missing or contradictory.",
+      "prompt_template": "Run mandatory Puber Compliance Review before cleanup.\n\nRead .kent/commands/compliance-review.md, .kent/project-contract.md, and AGENTS.md first. Reviewed scope: completed dependency update in workspace {{.Params.workspace_path}}. Changed files: {{.Params.changed_files}}. Review only compliance with task requirements, specs, AGENTS.md, dependency update rules, and workflow contract. Do not edit files.\n\nComplete with ship_pr and provide compliance_report when no compliance violations are found. Complete with needs_changes and provide workspace_path plus compliance_report when fixes are required. Complete with needs_user_action and provide blocker_reason if required sources are missing or contradictory.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/dependency-update-* workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "changed_files",
@@ -374,17 +416,18 @@
       "id": "edge-4f117691-e1e9-450e-84aa-536fbc3faa3d",
       "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
       "transition_group_id": "group-e52d04af-dfbd-4a58-9841-0254a894b7ff",
-      "key": "verify_blocked",
-      "target_node_id": "node-8e0cfb7b-5034-448b-9921-7b830c6b358c",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "verify_needs_user_action",
+      "target_node_id": "node-299c4802-4ea7-4dd7-8c47-36e269e5fc91",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why verification cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -399,15 +442,15 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Re-verify the Puber dependency update after fallout fixes. Complete with done, needs_changes, or blocked.",
+      "prompt_template": "Re-verify the Puber dependency update after fallout fixes. Complete with compliance, needs_changes, or needs_user_action.\n\nFor any needs_user_action transition, provide blocker_reason with the exact next user or external action needed.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/dependency-update-* workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "verification_report",
-          "description": "Original verification findings and fix summary."
+          "description": "Commands/tests run and their results, or path to a verification report."
         },
         {
           "key": "changed_files",
@@ -419,17 +462,18 @@
       "id": "edge-28c17c9e-d64c-45ef-93ef-d99e41043200",
       "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
       "transition_group_id": "group-78717f8d-cb76-4a49-b8fd-d5665581a8e6",
-      "key": "fix_blocked",
-      "target_node_id": "node-8e0cfb7b-5034-448b-9921-7b830c6b358c",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "fix_needs_user_action",
+      "target_node_id": "node-d51d551d-30cb-4948-8cbe-62d4d34fda9e",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why fallout fixing cannot continue, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -455,18 +499,18 @@
       "id": "edge-2391a51c-82b4-490e-b6a2-5f544f733cac",
       "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
       "transition_group_id": "group-5f92cf54-e07b-41db-a84d-c7787268e20d",
-      "key": "compliance_done",
+      "key": "compliance_ship_pr",
       "target_node_id": "node-e3459660-22bc-4ad2-bd8e-190745ecc83e",
       "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Create or update the Puber pull request for this completed task.\n\nRead .kent/project-contract.md, .kent/commands/ship-pr.md, and AGENTS.md first. Compliance result: {{.Params.compliance_report}}.\n\nIf this task produced repository changes, commit only task-related files, push the current task branch to origin, and create or update a GitHub PR. Do not merge the PR. Do not push directly to master/main. If there are no repository changes and the task is report-only or smoke-only, complete with done and provide pr_report explaining why PR is not applicable.\n\nComplete with monitor_ci when a PR exists and provide pr_url, branch_name, and workspace_path. Complete with needs_changes when PR creation/update is blocked by recoverable repository, branch, or PR state such as merge conflicts, non-fast-forward push, branch needing rebase, or missing PR metadata that can be fixed in the task worktree; provide workspace_path and blocker_reason. Complete with done only for PR-not-applicable/no-diff cases and provide pr_report. Complete with blocked only when continuing would be unsafe without changing task scope, credentials, or project policy; provide blocker_reason.",
+      "prompt_template": "Create or update the Puber pull request for this completed task.\n\nRead .kent/project-contract.md, .kent/commands/ship-pr.md, and AGENTS.md first. Compliance result: {{.Params.compliance_report}}.\n\nIf this task produced repository changes, commit only task-related files, push the current task branch to origin, and create or update a GitHub PR. Do not merge the PR. Do not push directly to master/main. If there are no repository changes and the task is report-only or smoke-only, complete with no_pr and provide pr_report explaining why PR is not applicable.\n\nComplete with monitor_ci when a PR exists and provide pr_url, branch_name, and workspace_path. Complete with needs_changes when PR creation/update is needs_user_action by recoverable repository, branch, or PR state such as merge conflicts, non-fast-forward push, branch needing rebase, or missing PR metadata that can be fixed in the task worktree; provide workspace_path and blocker_reason. Complete with no_pr only for PR-not-applicable/no-diff cases and provide pr_report. Complete with needs_user_action only when continuing would be unsafe without changing task scope, credentials, or project policy; provide blocker_reason.",
       "parameters": [
         {
           "key": "compliance_report",
-          "description": "Compliance review report, including rule sources checked and any findings."
+          "description": "Compliance review report or summary."
         }
       ]
     },
@@ -476,20 +520,20 @@
       "transition_group_id": "group-aeb735e7-b761-4f66-8a9e-12fd47cfeea5",
       "key": "compliance_fix",
       "target_node_id": "node-d51d551d-30cb-4948-8cbe-62d4d34fda9e",
-      "requires_approval": true,
+      "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Fix Puber dependency update compliance violations only.\n\nRead .kent/project-contract.md and .kent/commands/compliance-review.md first. Apply only the minimum changes required by compliance findings in {{.Params.compliance_report}} for workspace {{.Params.workspace_path}}. Verify narrowly, then complete with verify and provide workspace_path, verification_report, and changed_files. Complete with blocked and provide blocker_reason if unsafe or missing input.",
+      "prompt_template": "Fix Puber dependency update compliance violations only.\n\nRead .kent/project-contract.md and .kent/commands/compliance-review.md first. Apply only the minimum changes required by compliance findings in {{.Params.compliance_report}} for workspace {{.Params.workspace_path}}. Verify narrowly, then complete with verify and provide workspace_path, verification_report, and changed_files. Complete with needs_user_action and provide blocker_reason if unsafe or missing input.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/dependency-update-* workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "compliance_report",
-          "description": "Compliance review report, including rule sources checked and any findings."
+          "description": "Compliance review report or summary."
         }
       ]
     },
@@ -497,17 +541,18 @@
       "id": "edge-0b83081e-20cd-4b5c-b75e-e710c1750d1f",
       "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
       "transition_group_id": "group-bf582f19-d767-44aa-bedb-03f7f9de85c7",
-      "key": "compliance_blocked",
-      "target_node_id": "node-8e0cfb7b-5034-448b-9921-7b830c6b358c",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "compliance_needs_user_action",
+      "target_node_id": "node-46820ad9-67b1-4eb6-9a7c-8ed568e28e45",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why compliance review cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -522,19 +567,19 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Monitor Puber PR checks.\n\nRead .kent/project-contract.md and AGENTS.md first. Inspect PR {{.Params.pr_url}} on branch {{.Params.branch_name}}. Use GitHub CLI when available. Do not merge the PR. Do not push new commits from this node.\n\nComplete with done if CI/checks pass, are absent, or are intentionally skipped with a clear reason; provide ci_report and pr_url. Complete with needs_changes if CI failed due to task changes and provide workspace_path plus ci_report. Complete with retry_later when checks cannot be inspected because GitHub/CI is still starting, rate-limited, temporarily unavailable, or an expected run has not appeared yet; provide pr_url, branch_name, workspace_path, and ci_report. Complete with blocked only if checks cannot be inspected and retrying would be unsafe or misleading; provide blocker_reason.",
+      "prompt_template": "Monitor Puber PR checks.\n\nRead .kent/project-contract.md and AGENTS.md first. Inspect PR {{.Params.pr_url}} on branch {{.Params.branch_name}}. Use GitHub CLI when available. Do not merge the PR. Do not push new commits from this node.\n\nComplete with waiting_pr if CI/checks pass, are absent, or are intentionally skipped with a clear reason; provide ci_report and pr_url. Complete with needs_changes if CI failed due to task changes and provide workspace_path plus ci_report. Complete with needs_user_action for temporary external waits; provide blocker_reason. Complete with needs_user_action only if checks cannot be inspected and retrying would be unsafe or misleading; provide blocker_reason.",
       "parameters": [
         {
           "key": "pr_url",
-          "description": "URL of the pull request."
+          "description": "URL of the created, updated, or monitored pull request."
         },
         {
           "key": "branch_name",
-          "description": "Name of the pushed task branch."
+          "description": "Name of the task or release branch associated with the pull request."
         },
         {
           "key": "workspace_path",
-          "description": "Path to the worktree or checkout used for PR creation."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         }
       ]
     },
@@ -553,7 +598,7 @@
       "parameters": [
         {
           "key": "pr_report",
-          "description": "Why no pull request was created or updated."
+          "description": "PR creation, review, conflict, or post-CI regression report."
         }
       ]
     },
@@ -561,17 +606,18 @@
       "id": "edge-3e5e25ae-628d-4317-b14c-5c1edec8bd7a",
       "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
       "transition_group_id": "group-f6124d99-570f-4f64-8db5-f42b479d6e4f",
-      "key": "pr_blocked",
-      "target_node_id": "node-8e0cfb7b-5034-448b-9921-7b830c6b358c",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "ship_pr_needs_user_action",
+      "target_node_id": "node-e3459660-22bc-4ad2-bd8e-190745ecc83e",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why PR creation/update cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -579,22 +625,30 @@
       "id": "edge-fc5147e4-4047-4ae5-8d98-7b3eb3c11137",
       "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
       "transition_group_id": "group-b9a0562a-42d9-4c83-82ae-a8a0001e17a8",
-      "key": "ci_done",
-      "target_node_id": "node-60340771-783d-44fb-8854-1aca22a87dcf",
+      "key": "ci_waiting_pr",
+      "target_node_id": "node-5e2b9f5c-eed5-4639-8d38-8c4ee750662a",
       "requires_approval": false,
       "context_mode": "new_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Run conservative Puber task cleanup after PR/CI.\n\nRead .kent/project-contract.md first, then use .kent/commands/cleanup-task.md. PR: {{.Params.pr_url}}. CI report: {{.Params.ci_report}}. Do not delete any worktree containing unpushed or uncommitted user changes. Complete with done and provide cleanup_report.",
+      "prompt_template": "Hold this Puber task until its pull request is actually merged.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, PR {{.Params.pr_url}}, branch {{.Params.branch_name}}, workspace {{.Params.workspace_path}}, and CI report {{.Params.ci_report}}.\n\nUse `gh pr view --json state,mergedAt,mergeCommit,headRefName,baseRefName,url` when available. Do not merge the PR. Do not push commits from this node. Do not clean up while the PR is still open.\n\nComplete with pr_merged only when GitHub reports state=MERGED; provide pr_url, branch_name, and merge_report. Complete with needs_changes when PR review comments, merge conflicts, or post-CI regressions can be fixed within the task scope; provide workspace_path and pr_report. Complete with needs_user_action when the PR is still open, waiting for human review/approval/merge, or needs_user_action by an external process; add a task comment with the current PR status and exact human action, then provide pr_url, branch_name, workspace_path, and waiting_reason. Complete with close_without_merge only if the latest user comment explicitly says to close/cancel/skip this PR; provide pr_url, branch_name, and cleanup_reason.",
       "parameters": [
+        {
+          "key": "pr_url",
+          "description": "URL of the created, updated, or monitored pull request."
+        },
+        {
+          "key": "branch_name",
+          "description": "Name of the task or release branch associated with the pull request."
+        },
+        {
+          "key": "workspace_path",
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
+        },
         {
           "key": "ci_report",
           "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
-        },
-        {
-          "key": "pr_url",
-          "description": "URL of the created or updated pull request."
         }
       ]
     },
@@ -604,16 +658,16 @@
       "transition_group_id": "group-065b900c-c5fc-446c-8d01-97407158ce3a",
       "key": "ci_fix",
       "target_node_id": "node-d51d551d-30cb-4948-8cbe-62d4d34fda9e",
-      "requires_approval": true,
+      "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Fix Puber dependency update CI failures only.\n\nRead .kent/project-contract.md first. Apply only the minimum changes required by CI report {{.Params.ci_report}} in workspace {{.Params.workspace_path}}. Verify narrowly, then complete with verify and provide workspace_path, verification_report, and changed_files. Complete with blocked and provide blocker_reason if unsafe or missing input.",
+      "prompt_template": "Fix Puber dependency update CI failures only.\n\nRead .kent/project-contract.md first. Apply only the minimum changes required by CI report {{.Params.ci_report}} in workspace {{.Params.workspace_path}}. Verify narrowly, then complete with verify and provide workspace_path, verification_report, and changed_files. Complete with needs_user_action and provide blocker_reason if unsafe or missing input.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/dependency-update-* workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "ci_report",
@@ -625,17 +679,18 @@
       "id": "edge-af52bc8f-ce2f-4108-b9bb-f4efc2175269",
       "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
       "transition_group_id": "group-be8f0286-2f2d-464a-bf83-905baf5e9491",
-      "key": "ci_blocked",
-      "target_node_id": "node-8e0cfb7b-5034-448b-9921-7b830c6b358c",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "ci_monitor_needs_user_action",
+      "target_node_id": "node-09339573-c966-460d-aad9-82d0f53ef9fc",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why CI monitoring cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -650,46 +705,141 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Fix recoverable Puber PR creation/update issues only.\n\nRead .kent/project-contract.md, .kent/commands/ship-pr.md, and AGENTS.md first. Previous PR blocker: {{.Params.blocker_reason}}. Work in {{.Params.workspace_path}}. Apply only the minimum changes needed to make the task branch/PR shippable, such as rebasing, resolving merge conflicts, fixing branch metadata, or repairing the PR-ready commit set. Do not expand product scope. Verify narrowly, then continue through the workflow's normal review/compliance path. Complete with blocked only if the recovery is unsafe or requires user credentials/policy changes.",
+      "prompt_template": "Fix recoverable Puber PR creation/update issues only.\n\nRead .kent/project-contract.md, .kent/commands/ship-pr.md, and AGENTS.md first. Previous PR blocker: {{.Params.blocker_reason}}. Work in {{.Params.workspace_path}}. Apply only the minimum changes needed to make the task branch/PR shippable, such as rebasing, resolving merge conflicts, fixing branch metadata, or repairing the PR-ready commit set. Do not expand product scope. Verify narrowly, then continue through the workflow's normal review/compliance path. Complete with needs_user_action only if the recovery is unsafe or requires user credentials/policy changes.\n\nFor any needs_user_action transition, provide blocker_reason with the exact next user or external action needed.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the worktree or checkout used for PR creation."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "blocker_reason",
-          "description": "Why PR creation/update cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
     {
-      "id": "edge-2a67a605-53e4-4bd5-8219-917934b132ef",
+      "id": "edge-4e794d46-2ec5-4703-bd7b-cc07155334ad",
       "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
-      "transition_group_id": "group-5a27510e-031f-4255-a500-59d190274e44",
-      "key": "ci_retry",
-      "target_node_id": "node-09339573-c966-460d-aad9-82d0f53ef9fc",
+      "transition_group_id": "group-e03a83ac-c98a-46c8-81a8-c9d88ff95c7f",
+      "key": "cleanup_after_merge",
+      "target_node_id": "node-60340771-783d-44fb-8854-1aca22a87dcf",
+      "requires_approval": false,
+      "context_mode": "new_session",
+      "context_source": {
+        "kind": "immediate_source"
+      },
+      "prompt_template": "Run conservative Puber task cleanup after the pull request was confirmed merged.\n\nRead AGENTS.md, .kent/project-contract.md, .kent/commands/cleanup-task.md, PR {{.Params.pr_url}}, branch {{.Params.branch_name}}, and merge report {{.Params.merge_report}}. Verify the PR is merged with GitHub state, not only git ancestry, because squash merges are allowed. Do not delete any worktree containing unpushed commits, uncommitted user changes, or unclear ownership. Complete with done and provide cleanup_report.",
+      "parameters": [
+        {
+          "key": "pr_url",
+          "description": "URL of the created, updated, or monitored pull request."
+        },
+        {
+          "key": "branch_name",
+          "description": "Name of the task or release branch associated with the pull request."
+        },
+        {
+          "key": "merge_report",
+          "description": "GitHub PR state, mergedAt, mergeCommit, and cleanup or release notes."
+        }
+      ]
+    },
+    {
+      "id": "edge-10d40135-b389-46e5-babd-4019899b8cc1",
+      "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
+      "transition_group_id": "group-05ba971b-6bff-49fd-88ec-75d86ddd2199",
+      "key": "pr_feedback",
+      "target_node_id": "node-d51d551d-30cb-4948-8cbe-62d4d34fda9e",
+      "requires_approval": false,
+      "context_mode": "compact_and_continue_session",
+      "context_source": {
+        "kind": "immediate_source"
+      },
+      "prompt_template": "Fix Puber PR feedback only.\n\nRead AGENTS.md, .kent/project-contract.md, latest task comments, workspace {{.Params.workspace_path}}, and PR feedback report {{.Params.pr_report}}. Apply only task-scoped changes needed for PR review comments, merge conflicts, or post-CI regressions. Do not force-push unless the latest user comment explicitly permits force-push for this exact PR/branch. Verify narrowly, then return through the workflow's normal review/verify/compliance path with an updated report. If user input is required, complete with needs_user_action and provide blocker_reason.",
+      "parameters": [
+        {
+          "key": "workspace_path",
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
+        },
+        {
+          "key": "pr_report",
+          "description": "PR creation, review, conflict, or post-CI regression report."
+        }
+      ]
+    },
+    {
+      "id": "edge-e0305d17-0836-4dd0-b575-505062f55628",
+      "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
+      "transition_group_id": "group-284c689d-3e77-460b-8dc3-125178512bce",
+      "key": "waiting_pr_needs_user_action",
+      "target_node_id": "node-5e2b9f5c-eed5-4639-8d38-8c4ee750662a",
       "requires_approval": true,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Retry Puber PR check monitoring after an approved temporary CI/GitHub wait.\n\nRead .kent/project-contract.md and AGENTS.md first. Previous CI status: {{.Params.ci_report}}. Inspect PR {{.Params.pr_url}} on branch {{.Params.branch_name}} again. Do not merge the PR. Do not push new commits from this node.\n\nComplete with done if CI/checks pass, are absent, or are intentionally skipped with a clear reason; provide ci_report and pr_url. Complete with needs_changes if CI failed due to task changes and provide workspace_path plus ci_report. Complete with retry_later if CI/GitHub is still temporarily unavailable and provide pr_url, branch_name, workspace_path, and ci_report. Complete with blocked only if retrying is no longer useful or safe; provide blocker_reason.",
+      "prompt_template": "Re-check the Puber pull request after the user resolved the external wait or approved another check.\n\nRead AGENTS.md, .kent/project-contract.md, latest task comments, PR {{.Params.pr_url}}, branch {{.Params.branch_name}}, workspace {{.Params.workspace_path}}, and previous waiting reason {{.Params.waiting_reason}}. Do not merge, push, or clean up unless the PR is confirmed merged.\n\nComplete with pr_merged only when GitHub reports state=MERGED. Complete with needs_changes for task-scoped PR review/conflict/regression fixes. Complete with needs_user_action again if the PR is still waiting externally. Complete with close_without_merge only on explicit latest user instruction.",
       "parameters": [
         {
           "key": "pr_url",
-          "description": "URL of the created or updated pull request."
+          "description": "URL of the created, updated, or monitored pull request."
         },
         {
           "key": "branch_name",
-          "description": "Name of the pushed task branch."
+          "description": "Name of the task or release branch associated with the pull request."
         },
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/dependency-update-* workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
-          "key": "ci_report",
-          "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+          "key": "waiting_reason",
+          "description": "Why the PR cannot advance yet and the exact user or external action needed."
+        }
+      ]
+    },
+    {
+      "id": "edge-516fd78c-4831-4e2d-a164-912fbad2d2bf",
+      "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
+      "transition_group_id": "group-06502ce4-5072-4b6c-a3e2-a2d0857e32c9",
+      "key": "cancel_cleanup",
+      "target_node_id": "node-60340771-783d-44fb-8854-1aca22a87dcf",
+      "requires_approval": true,
+      "context_mode": "new_session",
+      "context_source": {
+        "kind": "immediate_source"
+      },
+      "prompt_template": "Run conservative Puber task cleanup after the user explicitly closed/canceled the PR without merge.\n\nRead AGENTS.md, .kent/project-contract.md, .kent/commands/cleanup-task.md, PR {{.Params.pr_url}}, branch {{.Params.branch_name}}, and cleanup reason {{.Params.cleanup_reason}}. Do not delete any worktree containing unpushed commits, uncommitted user changes, or unclear ownership. Complete with done and provide cleanup_report.",
+      "parameters": [
+        {
+          "key": "pr_url",
+          "description": "URL of the created, updated, or monitored pull request."
+        },
+        {
+          "key": "branch_name",
+          "description": "Name of the task or release branch associated with the pull request."
+        },
+        {
+          "key": "cleanup_reason",
+          "description": "Explicit user instruction or reason for cleanup without merge."
+        }
+      ]
+    },
+    {
+      "id": "edge-3130ff39-1507-4167-a28b-d6f8e7dc39e6",
+      "workflow_id": "workflow-ee05cfa8-8fc8-49e7-8eda-2e3893424ad2",
+      "transition_group_id": "group-e8fdd2bf-b3c0-4c75-893d-3144a8f7bbae",
+      "key": "update_wont_do",
+      "target_node_id": "node-8e0cfb7b-5034-448b-9921-7b830c6b358c",
+      "requires_approval": true,
+      "context_mode": "new_session",
+      "context_source": {
+        "kind": "immediate_source"
+      },
+      "parameters": [
+        {
+          "key": "closure_reason",
+          "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
         }
       ]
     }
@@ -704,11 +854,11 @@
         "possible_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/dependency-update-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "plan_path",
-            "description": "Path to the dependency update plan.md or report artifact."
+            "description": "Path to the plan.md used by this workflow transition."
           },
           {
             "name": "updated_dependencies",
@@ -724,7 +874,11 @@
           },
           {
             "name": "blocker_reason",
-            "description": "Why dependency update cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          },
+          {
+            "name": "closure_reason",
+            "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
           }
         ]
       },
@@ -733,11 +887,11 @@
         "possible_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/dependency-update-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "verification_report",
-            "description": "Verification findings and fallout to fix."
+            "description": "Commands/tests run and their results, or path to a verification report."
           },
           {
             "name": "changed_files",
@@ -745,7 +899,7 @@
           },
           {
             "name": "blocker_reason",
-            "description": "Why verification cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -754,11 +908,11 @@
         "possible_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/dependency-update-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "verification_report",
-            "description": "Original verification findings and fix summary."
+            "description": "Commands/tests run and their results, or path to a verification report."
           },
           {
             "name": "changed_files",
@@ -766,7 +920,7 @@
           },
           {
             "name": "blocker_reason",
-            "description": "Why fallout fixing cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -787,15 +941,15 @@
         "possible_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/dependency-update-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -804,23 +958,23 @@
         "possible_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "pr_report",
-            "description": "Why no pull request was created or updated."
+            "description": "PR creation, review, conflict, or post-CI regression report."
           },
           {
             "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -828,24 +982,57 @@
         "node_id": "node-09339573-c966-460d-aad9-82d0f53ef9fc",
         "possible_provision_fields": [
           {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
             "name": "ci_report",
             "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
           },
           {
-            "name": "pr_url",
-            "description": "URL of the created or updated pull request."
-          },
-          {
-            "name": "workspace_path",
-            "description": "Path to the explicit .todo/dependency-update-* workspace."
-          },
-          {
             "name": "blocker_reason",
-            "description": "Why CI monitoring cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          }
+        ]
+      },
+      {
+        "node_id": "node-5e2b9f5c-eed5-4639-8d38-8c4ee750662a",
+        "possible_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "merge_report",
+            "description": "GitHub PR state, mergedAt, mergeCommit, and cleanup or release notes."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "pr_report",
+            "description": "PR creation, review, conflict, or post-CI regression report."
+          },
+          {
+            "name": "waiting_reason",
+            "description": "Why the PR cannot advance yet and the exact user or external action needed."
+          },
+          {
+            "name": "cleanup_reason",
+            "description": "Explicit user instruction or reason for cleanup without merge."
           }
         ]
       },
@@ -862,11 +1049,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/dependency-update-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "plan_path",
-            "description": "Path to the dependency update plan.md or report artifact."
+            "description": "Path to the plan.md used by this workflow transition."
           },
           {
             "name": "updated_dependencies",
@@ -887,7 +1074,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why dependency update cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -896,11 +1083,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/dependency-update-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "verification_report",
-            "description": "Verification findings and fallout to fix."
+            "description": "Commands/tests run and their results, or path to a verification report."
           },
           {
             "name": "changed_files",
@@ -913,7 +1100,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/dependency-update-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "changed_files",
@@ -926,7 +1113,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why verification cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -935,11 +1122,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/dependency-update-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "verification_report",
-            "description": "Original verification findings and fix summary."
+            "description": "Commands/tests run and their results, or path to a verification report."
           },
           {
             "name": "changed_files",
@@ -952,7 +1139,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why fallout fixing cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -970,7 +1157,7 @@
         "required_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -979,11 +1166,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/dependency-update-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -992,7 +1179,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1001,15 +1188,15 @@
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           }
         ]
       },
@@ -1018,7 +1205,7 @@
         "required_provision_fields": [
           {
             "name": "pr_report",
-            "description": "Why no pull request was created or updated."
+            "description": "PR creation, review, conflict, or post-CI regression report."
           }
         ]
       },
@@ -1027,7 +1214,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1035,12 +1222,20 @@
         "transition_group_id": "group-b9a0562a-42d9-4c83-82ae-a8a0001e17a8",
         "required_provision_fields": [
           {
-            "name": "ci_report",
-            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
-            "name": "pr_url",
-            "description": "URL of the created or updated pull request."
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "ci_report",
+            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
           }
         ]
       },
@@ -1049,7 +1244,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/dependency-update-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "ci_report",
@@ -1062,7 +1257,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why CI monitoring cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1071,32 +1266,88 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
       {
-        "transition_group_id": "group-5a27510e-031f-4255-a500-59d190274e44",
+        "transition_group_id": "group-e03a83ac-c98a-46c8-81a8-c9d88ff95c7f",
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the created or updated pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "merge_report",
+            "description": "GitHub PR state, mergedAt, mergeCommit, and cleanup or release notes."
+          }
+        ]
+      },
+      {
+        "transition_group_id": "group-05ba971b-6bff-49fd-88ec-75d86ddd2199",
+        "required_provision_fields": [
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "pr_report",
+            "description": "PR creation, review, conflict, or post-CI regression report."
+          }
+        ]
+      },
+      {
+        "transition_group_id": "group-284c689d-3e77-460b-8dc3-125178512bce",
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/dependency-update-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
-            "name": "ci_report",
-            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+            "name": "waiting_reason",
+            "description": "Why the PR cannot advance yet and the exact user or external action needed."
+          }
+        ]
+      },
+      {
+        "transition_group_id": "group-06502ce4-5072-4b6c-a3e2-a2d0857e32c9",
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "cleanup_reason",
+            "description": "Explicit user instruction or reason for cleanup without merge."
+          }
+        ]
+      },
+      {
+        "transition_group_id": "group-e8fdd2bf-b3c0-4c75-893d-3144a8f7bbae",
+        "required_provision_fields": [
+          {
+            "name": "closure_reason",
+            "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
           }
         ]
       }
@@ -1137,11 +1388,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/dependency-update-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "plan_path",
-            "description": "Path to the dependency update plan.md or report artifact."
+            "description": "Path to the plan.md used by this workflow transition."
           },
           {
             "name": "updated_dependencies",
@@ -1169,7 +1420,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why dependency update cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1195,11 +1446,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/dependency-update-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "verification_report",
-            "description": "Verification findings and fallout to fix."
+            "description": "Commands/tests run and their results, or path to a verification report."
           },
           {
             "name": "changed_files",
@@ -1224,7 +1475,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/dependency-update-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "changed_files",
@@ -1244,7 +1495,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why verification cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1270,11 +1521,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/dependency-update-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "verification_report",
-            "description": "Original verification findings and fix summary."
+            "description": "Commands/tests run and their results, or path to a verification report."
           },
           {
             "name": "changed_files",
@@ -1294,7 +1545,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why fallout fixing cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1326,7 +1577,7 @@
         "required_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -1347,11 +1598,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/dependency-update-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -1367,7 +1618,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1393,15 +1644,15 @@
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           }
         ]
       },
@@ -1417,7 +1668,7 @@
         "required_provision_fields": [
           {
             "name": "pr_report",
-            "description": "Why no pull request was created or updated."
+            "description": "PR creation, review, conflict, or post-CI regression report."
           }
         ]
       },
@@ -1433,103 +1684,12 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
       {
         "edge_id": "edge-fc5147e4-4047-4ae5-8d98-7b3eb3c11137",
-        "input_bindings": [
-          {
-            "name": "ci_report",
-            "source": "transition_output",
-            "field": "ci_report"
-          },
-          {
-            "name": "pr_url",
-            "source": "transition_output",
-            "field": "pr_url"
-          }
-        ],
-        "required_provision_fields": [
-          {
-            "name": "ci_report",
-            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
-          },
-          {
-            "name": "pr_url",
-            "description": "URL of the created or updated pull request."
-          }
-        ]
-      },
-      {
-        "edge_id": "edge-e1c7f78e-26be-4d77-a479-2bd1afc681b5",
-        "input_bindings": [
-          {
-            "name": "workspace_path",
-            "source": "transition_output",
-            "field": "workspace_path"
-          },
-          {
-            "name": "ci_report",
-            "source": "transition_output",
-            "field": "ci_report"
-          }
-        ],
-        "required_provision_fields": [
-          {
-            "name": "workspace_path",
-            "description": "Path to the explicit .todo/dependency-update-* workspace."
-          },
-          {
-            "name": "ci_report",
-            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
-          }
-        ]
-      },
-      {
-        "edge_id": "edge-af52bc8f-ce2f-4108-b9bb-f4efc2175269",
-        "input_bindings": [
-          {
-            "name": "blocker_reason",
-            "source": "transition_output",
-            "field": "blocker_reason"
-          }
-        ],
-        "required_provision_fields": [
-          {
-            "name": "blocker_reason",
-            "description": "Why CI monitoring cannot complete, in the task language when practical."
-          }
-        ]
-      },
-      {
-        "edge_id": "edge-7fa56ec2-0d6b-4529-9e56-0d0fdd69ffe7",
-        "input_bindings": [
-          {
-            "name": "workspace_path",
-            "source": "transition_output",
-            "field": "workspace_path"
-          },
-          {
-            "name": "blocker_reason",
-            "source": "transition_output",
-            "field": "blocker_reason"
-          }
-        ],
-        "required_provision_fields": [
-          {
-            "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
-          },
-          {
-            "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
-          }
-        ]
-      },
-      {
-        "edge_id": "edge-2a67a605-53e4-4bd5-8219-917934b132ef",
         "input_bindings": [
           {
             "name": "pr_url",
@@ -1555,19 +1715,237 @@
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the created or updated pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/dependency-update-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "ci_report",
             "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-e1c7f78e-26be-4d77-a479-2bd1afc681b5",
+        "input_bindings": [
+          {
+            "name": "workspace_path",
+            "source": "transition_output",
+            "field": "workspace_path"
+          },
+          {
+            "name": "ci_report",
+            "source": "transition_output",
+            "field": "ci_report"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "ci_report",
+            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-af52bc8f-ce2f-4108-b9bb-f4efc2175269",
+        "input_bindings": [
+          {
+            "name": "blocker_reason",
+            "source": "transition_output",
+            "field": "blocker_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "blocker_reason",
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-7fa56ec2-0d6b-4529-9e56-0d0fdd69ffe7",
+        "input_bindings": [
+          {
+            "name": "workspace_path",
+            "source": "transition_output",
+            "field": "workspace_path"
+          },
+          {
+            "name": "blocker_reason",
+            "source": "transition_output",
+            "field": "blocker_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "blocker_reason",
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-4e794d46-2ec5-4703-bd7b-cc07155334ad",
+        "input_bindings": [
+          {
+            "name": "pr_url",
+            "source": "transition_output",
+            "field": "pr_url"
+          },
+          {
+            "name": "branch_name",
+            "source": "transition_output",
+            "field": "branch_name"
+          },
+          {
+            "name": "merge_report",
+            "source": "transition_output",
+            "field": "merge_report"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "merge_report",
+            "description": "GitHub PR state, mergedAt, mergeCommit, and cleanup or release notes."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-10d40135-b389-46e5-babd-4019899b8cc1",
+        "input_bindings": [
+          {
+            "name": "workspace_path",
+            "source": "transition_output",
+            "field": "workspace_path"
+          },
+          {
+            "name": "pr_report",
+            "source": "transition_output",
+            "field": "pr_report"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "pr_report",
+            "description": "PR creation, review, conflict, or post-CI regression report."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-e0305d17-0836-4dd0-b575-505062f55628",
+        "input_bindings": [
+          {
+            "name": "pr_url",
+            "source": "transition_output",
+            "field": "pr_url"
+          },
+          {
+            "name": "branch_name",
+            "source": "transition_output",
+            "field": "branch_name"
+          },
+          {
+            "name": "workspace_path",
+            "source": "transition_output",
+            "field": "workspace_path"
+          },
+          {
+            "name": "waiting_reason",
+            "source": "transition_output",
+            "field": "waiting_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "waiting_reason",
+            "description": "Why the PR cannot advance yet and the exact user or external action needed."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-516fd78c-4831-4e2d-a164-912fbad2d2bf",
+        "input_bindings": [
+          {
+            "name": "pr_url",
+            "source": "transition_output",
+            "field": "pr_url"
+          },
+          {
+            "name": "branch_name",
+            "source": "transition_output",
+            "field": "branch_name"
+          },
+          {
+            "name": "cleanup_reason",
+            "source": "transition_output",
+            "field": "cleanup_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "cleanup_reason",
+            "description": "Explicit user instruction or reason for cleanup without merge."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-3130ff39-1507-4167-a28b-d6f8e7dc39e6",
+        "input_bindings": [
+          {
+            "name": "closure_reason",
+            "source": "transition_output",
+            "field": "closure_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "closure_reason",
+            "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
           }
         ]
       }

--- a/.kent/workflows/puber-feature-delivery.json
+++ b/.kent/workflows/puber-feature-delivery.json
@@ -3,7 +3,7 @@
     "id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
     "name": "Puber Feature Delivery",
     "description": "Plan, implement, audit, fix, optionally smoke-test, and conservatively clean up a Puber Android feature.",
-    "version": 87
+    "version": 194
   },
   "nodes": [
     {
@@ -70,9 +70,9 @@
     {
       "id": "node-6f47e8ba-91b3-410e-9712-33a8460d051c",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
-      "key": "blocked",
+      "key": "wont_do",
       "kind": "terminal",
-      "display_name": "Blocked"
+      "display_name": "Won't Do"
     },
     {
       "id": "node-e6237246-e06b-4dbd-8ef5-82cc5e4d37f9",
@@ -98,6 +98,15 @@
       "key": "ci_monitor",
       "kind": "agent",
       "display_name": "Monitor CI",
+      "subagent_role": "default",
+      "completion_mode": "shell_command"
+    },
+    {
+      "id": "node-18c10adf-87fd-410d-a3d7-7b5184e213d0",
+      "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
+      "key": "waiting_pr",
+      "kind": "agent",
+      "display_name": "Waiting PR",
       "subagent_role": "default",
       "completion_mode": "shell_command"
     },
@@ -130,9 +139,9 @@
       "id": "group-ab10fc78-3382-442c-89af-7ec5048c6469",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
       "source_node_id": "node-d2f1beb1-9ec0-46dd-af07-5791247f7cd2",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Planning is blocked by missing context, access, or product input."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "plan cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-eeb153bb-cd73-4f6a-97ca-8047af9b5a2c",
@@ -154,9 +163,9 @@
       "id": "group-362b1402-9eb9-4ca9-bbbc-6a3d3e9bacd9",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
       "source_node_id": "node-2f67f636-18bc-4279-8d5e-bd7875befdf5",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Implementation is blocked by missing input, access, or unsafe state."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "implement cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-10df1811-99b9-40ea-b7f0-012c9ae9ee80",
@@ -178,17 +187,17 @@
       "id": "group-dd5fdae9-7977-4fa6-aa8a-84fc70ad552f",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
       "source_node_id": "node-79d3facb-ccb3-4c41-87f6-557b52ddd9c0",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "Audit is acceptable and no smoke test is needed; run mandatory compliance review before cleanup."
+      "transition_id": "compliance",
+      "display_name": "Compliance",
+      "description": "Work passed this stage; run mandatory compliance review before any PR/cleanup path."
     },
     {
       "id": "group-2387bd03-a0a3-4513-95db-660db539c42a",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
       "source_node_id": "node-79d3facb-ccb3-4c41-87f6-557b52ddd9c0",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Audit cannot continue due to missing access, context, or verification."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "audit cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-7dafb6af-924d-42c0-b204-cbbdb9f49328",
@@ -202,17 +211,17 @@
       "id": "group-03c0801f-bfda-47bf-9c33-34e5b8f0969b",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
       "source_node_id": "node-9062f417-dae0-4134-8ce6-941b08acd8c9",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Fixing is blocked by missing input, unsafe state, or verification failure."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "fix cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-657b1d9e-7326-4595-824d-cc958572d539",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
       "source_node_id": "node-3f862fff-37e7-47e3-810c-46efe5cdafce",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "Smoke test passed or is accepted; run mandatory compliance review before cleanup."
+      "transition_id": "compliance",
+      "display_name": "Compliance",
+      "description": "Work passed this stage; run mandatory compliance review before any PR/cleanup path."
     },
     {
       "id": "group-08a76455-9bc0-4108-9b65-3d1db914688c",
@@ -226,9 +235,9 @@
       "id": "group-1ff098ab-f943-49a7-818b-f956b0b13be9",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
       "source_node_id": "node-3f862fff-37e7-47e3-810c-46efe5cdafce",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Smoke test is blocked by missing device, MCP, build, or credentials."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "smoke cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-08623de3-fc3a-46d0-a8dd-196b12611db1",
@@ -242,9 +251,9 @@
       "id": "group-9dda5506-b406-4c3a-be0a-244ab3a8a2d2",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
       "source_node_id": "node-e6237246-e06b-4dbd-8ef5-82cc5e4d37f9",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "Compliance review passed; create or update the task pull request before cleanup."
+      "transition_id": "ship_pr",
+      "display_name": "Ship PR",
+      "description": "Compliance passed; create or update the task PR before any terminal completion."
     },
     {
       "id": "group-e638780a-d2e5-4455-8612-273ccf8622c6",
@@ -258,9 +267,9 @@
       "id": "group-e1d15c14-1bb1-48e3-9150-be1779aaf4db",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
       "source_node_id": "node-e6237246-e06b-4dbd-8ef5-82cc5e4d37f9",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Compliance review is blocked by missing or contradictory required sources."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "compliance cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-d824db76-ee2f-42b7-aba2-e917b541d9a4",
@@ -274,25 +283,25 @@
       "id": "group-04225c23-767a-409e-af1a-e82da0ef3c4d",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
       "source_node_id": "node-c09db099-fbc4-474b-be0f-2e04447e7bd4",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "PR is intentionally not applicable because there are no repository changes; run cleanup."
+      "transition_id": "no_pr",
+      "display_name": "No PR",
+      "description": "No PR is applicable because there are no repository changes or the task is explicitly report-only; cleanup can finish the task."
     },
     {
       "id": "group-7e0a7c4a-d0f6-4810-8c5c-d31d10f55b72",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
       "source_node_id": "node-c09db099-fbc4-474b-be0f-2e04447e7bd4",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "PR creation or update is blocked by git state, auth, remote, branch, or unsafe repository state."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "ship_pr cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-4e98fceb-2f43-4b59-94f9-f36e2458b7f0",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
       "source_node_id": "node-e83dfbfe-4816-4a05-933a-703b38648ef8",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "PR checks passed or are intentionally skipped; run conservative cleanup."
+      "transition_id": "waiting_pr",
+      "display_name": "Waiting PR",
+      "description": "PR checks passed or were intentionally skipped; wait until the PR is merged before cleanup/done."
     },
     {
       "id": "group-1b46370e-d35a-4808-afa5-e96bb3fc1418",
@@ -306,9 +315,9 @@
       "id": "group-13db20db-4732-4367-8faa-1aa8c1c394bc",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
       "source_node_id": "node-e83dfbfe-4816-4a05-933a-703b38648ef8",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "CI monitoring is blocked by GitHub access, missing check data, or unsafe repository state."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "ci_monitor cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-55863a97-3ddc-465a-92c2-94389c992537",
@@ -319,20 +328,44 @@
       "description": "PR creation/update hit a recoverable branch, rebase, conflict, or metadata issue; user approval required before recovery work."
     },
     {
-      "id": "group-2289b446-bf32-4815-87e2-e561447f772d",
+      "id": "group-97a95f65-c303-45b0-a5d0-7d8634b7ba5d",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
-      "source_node_id": "node-e83dfbfe-4816-4a05-933a-703b38648ef8",
-      "transition_id": "retry_later",
-      "display_name": "Retry Later",
-      "description": "CI or GitHub is temporarily unavailable, still starting, or missing an expected run; user approval required before retrying monitoring."
+      "source_node_id": "node-18c10adf-87fd-410d-a3d7-7b5184e213d0",
+      "transition_id": "pr_merged",
+      "display_name": "Pr Merged",
+      "description": "PR is confirmed merged; cleanup can finish the task."
     },
     {
-      "id": "group-fa1d36b6-c72c-4828-8116-333044f4c7c8",
+      "id": "group-1005c60e-681a-456f-8530-8b94ded4ebda",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
-      "source_node_id": "node-3f862fff-37e7-47e3-810c-46efe5cdafce",
-      "transition_id": "retry_later",
-      "display_name": "Retry Later",
-      "description": "Device, MCP, build, or emulator-lock access is temporarily unavailable; user approval required before retrying smoke."
+      "source_node_id": "node-18c10adf-87fd-410d-a3d7-7b5184e213d0",
+      "transition_id": "needs_changes",
+      "display_name": "Needs Changes",
+      "description": "PR review, conflicts, or post-CI regressions need task-scoped fixes."
+    },
+    {
+      "id": "group-a90ef3e6-c834-44eb-a12a-685cfe40959e",
+      "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
+      "source_node_id": "node-18c10adf-87fd-410d-a3d7-7b5184e213d0",
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "PR is still waiting on a human or external process; remain in Waiting PR."
+    },
+    {
+      "id": "group-7da26b5a-3af4-4e2a-a7e5-c796474d66a1",
+      "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
+      "source_node_id": "node-18c10adf-87fd-410d-a3d7-7b5184e213d0",
+      "transition_id": "close_without_merge",
+      "display_name": "Close Without Merge",
+      "description": "User explicitly closed/canceled the PR without merge; cleanup can finish."
+    },
+    {
+      "id": "group-8acf1f57-bf78-4b5d-9f91-4af25470abd1",
+      "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
+      "source_node_id": "node-d2f1beb1-9ec0-46dd-af07-5791247f7cd2",
+      "transition_id": "wont_do",
+      "display_name": "Wont Do",
+      "description": "Latest user comment explicitly cancels this task or declares it not planned; finish without treating it as a recoverable blocker."
     }
   ],
   "edges": [
@@ -347,7 +380,7 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Run the Puber feature planning flow for this Kent task.\n\nRead .kent/project-contract.md first, then use .kent/commands/feature-start.md as the project feature planning command. Treat the task title/body as the feature arguments and source context. Resolve or create an explicit .todo/<feature> workspace; do not infer or create .todo/.current.\n\nGather available Figma/spec/source context through project-local adapters only when present. Produce .todo/<feature>/spec.md as needed and .todo/<feature>/plan.md. Do not implement production code.\n\nComplete with transition implement when the plan is ready for user approval and provide workspace_path plus plan_path. Complete with blocked if required source context or product input is unavailable, and provide blocker_reason in the task language when practical."
+      "prompt_template": "Run the Puber feature planning flow for this Kent task.\n\nRead .kent/project-contract.md first, then use .kent/commands/feature-start.md as the project feature planning command. Treat the task title/body as the feature arguments and source context. Resolve or create an explicit .todo/<feature> workspace; do not infer or create .todo/.current.\n\nGather available Figma/spec/source context through project-local adapters only when present. Produce .todo/<feature>/spec.md as needed and .todo/<feature>/plan.md. Do not implement production code.\n\nComplete with transition implement when the plan is ready and has no unresolved product/API/UX ambiguity and provide workspace_path plus plan_path. Complete with needs_user_action if required source context or product input is unavailable, and provide blocker_reason in the task language when practical."
     },
     {
       "id": "edge-3ae5e6b8-37e9-4adf-aa70-62032cf14fae",
@@ -355,20 +388,20 @@
       "transition_group_id": "group-bbb7070d-ea25-4bc0-aa79-1af3cc59ec2e",
       "key": "approve_implement",
       "target_node_id": "node-2f67f636-18bc-4279-8d5e-bd7875befdf5",
-      "requires_approval": true,
+      "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Implement the approved Puber feature plan.\n\nRead .kent/project-contract.md first. Use .kent/commands/feature-implement.md with explicit workspace {{.Params.workspace_path}} and plan {{.Params.plan_path}}. Do not infer .todo/.current.\n\nImplement one next unchecked ready step or one ready parallel group. For parallel groups, delegate to project-local orchestration with: kent run --agent=feature-orchestrator --workspace \"$PWD\" \"<bounded prompt containing workspace_path, plan_path, selected steps, file boundaries, and compile command>\". Use kent run --agent=implementation-worker for bounded slices and kent run --agent=build-doctor for noisy compile failures.\n\nVerify with the narrowest relevant Gradle/test command, using ./tools/agentw in .kent/worktrees and ./gradlew in the main checkout. Update plan.md and meta.json progress.\n\nIf more unchecked implementation steps remain, complete with transition continue_implementation and provide workspace_path plus plan_path again. If all implementation steps are complete, complete with transition audit and provide workspace_path, plan_path, and verification_report. Complete with blocked on unresolved blockers and provide blocker_reason.",
+      "prompt_template": "Implement the Puber feature plan.\n\nRead .kent/project-contract.md first. Use .kent/commands/feature-implement.md with explicit workspace {{.Params.workspace_path}} and plan {{.Params.plan_path}}. Do not infer .todo/.current.\n\nImplement one next unchecked ready step or one ready parallel group. For parallel groups, delegate to project-local orchestration with: kent run --agent=feature-orchestrator --workspace \"$PWD\" \"<bounded prompt containing workspace_path, plan_path, selected steps, file boundaries, and compile command>\". Use kent run --agent=implementation-worker for bounded slices and kent run --agent=build-doctor for noisy compile failures.\n\nVerify with the narrowest relevant Gradle/test command, using ./tools/agentw in .kent/worktrees and ./gradlew in the main checkout. Update plan.md and meta.json progress.\n\nIf more unchecked implementation steps remain, complete with transition continue_implementation and provide workspace_path plus plan_path again. If all implementation steps are complete, complete with transition audit and provide workspace_path, plan_path, and verification_report. Complete with needs_user_action on unresolved blockers and provide blocker_reason.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/<feature> workspace created by planning."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "plan_path",
-          "description": "Path to the generated plan.md inside the feature workspace."
+          "description": "Path to the plan.md used by this workflow transition."
         }
       ]
     },
@@ -376,17 +409,18 @@
       "id": "edge-ec37d01a-f355-4f9e-9bff-eadd92442241",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
       "transition_group_id": "group-ab10fc78-3382-442c-89af-7ec5048c6469",
-      "key": "plan_blocked",
-      "target_node_id": "node-6f47e8ba-91b3-410e-9712-33a8460d051c",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "plan_needs_user_action",
+      "target_node_id": "node-d2f1beb1-9ec0-46dd-af07-5791247f7cd2",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Short human-readable blocker explanation. Use the same language as the task/user request when practical; include the missing access/input/check and next action needed."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -401,15 +435,15 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Continue the same Puber feature implementation.\n\nRead .kent/project-contract.md, then use .kent/commands/feature-implement.md with explicit workspace {{.Params.workspace_path}} and plan {{.Params.plan_path}}. Do not infer .todo/.current.\n\nSelect the next unchecked ready step or ready parallel group, implement it, verify it, and update plan.md/meta.json. Use project-local delegated agents only for bounded work: feature-orchestrator, implementation-worker, and build-doctor.\n\nComplete with continue_implementation and provide workspace_path plus plan_path if more steps remain. Complete with audit and provide workspace_path, plan_path, and verification_report when all implementation steps are complete. Complete with blocked and blocker_reason if blocked.",
+      "prompt_template": "Continue the same Puber feature implementation.\n\nRead .kent/project-contract.md, then use .kent/commands/feature-implement.md with explicit workspace {{.Params.workspace_path}} and plan {{.Params.plan_path}}. Do not infer .todo/.current.\n\nSelect the next unchecked ready step or ready parallel group, implement it, verify it, and update plan.md/meta.json. Use project-local delegated agents only for bounded work: feature-orchestrator, implementation-worker, and build-doctor.\n\nComplete with continue_implementation and provide workspace_path plus plan_path if more steps remain. Complete with audit and provide workspace_path, plan_path, and verification_report when all implementation steps are complete. Complete with needs_user_action and blocker_reason if needs_user_action.\n\nFor any needs_user_action transition, provide blocker_reason with the exact next user or external action needed.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/<feature> workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "plan_path",
-          "description": "Path to plan.md inside the feature workspace."
+          "description": "Path to the plan.md used by this workflow transition."
         }
       ]
     },
@@ -424,15 +458,15 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Run a read-only Puber feature audit.\n\nRead .kent/project-contract.md first. Use .kent/commands/feature-audit.md with explicit workspace {{.Params.workspace_path}} and plan {{.Params.plan_path}}. Do not infer .todo/.current.\n\nReview implementation against spec, optional design artifacts, plan, Puber architecture in AGENTS.md, Compose quality, API/domain contracts, and verification coverage. Delegate broad read-only review when useful with kent run --agent=quality-reviewer --workspace \"$PWD\" \"<bounded review prompt>\". Use compose-reviewer and domain-model-reviewer for focused read-only review when applicable.\n\nWrite/update an audit report under the feature workspace. Complete with needs_changes if fixes are required and provide workspace_path plus audit_report. Complete with smoke if implementation is acceptable and device smoke is useful, providing workspace_path plus audit_report. Complete with done if no smoke is needed, providing workspace_path plus audit_report. Complete with blocked and blocker_reason if verification cannot continue.",
+      "prompt_template": "Run a read-only Puber feature audit.\n\nRead .kent/project-contract.md first. Use .kent/commands/feature-audit.md with explicit workspace {{.Params.workspace_path}} and plan {{.Params.plan_path}}. Do not infer .todo/.current.\n\nReview implementation against spec, optional design artifacts, plan, Puber architecture in AGENTS.md, Compose quality, API/domain contracts, and verification coverage. Delegate broad read-only review when useful with kent run --agent=quality-reviewer --workspace \"$PWD\" \"<bounded review prompt>\". Use compose-reviewer and domain-model-reviewer for focused read-only review when applicable.\n\nWrite/update an audit report under the feature workspace. Complete with needs_changes if fixes are required and provide workspace_path plus audit_report. Complete with smoke if implementation is acceptable and device smoke is useful, providing workspace_path plus audit_report. Complete with compliance if no smoke is needed, providing workspace_path plus audit_report. Complete with needs_user_action and blocker_reason if verification cannot continue.\n\nFor any needs_user_action transition, provide blocker_reason with the exact next user or external action needed.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/<feature> workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "plan_path",
-          "description": "Path to plan.md inside the feature workspace."
+          "description": "Path to the plan.md used by this workflow transition."
         },
         {
           "key": "verification_report",
@@ -444,17 +478,18 @@
       "id": "edge-84dba5e3-443c-48a4-8d76-78356d82fcc7",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
       "transition_group_id": "group-362b1402-9eb9-4ca9-bbbc-6a3d3e9bacd9",
-      "key": "implementation_blocked",
-      "target_node_id": "node-6f47e8ba-91b3-410e-9712-33a8460d051c",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "implement_needs_user_action",
+      "target_node_id": "node-2f67f636-18bc-4279-8d5e-bd7875befdf5",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Short human-readable blocker explanation. Use the same language as the task/user request when practical; include the missing access/input/check and next action needed."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -464,20 +499,20 @@
       "transition_group_id": "group-10df1811-99b9-40ea-b7f0-012c9ae9ee80",
       "key": "audit_fix",
       "target_node_id": "node-9062f417-dae0-4134-8ce6-941b08acd8c9",
-      "requires_approval": true,
+      "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Apply approved fixes for the Puber feature audit.\n\nRead .kent/project-contract.md first. Use .kent/commands/feature-fix.md with explicit workspace {{.Params.workspace_path}} and audit report {{.Params.audit_report}}, or apply the smallest safe manual fixes described in the audit report. Do not infer .todo/.current.\n\nUse kent run --agent=implementation-worker for bounded fix slices and kent run --agent=build-doctor for compile diagnostics when useful. Keep the fix scope narrow, verify locally, update the audit report, then complete with transition audit and provide workspace_path plus audit_report. Complete with blocked and blocker_reason if blocked.",
+      "prompt_template": "Apply audit fixes for the Puber feature audit.\n\nRead .kent/project-contract.md first. Use .kent/commands/feature-fix.md with explicit workspace {{.Params.workspace_path}} and audit report {{.Params.audit_report}}, or apply the smallest safe manual fixes described in the audit report. Do not infer .todo/.current.\n\nUse kent run --agent=implementation-worker for bounded fix slices and kent run --agent=build-doctor for compile diagnostics when useful. Keep the fix scope narrow, verify locally, update the audit report, then complete with transition audit and provide workspace_path plus audit_report. Complete with needs_user_action and blocker_reason if needs_user_action.\n\nFor any needs_user_action transition, provide blocker_reason with the exact next user or external action needed.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/<feature> workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "audit_report",
-          "description": "Path to the audit report for the feature workspace."
+          "description": "Path or summary of the current audit/review report."
         }
       ]
     },
@@ -487,20 +522,20 @@
       "transition_group_id": "group-056da8c9-a711-48ee-9ce9-7e7ae75d0360",
       "key": "audit_smoke",
       "target_node_id": "node-3f862fff-37e7-47e3-810c-46efe5cdafce",
-      "requires_approval": true,
+      "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Run a focused Puber device smoke test.\n\nRead .kent/project-contract.md first. Use .kent/commands/smoke-test.md for workspace {{.Params.workspace_path}} and audit report {{.Params.audit_report}}. Before touching any emulator/device, use .kent/adapters/mobile/emulator-resource-lock.sh to discover running adb emulators and acquire any free emulator-specific lock. Pass the selected serial to every adb command with adb -s. Physical devices, including a real TV, are forbidden unless the task/user explicitly names or allows that physical device. Never rely on adb default target selection. If all running emulators are busy, inspect lock owners and start a second emulator only when the task/user explicitly allows parallel device usage and you can acquire a distinct lock for it. Install a trap immediately after acquiring a lock so it is released on failure.\n\nAlways build a fresh devDebug APK before device testing, install it with explicit adb -s \"$DEVICE_SERIAL\" install -r app/build/outputs/apk/dev/debug/app-dev-debug.apk, force-stop the app, and launch com.kino.puber.stage/com.kino.puber.MainActivity. Do not use Gradle install* tasks for smoke tests. Use Mobile MCP through .kent/adapters/mcp wrappers, save useful artifacts under build/test-artifacts or the feature workspace, and release the mobile resource lock after reporting.\n\nComplete with done if smoke passes. Complete with needs_changes if smoke finds implementation issues and provide workspace_path, audit_report, and smoke_report. Complete with retry_later if device/MCP/build/resource locking access is temporarily unavailable and provide workspace_path, audit_report, and blocker_reason. Complete with blocked only for unrecoverable smoke blockers that cannot be solved by waiting, freeing an emulator, or user approval; provide blocker_reason.",
+      "prompt_template": "Run a focused Puber device smoke test.\n\nRead .kent/project-contract.md first. Use .kent/commands/smoke-test.md for workspace {{.Params.workspace_path}} and audit report {{.Params.audit_report}}. Before touching any emulator/device, use .kent/adapters/mobile/emulator-resource-lock.sh to discover running adb emulators and acquire any free emulator-specific lock. Pass the selected serial to every adb command with adb -s. Physical devices, including a real TV, are forbidden unless the task/user explicitly provides permission and an explicit serial for that physical device. Never rely on adb default target selection. If all running emulators are busy, inspect lock owners and start a second emulator only when the task/user explicitly allows parallel device usage and you can acquire a distinct lock for it. Install a trap immediately after acquiring a lock so it is released on failure.\n\nAlways build a fresh devDebug APK before device testing, install it with explicit adb -s \"$DEVICE_SERIAL\" install -r app/build/outputs/apk/dev/debug/app-dev-debug.apk, force-stop the app, and launch com.kino.puber.stage/com.kino.puber.MainActivity. Do not use Gradle install* tasks for smoke tests. Use Mobile MCP through .kent/adapters/mcp wrappers, save useful artifacts under build/test-artifacts or the feature workspace, and release the mobile resource lock after reporting.\n\nComplete with compliance if smoke passes. Complete with needs_changes if smoke finds implementation issues and provide workspace_path, audit_report, and smoke_report. Complete with needs_user_action for temporary external waits; provide blocker_reason. Complete with needs_user_action only for unrecoverable smoke blockers that cannot be solved by waiting, freeing an emulator, or user approval; provide blocker_reason.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/<feature> workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "audit_report",
-          "description": "Path to the audit report for the feature workspace."
+          "description": "Path or summary of the current audit/review report."
         }
       ]
     },
@@ -508,22 +543,22 @@
       "id": "edge-ce425045-47bb-4395-8280-7c4e93637685",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
       "transition_group_id": "group-dd5fdae9-7977-4fa6-aa8a-84fc70ad552f",
-      "key": "audit_done",
+      "key": "audit_compliance",
       "target_node_id": "node-e6237246-e06b-4dbd-8ef5-82cc5e4d37f9",
       "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Run mandatory Puber Compliance Review before cleanup.\n\nRead .kent/commands/compliance-review.md, .kent/project-contract.md, and AGENTS.md first. Reviewed scope: completed feature implementation in workspace {{.Params.workspace_path}} after audit {{.Params.audit_report}}. Review only compliance with task requirements, plan/design/specs, AGENTS.md, and workflow contract. Do not edit files.\n\nComplete with done and provide compliance_report when no compliance violations are found. Complete with needs_changes and provide workspace_path plus compliance_report when fixes are required. Complete with blocked and provide blocker_reason if required sources are missing or contradictory.",
+      "prompt_template": "Run mandatory Puber Compliance Review before cleanup.\n\nRead .kent/commands/compliance-review.md, .kent/project-contract.md, and AGENTS.md first. Reviewed scope: completed feature implementation in workspace {{.Params.workspace_path}} after audit {{.Params.audit_report}}. Review only compliance with task requirements, plan/design/specs, AGENTS.md, and workflow contract. Do not edit files.\n\nComplete with ship_pr and provide compliance_report when no compliance violations are found. Complete with needs_changes and provide workspace_path plus compliance_report when fixes are required. Complete with needs_user_action and provide blocker_reason if required sources are missing or contradictory.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/<feature> workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "audit_report",
-          "description": "Path to the audit report for the feature workspace."
+          "description": "Path or summary of the current audit/review report."
         }
       ]
     },
@@ -531,17 +566,18 @@
       "id": "edge-5aa17012-ad22-47d8-8f99-8d900d1bf98f",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
       "transition_group_id": "group-2387bd03-a0a3-4513-95db-660db539c42a",
-      "key": "audit_blocked",
-      "target_node_id": "node-6f47e8ba-91b3-410e-9712-33a8460d051c",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "audit_needs_user_action",
+      "target_node_id": "node-79d3facb-ccb3-4c41-87f6-557b52ddd9c0",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Short human-readable blocker explanation. Use the same language as the task/user request when practical; include the missing access/input/check and next action needed."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -556,15 +592,15 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Re-run the Puber feature audit after fixes.\n\nRead .kent/project-contract.md first. Re-check workspace {{.Params.workspace_path}} with audit report {{.Params.audit_report}}. Focus on previous findings plus regressions from the fix pass. Do not infer .todo/.current.\n\nComplete with needs_changes, smoke, done, or blocked. Provide workspace_path plus audit_report when continuing, or blocker_reason when blocked.",
+      "prompt_template": "Re-run the Puber feature audit after fixes.\n\nRead .kent/project-contract.md first. Re-check workspace {{.Params.workspace_path}} with audit report {{.Params.audit_report}}. Focus on previous findings plus regressions from the fix pass. Do not infer .todo/.current.\n\nComplete with needs_changes, smoke, compliance, or needs_user_action. Provide workspace_path plus audit_report when continuing, or blocker_reason when needs_user_action.\n\nFor any needs_user_action transition, provide blocker_reason with the exact next user or external action needed.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/<feature> workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "audit_report",
-          "description": "Path to the audit report after fixes or concise fix summary."
+          "description": "Path or summary of the current audit/review report."
         }
       ]
     },
@@ -572,17 +608,18 @@
       "id": "edge-b3b67a5a-5f24-40b7-a0a7-e4906914211c",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
       "transition_group_id": "group-03c0801f-bfda-47bf-9c33-34e5b8f0969b",
-      "key": "fix_blocked",
-      "target_node_id": "node-6f47e8ba-91b3-410e-9712-33a8460d051c",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "fix_needs_user_action",
+      "target_node_id": "node-9062f417-dae0-4134-8ce6-941b08acd8c9",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Short human-readable blocker explanation. Use the same language as the task/user request when practical; include the missing access/input/check and next action needed."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -590,22 +627,22 @@
       "id": "edge-1d8ca363-814f-49fc-8b0e-bd28b78f65de",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
       "transition_group_id": "group-657b1d9e-7326-4595-824d-cc958572d539",
-      "key": "smoke_done",
+      "key": "smoke_compliance",
       "target_node_id": "node-e6237246-e06b-4dbd-8ef5-82cc5e4d37f9",
       "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Run mandatory Puber Compliance Review before cleanup.\n\nRead .kent/commands/compliance-review.md, .kent/project-contract.md, and AGENTS.md first. Reviewed scope: completed feature implementation in workspace {{.Params.workspace_path}} after audit/smoke context {{.Params.audit_report}}. Review only compliance with task requirements, plan/design/specs, AGENTS.md, and workflow contract. Do not edit files.\n\nComplete with done and provide compliance_report when no compliance violations are found. Complete with needs_changes and provide workspace_path plus compliance_report when fixes are required. Complete with blocked and provide blocker_reason if required sources are missing or contradictory.",
+      "prompt_template": "Run mandatory Puber Compliance Review before cleanup.\n\nRead .kent/commands/compliance-review.md, .kent/project-contract.md, and AGENTS.md first. Reviewed scope: completed feature implementation in workspace {{.Params.workspace_path}} after audit/smoke context {{.Params.audit_report}}. Review only compliance with task requirements, plan/design/specs, AGENTS.md, and workflow contract. Do not edit files.\n\nComplete with ship_pr and provide compliance_report when no compliance violations are found. Complete with needs_changes and provide workspace_path plus compliance_report when fixes are required. Complete with needs_user_action and provide blocker_reason if required sources are missing or contradictory.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/<feature> workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "audit_report",
-          "description": "Path to the audit report for the feature workspace."
+          "description": "Path or summary of the current audit/review report."
         }
       ]
     },
@@ -615,24 +652,24 @@
       "transition_group_id": "group-08a76455-9bc0-4108-9b65-3d1db914688c",
       "key": "smoke_fix",
       "target_node_id": "node-9062f417-dae0-4134-8ce6-941b08acd8c9",
-      "requires_approval": true,
+      "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Fix approved issues found during Puber smoke testing.\n\nRead .kent/project-contract.md first. Use workspace {{.Params.workspace_path}}, audit report {{.Params.audit_report}}, and smoke report {{.Params.smoke_report}}. Keep fixes narrow, verify locally, update the audit report, then complete with audit and provide workspace_path plus audit_report. Complete with blocked and blocker_reason if blocked.",
+      "prompt_template": "Fix issues found during Puber smoke testing.\n\nRead .kent/project-contract.md first. Use workspace {{.Params.workspace_path}}, audit report {{.Params.audit_report}}, and smoke report {{.Params.smoke_report}}. Keep fixes narrow, verify locally, update the audit report, then complete with audit and provide workspace_path plus audit_report. Complete with needs_user_action and blocker_reason if needs_user_action.\n\nFor any needs_user_action transition, provide blocker_reason with the exact next user or external action needed.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/<feature> workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "audit_report",
-          "description": "Path to the audit report for the feature workspace."
+          "description": "Path or summary of the current audit/review report."
         },
         {
           "key": "smoke_report",
-          "description": "Smoke test issue report with artifacts or concise summary."
+          "description": "Device smoke report or artifact path."
         }
       ]
     },
@@ -640,17 +677,18 @@
       "id": "edge-5e989163-28ae-4c04-96e7-b46a73d16747",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
       "transition_group_id": "group-1ff098ab-f943-49a7-818b-f956b0b13be9",
-      "key": "smoke_blocked",
-      "target_node_id": "node-6f47e8ba-91b3-410e-9712-33a8460d051c",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "smoke_needs_user_action",
+      "target_node_id": "node-3f862fff-37e7-47e3-810c-46efe5cdafce",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Short human-readable blocker explanation. Use the same language as the task/user request when practical; include the missing access/input/check and next action needed."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -676,18 +714,18 @@
       "id": "edge-27b66fee-df8b-46a0-bdb5-56558a6cbda8",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
       "transition_group_id": "group-9dda5506-b406-4c3a-be0a-244ab3a8a2d2",
-      "key": "compliance_done",
+      "key": "compliance_ship_pr",
       "target_node_id": "node-c09db099-fbc4-474b-be0f-2e04447e7bd4",
       "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Create or update the Puber pull request for this completed task.\n\nRead .kent/project-contract.md, .kent/commands/ship-pr.md, and AGENTS.md first. Compliance result: {{.Params.compliance_report}}.\n\nIf this task produced repository changes, commit only task-related files, push the current task branch to origin, and create or update a GitHub PR. Do not merge the PR. Do not push directly to master/main. If there are no repository changes and the task is report-only or smoke-only, complete with done and provide pr_report explaining why PR is not applicable.\n\nComplete with monitor_ci when a PR exists and provide pr_url, branch_name, and workspace_path. Complete with needs_changes when PR creation/update is blocked by recoverable repository, branch, or PR state such as merge conflicts, non-fast-forward push, branch needing rebase, or missing PR metadata that can be fixed in the task worktree; provide workspace_path and blocker_reason. Complete with done only for PR-not-applicable/no-diff cases and provide pr_report. Complete with blocked only when continuing would be unsafe without changing task scope, credentials, or project policy; provide blocker_reason.",
+      "prompt_template": "Create or update the Puber pull request for this completed task.\n\nRead .kent/project-contract.md, .kent/commands/ship-pr.md, and AGENTS.md first. Compliance result: {{.Params.compliance_report}}.\n\nIf this task produced repository changes, commit only task-related files, push the current task branch to origin, and create or update a GitHub PR. Do not merge the PR. Do not push directly to master/main. If there are no repository changes and the task is report-only or smoke-only, complete with no_pr and provide pr_report explaining why PR is not applicable.\n\nComplete with monitor_ci when a PR exists and provide pr_url, branch_name, and workspace_path. Complete with needs_changes when PR creation/update is needs_user_action by recoverable repository, branch, or PR state such as merge conflicts, non-fast-forward push, branch needing rebase, or missing PR metadata that can be fixed in the task worktree; provide workspace_path and blocker_reason. Complete with no_pr only for PR-not-applicable/no-diff cases and provide pr_report. Complete with needs_user_action only when continuing would be unsafe without changing task scope, credentials, or project policy; provide blocker_reason.",
       "parameters": [
         {
           "key": "compliance_report",
-          "description": "Compliance review report, including rule sources checked and any findings."
+          "description": "Compliance review report or summary."
         }
       ]
     },
@@ -697,20 +735,20 @@
       "transition_group_id": "group-e638780a-d2e5-4455-8612-273ccf8622c6",
       "key": "compliance_fix",
       "target_node_id": "node-9062f417-dae0-4134-8ce6-941b08acd8c9",
-      "requires_approval": true,
+      "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Fix Puber feature compliance violations only.\n\nRead .kent/project-contract.md and .kent/commands/compliance-review.md first. Apply only the minimum changes required by compliance findings in {{.Params.compliance_report}} for workspace {{.Params.workspace_path}}. Verify narrowly, then complete with audit and provide workspace_path plus audit_report. Complete with blocked and provide blocker_reason if unsafe or missing input.",
+      "prompt_template": "Fix Puber feature compliance violations only.\n\nRead .kent/project-contract.md and .kent/commands/compliance-review.md first. Apply only the minimum changes required by compliance findings in {{.Params.compliance_report}} for workspace {{.Params.workspace_path}}. Verify narrowly, then complete with audit and provide workspace_path plus audit_report. Complete with needs_user_action and provide blocker_reason if unsafe or missing input.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/<feature> workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "compliance_report",
-          "description": "Compliance review report, including rule sources checked and any findings."
+          "description": "Compliance review report or summary."
         }
       ]
     },
@@ -718,17 +756,18 @@
       "id": "edge-cc32f3da-137e-49a5-a0e3-f80ec2ba3f06",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
       "transition_group_id": "group-e1d15c14-1bb1-48e3-9150-be1779aaf4db",
-      "key": "compliance_blocked",
-      "target_node_id": "node-6f47e8ba-91b3-410e-9712-33a8460d051c",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "compliance_needs_user_action",
+      "target_node_id": "node-e6237246-e06b-4dbd-8ef5-82cc5e4d37f9",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why compliance review cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -743,19 +782,19 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Monitor Puber PR checks.\n\nRead .kent/project-contract.md and AGENTS.md first. Inspect PR {{.Params.pr_url}} on branch {{.Params.branch_name}}. Use GitHub CLI when available. Do not merge the PR. Do not push new commits from this node.\n\nComplete with done if CI/checks pass, are absent, or are intentionally skipped with a clear reason; provide ci_report and pr_url. Complete with needs_changes if CI failed due to task changes and provide workspace_path plus ci_report. Complete with retry_later when checks cannot be inspected because GitHub/CI is still starting, rate-limited, temporarily unavailable, or an expected run has not appeared yet; provide pr_url, branch_name, workspace_path, and ci_report. Complete with blocked only if checks cannot be inspected and retrying would be unsafe or misleading; provide blocker_reason.",
+      "prompt_template": "Monitor Puber PR checks.\n\nRead .kent/project-contract.md and AGENTS.md first. Inspect PR {{.Params.pr_url}} on branch {{.Params.branch_name}}. Use GitHub CLI when available. Do not merge the PR. Do not push new commits from this node.\n\nComplete with waiting_pr if CI/checks pass, are absent, or are intentionally skipped with a clear reason; provide ci_report and pr_url. Complete with needs_changes if CI failed due to task changes and provide workspace_path plus ci_report. Complete with needs_user_action for temporary external waits; provide blocker_reason. Complete with needs_user_action only if checks cannot be inspected and retrying would be unsafe or misleading; provide blocker_reason.",
       "parameters": [
         {
           "key": "pr_url",
-          "description": "URL of the pull request."
+          "description": "URL of the created, updated, or monitored pull request."
         },
         {
           "key": "branch_name",
-          "description": "Name of the pushed task branch."
+          "description": "Name of the task or release branch associated with the pull request."
         },
         {
           "key": "workspace_path",
-          "description": "Path to the worktree or checkout used for PR creation."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         }
       ]
     },
@@ -774,7 +813,7 @@
       "parameters": [
         {
           "key": "pr_report",
-          "description": "Why no pull request was created or updated."
+          "description": "PR creation, review, conflict, or post-CI regression report."
         }
       ]
     },
@@ -782,17 +821,18 @@
       "id": "edge-879f62dd-da00-458f-9e94-ca68ee855e8f",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
       "transition_group_id": "group-7e0a7c4a-d0f6-4810-8c5c-d31d10f55b72",
-      "key": "pr_blocked",
-      "target_node_id": "node-6f47e8ba-91b3-410e-9712-33a8460d051c",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "ship_pr_needs_user_action",
+      "target_node_id": "node-c09db099-fbc4-474b-be0f-2e04447e7bd4",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why PR creation/update cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -800,22 +840,30 @@
       "id": "edge-f47451d6-4188-42db-b359-f754e62dbd53",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
       "transition_group_id": "group-4e98fceb-2f43-4b59-94f9-f36e2458b7f0",
-      "key": "ci_done",
-      "target_node_id": "node-2b50a102-85d1-4fcb-813f-2d8f21f3ca86",
+      "key": "ci_waiting_pr",
+      "target_node_id": "node-18c10adf-87fd-410d-a3d7-7b5184e213d0",
       "requires_approval": false,
       "context_mode": "new_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Run conservative Puber task cleanup after PR/CI.\n\nRead .kent/project-contract.md first, then use .kent/commands/cleanup-task.md. PR: {{.Params.pr_url}}. CI report: {{.Params.ci_report}}. Do not delete any worktree containing unpushed or uncommitted user changes. Complete with done and provide cleanup_report.",
+      "prompt_template": "Hold this Puber task until its pull request is actually merged.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, PR {{.Params.pr_url}}, branch {{.Params.branch_name}}, workspace {{.Params.workspace_path}}, and CI report {{.Params.ci_report}}.\n\nUse `gh pr view --json state,mergedAt,mergeCommit,headRefName,baseRefName,url` when available. Do not merge the PR. Do not push commits from this node. Do not clean up while the PR is still open.\n\nComplete with pr_merged only when GitHub reports state=MERGED; provide pr_url, branch_name, and merge_report. Complete with needs_changes when PR review comments, merge conflicts, or post-CI regressions can be fixed within the task scope; provide workspace_path and pr_report. Complete with needs_user_action when the PR is still open, waiting for human review/approval/merge, or needs_user_action by an external process; add a task comment with the current PR status and exact human action, then provide pr_url, branch_name, workspace_path, and waiting_reason. Complete with close_without_merge only if the latest user comment explicitly says to close/cancel/skip this PR; provide pr_url, branch_name, and cleanup_reason.",
       "parameters": [
+        {
+          "key": "pr_url",
+          "description": "URL of the created, updated, or monitored pull request."
+        },
+        {
+          "key": "branch_name",
+          "description": "Name of the task or release branch associated with the pull request."
+        },
+        {
+          "key": "workspace_path",
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
+        },
         {
           "key": "ci_report",
           "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
-        },
-        {
-          "key": "pr_url",
-          "description": "URL of the created or updated pull request."
         }
       ]
     },
@@ -825,16 +873,16 @@
       "transition_group_id": "group-1b46370e-d35a-4808-afa5-e96bb3fc1418",
       "key": "ci_fix",
       "target_node_id": "node-9062f417-dae0-4134-8ce6-941b08acd8c9",
-      "requires_approval": true,
+      "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Fix Puber feature CI failures only.\n\nRead .kent/project-contract.md first. Apply only the minimum changes required by CI report {{.Params.ci_report}} in workspace {{.Params.workspace_path}}. Verify narrowly, then complete with audit and provide workspace_path plus audit_report. Complete with blocked and provide blocker_reason if unsafe or missing input.",
+      "prompt_template": "Fix Puber feature CI failures only.\n\nRead .kent/project-contract.md first. Apply only the minimum changes required by CI report {{.Params.ci_report}} in workspace {{.Params.workspace_path}}. Verify narrowly, then complete with audit and provide workspace_path plus audit_report. Complete with needs_user_action and provide blocker_reason if unsafe or missing input.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/<feature> workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "ci_report",
@@ -846,17 +894,18 @@
       "id": "edge-d5ec5a8e-71b4-49da-8485-f26a26554f3c",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
       "transition_group_id": "group-13db20db-4732-4367-8faa-1aa8c1c394bc",
-      "key": "ci_blocked",
-      "target_node_id": "node-6f47e8ba-91b3-410e-9712-33a8460d051c",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "ci_monitor_needs_user_action",
+      "target_node_id": "node-e83dfbfe-4816-4a05-933a-703b38648ef8",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why CI monitoring cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -871,73 +920,141 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Fix recoverable Puber PR creation/update issues only.\n\nRead .kent/project-contract.md, .kent/commands/ship-pr.md, and AGENTS.md first. Previous PR blocker: {{.Params.blocker_reason}}. Work in {{.Params.workspace_path}}. Apply only the minimum changes needed to make the task branch/PR shippable, such as rebasing, resolving merge conflicts, fixing branch metadata, or repairing the PR-ready commit set. Do not expand product scope. Verify narrowly, then continue through the workflow's normal review/compliance path. Complete with blocked only if the recovery is unsafe or requires user credentials/policy changes.",
+      "prompt_template": "Fix recoverable Puber PR creation/update issues only.\n\nRead .kent/project-contract.md, .kent/commands/ship-pr.md, and AGENTS.md first. Previous PR blocker: {{.Params.blocker_reason}}. Work in {{.Params.workspace_path}}. Apply only the minimum changes needed to make the task branch/PR shippable, such as rebasing, resolving merge conflicts, fixing branch metadata, or repairing the PR-ready commit set. Do not expand product scope. Verify narrowly, then continue through the workflow's normal review/compliance path. Complete with needs_user_action only if the recovery is unsafe or requires user credentials/policy changes.\n\nFor any needs_user_action transition, provide blocker_reason with the exact next user or external action needed.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the worktree or checkout used for PR creation."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "blocker_reason",
-          "description": "Why PR creation/update cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
     {
-      "id": "edge-8c123a54-1084-4840-9bed-b33875a8c593",
+      "id": "edge-fb67e9ba-0627-4c54-a321-6f79a3556c31",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
-      "transition_group_id": "group-2289b446-bf32-4815-87e2-e561447f772d",
-      "key": "ci_retry",
-      "target_node_id": "node-e83dfbfe-4816-4a05-933a-703b38648ef8",
-      "requires_approval": true,
-      "context_mode": "compact_and_continue_session",
+      "transition_group_id": "group-97a95f65-c303-45b0-a5d0-7d8634b7ba5d",
+      "key": "cleanup_after_merge",
+      "target_node_id": "node-2b50a102-85d1-4fcb-813f-2d8f21f3ca86",
+      "requires_approval": false,
+      "context_mode": "new_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Retry Puber PR check monitoring after an approved temporary CI/GitHub wait.\n\nRead .kent/project-contract.md and AGENTS.md first. Previous CI status: {{.Params.ci_report}}. Inspect PR {{.Params.pr_url}} on branch {{.Params.branch_name}} again. Do not merge the PR. Do not push new commits from this node.\n\nComplete with done if CI/checks pass, are absent, or are intentionally skipped with a clear reason; provide ci_report and pr_url. Complete with needs_changes if CI failed due to task changes and provide workspace_path plus ci_report. Complete with retry_later if CI/GitHub is still temporarily unavailable and provide pr_url, branch_name, workspace_path, and ci_report. Complete with blocked only if retrying is no longer useful or safe; provide blocker_reason.",
+      "prompt_template": "Run conservative Puber task cleanup after the pull request was confirmed merged.\n\nRead AGENTS.md, .kent/project-contract.md, .kent/commands/cleanup-task.md, PR {{.Params.pr_url}}, branch {{.Params.branch_name}}, and merge report {{.Params.merge_report}}. Verify the PR is merged with GitHub state, not only git ancestry, because squash merges are allowed. Do not delete any worktree containing unpushed commits, uncommitted user changes, or unclear ownership. Complete with done and provide cleanup_report.",
       "parameters": [
         {
           "key": "pr_url",
-          "description": "URL of the created or updated pull request."
+          "description": "URL of the created, updated, or monitored pull request."
         },
         {
           "key": "branch_name",
-          "description": "Name of the pushed task branch."
+          "description": "Name of the task or release branch associated with the pull request."
         },
         {
-          "key": "workspace_path",
-          "description": "Path to the explicit .todo/<feature> workspace."
-        },
-        {
-          "key": "ci_report",
-          "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+          "key": "merge_report",
+          "description": "GitHub PR state, mergedAt, mergeCommit, and cleanup or release notes."
         }
       ]
     },
     {
-      "id": "edge-c1c066fd-7607-4896-a4cf-50ee1135e488",
+      "id": "edge-3a7a9d71-ac1e-41e1-bcdd-a180864af363",
       "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
-      "transition_group_id": "group-fa1d36b6-c72c-4828-8116-333044f4c7c8",
-      "key": "smoke_retry",
-      "target_node_id": "node-3f862fff-37e7-47e3-810c-46efe5cdafce",
+      "transition_group_id": "group-1005c60e-681a-456f-8530-8b94ded4ebda",
+      "key": "pr_feedback",
+      "target_node_id": "node-9062f417-dae0-4134-8ce6-941b08acd8c9",
+      "requires_approval": false,
+      "context_mode": "compact_and_continue_session",
+      "context_source": {
+        "kind": "immediate_source"
+      },
+      "prompt_template": "Fix Puber PR feedback only.\n\nRead AGENTS.md, .kent/project-contract.md, latest task comments, workspace {{.Params.workspace_path}}, and PR feedback report {{.Params.pr_report}}. Apply only task-scoped changes needed for PR review comments, merge conflicts, or post-CI regressions. Do not force-push unless the latest user comment explicitly permits force-push for this exact PR/branch. Verify narrowly, then return through the workflow's normal review/verify/compliance path with an updated report. If user input is required, complete with needs_user_action and provide blocker_reason.",
+      "parameters": [
+        {
+          "key": "workspace_path",
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
+        },
+        {
+          "key": "pr_report",
+          "description": "PR creation, review, conflict, or post-CI regression report."
+        }
+      ]
+    },
+    {
+      "id": "edge-d3e9355d-027f-46cf-920f-813bc9ae5f57",
+      "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
+      "transition_group_id": "group-a90ef3e6-c834-44eb-a12a-685cfe40959e",
+      "key": "waiting_pr_needs_user_action",
+      "target_node_id": "node-18c10adf-87fd-410d-a3d7-7b5184e213d0",
       "requires_approval": true,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Retry the focused Puber device smoke test after an approved temporary blocker wait.\n\nRead .kent/project-contract.md and .kent/commands/smoke-test.md first. Previous blocker: {{.Params.blocker_reason}}. Use workspace {{.Params.workspace_path}} and audit report {{.Params.audit_report}}. Follow the same emulator locking, physical-device prohibition, fresh devDebug build/install, and adb -s rules as the original smoke node.\n\nComplete with done if smoke passes. Complete with needs_changes if smoke finds implementation issues and provide workspace_path, audit_report, and smoke_report. Complete with retry_later if device/MCP/build/resource locking access is still temporarily unavailable and provide workspace_path, audit_report, and blocker_reason. Complete with blocked only for unrecoverable smoke blockers; provide blocker_reason.",
+      "prompt_template": "Re-check the Puber pull request after the user resolved the external wait or approved another check.\n\nRead AGENTS.md, .kent/project-contract.md, latest task comments, PR {{.Params.pr_url}}, branch {{.Params.branch_name}}, workspace {{.Params.workspace_path}}, and previous waiting reason {{.Params.waiting_reason}}. Do not merge, push, or clean up unless the PR is confirmed merged.\n\nComplete with pr_merged only when GitHub reports state=MERGED. Complete with needs_changes for task-scoped PR review/conflict/regression fixes. Complete with needs_user_action again if the PR is still waiting externally. Complete with close_without_merge only on explicit latest user instruction.",
       "parameters": [
         {
+          "key": "pr_url",
+          "description": "URL of the created, updated, or monitored pull request."
+        },
+        {
+          "key": "branch_name",
+          "description": "Name of the task or release branch associated with the pull request."
+        },
+        {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/<feature> workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
-          "key": "audit_report",
-          "description": "Path to the audit report for the feature workspace."
+          "key": "waiting_reason",
+          "description": "Why the PR cannot advance yet and the exact user or external action needed."
+        }
+      ]
+    },
+    {
+      "id": "edge-430596f4-9040-4a3d-848c-304bc7c05197",
+      "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
+      "transition_group_id": "group-7da26b5a-3af4-4e2a-a7e5-c796474d66a1",
+      "key": "cancel_cleanup",
+      "target_node_id": "node-2b50a102-85d1-4fcb-813f-2d8f21f3ca86",
+      "requires_approval": true,
+      "context_mode": "new_session",
+      "context_source": {
+        "kind": "immediate_source"
+      },
+      "prompt_template": "Run conservative Puber task cleanup after the user explicitly closed/canceled the PR without merge.\n\nRead AGENTS.md, .kent/project-contract.md, .kent/commands/cleanup-task.md, PR {{.Params.pr_url}}, branch {{.Params.branch_name}}, and cleanup reason {{.Params.cleanup_reason}}. Do not delete any worktree containing unpushed commits, uncommitted user changes, or unclear ownership. Complete with done and provide cleanup_report.",
+      "parameters": [
+        {
+          "key": "pr_url",
+          "description": "URL of the created, updated, or monitored pull request."
         },
         {
-          "key": "blocker_reason",
-          "description": "Short human-readable blocker explanation. Use the same language as the task/user request when practical; include the missing access/input/check and next action needed."
+          "key": "branch_name",
+          "description": "Name of the task or release branch associated with the pull request."
+        },
+        {
+          "key": "cleanup_reason",
+          "description": "Explicit user instruction or reason for cleanup without merge."
+        }
+      ]
+    },
+    {
+      "id": "edge-7e76a35d-18f5-46d3-9fdf-e022a4e4be39",
+      "workflow_id": "workflow-fff53dd7-12b2-4506-af57-6493008f6ff9",
+      "transition_group_id": "group-8acf1f57-bf78-4b5d-9f91-4af25470abd1",
+      "key": "plan_wont_do",
+      "target_node_id": "node-6f47e8ba-91b3-410e-9712-33a8460d051c",
+      "requires_approval": true,
+      "context_mode": "new_session",
+      "context_source": {
+        "kind": "immediate_source"
+      },
+      "parameters": [
+        {
+          "key": "closure_reason",
+          "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
         }
       ]
     }
@@ -952,15 +1069,19 @@
         "possible_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace created by planning."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "plan_path",
-            "description": "Path to the generated plan.md inside the feature workspace."
+            "description": "Path to the plan.md used by this workflow transition."
           },
           {
             "name": "blocker_reason",
-            "description": "Short human-readable blocker explanation. Use the same language as the task/user request when practical; include the missing access/input/check and next action needed."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          },
+          {
+            "name": "closure_reason",
+            "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
           }
         ]
       },
@@ -969,11 +1090,11 @@
         "possible_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "plan_path",
-            "description": "Path to plan.md inside the feature workspace."
+            "description": "Path to the plan.md used by this workflow transition."
           },
           {
             "name": "verification_report",
@@ -981,7 +1102,7 @@
           },
           {
             "name": "blocker_reason",
-            "description": "Short human-readable blocker explanation. Use the same language as the task/user request when practical; include the missing access/input/check and next action needed."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -990,15 +1111,15 @@
         "possible_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "audit_report",
-            "description": "Path to the audit report for the feature workspace."
+            "description": "Path or summary of the current audit/review report."
           },
           {
             "name": "blocker_reason",
-            "description": "Short human-readable blocker explanation. Use the same language as the task/user request when practical; include the missing access/input/check and next action needed."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1007,15 +1128,15 @@
         "possible_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "audit_report",
-            "description": "Path to the audit report after fixes or concise fix summary."
+            "description": "Path or summary of the current audit/review report."
           },
           {
             "name": "blocker_reason",
-            "description": "Short human-readable blocker explanation. Use the same language as the task/user request when practical; include the missing access/input/check and next action needed."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1024,19 +1145,19 @@
         "possible_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "audit_report",
-            "description": "Path to the audit report for the feature workspace."
+            "description": "Path or summary of the current audit/review report."
           },
           {
             "name": "smoke_report",
-            "description": "Smoke test issue report with artifacts or concise summary."
+            "description": "Device smoke report or artifact path."
           },
           {
             "name": "blocker_reason",
-            "description": "Short human-readable blocker explanation. Use the same language as the task/user request when practical; include the missing access/input/check and next action needed."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1057,15 +1178,15 @@
         "possible_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1074,23 +1195,23 @@
         "possible_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "pr_report",
-            "description": "Why no pull request was created or updated."
+            "description": "PR creation, review, conflict, or post-CI regression report."
           },
           {
             "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1098,24 +1219,57 @@
         "node_id": "node-e83dfbfe-4816-4a05-933a-703b38648ef8",
         "possible_provision_fields": [
           {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
             "name": "ci_report",
             "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
           },
           {
-            "name": "pr_url",
-            "description": "URL of the created or updated pull request."
-          },
-          {
-            "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
-          },
-          {
             "name": "blocker_reason",
-            "description": "Why CI monitoring cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          }
+        ]
+      },
+      {
+        "node_id": "node-18c10adf-87fd-410d-a3d7-7b5184e213d0",
+        "possible_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "merge_report",
+            "description": "GitHub PR state, mergedAt, mergeCommit, and cleanup or release notes."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "pr_report",
+            "description": "PR creation, review, conflict, or post-CI regression report."
+          },
+          {
+            "name": "waiting_reason",
+            "description": "Why the PR cannot advance yet and the exact user or external action needed."
+          },
+          {
+            "name": "cleanup_reason",
+            "description": "Explicit user instruction or reason for cleanup without merge."
           }
         ]
       },
@@ -1132,11 +1286,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace created by planning."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "plan_path",
-            "description": "Path to the generated plan.md inside the feature workspace."
+            "description": "Path to the plan.md used by this workflow transition."
           }
         ]
       },
@@ -1145,7 +1299,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Short human-readable blocker explanation. Use the same language as the task/user request when practical; include the missing access/input/check and next action needed."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1154,11 +1308,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "plan_path",
-            "description": "Path to plan.md inside the feature workspace."
+            "description": "Path to the plan.md used by this workflow transition."
           }
         ]
       },
@@ -1167,11 +1321,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "plan_path",
-            "description": "Path to plan.md inside the feature workspace."
+            "description": "Path to the plan.md used by this workflow transition."
           },
           {
             "name": "verification_report",
@@ -1184,7 +1338,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Short human-readable blocker explanation. Use the same language as the task/user request when practical; include the missing access/input/check and next action needed."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1193,11 +1347,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "audit_report",
-            "description": "Path to the audit report for the feature workspace."
+            "description": "Path or summary of the current audit/review report."
           }
         ]
       },
@@ -1206,11 +1360,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "audit_report",
-            "description": "Path to the audit report for the feature workspace."
+            "description": "Path or summary of the current audit/review report."
           }
         ]
       },
@@ -1219,11 +1373,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "audit_report",
-            "description": "Path to the audit report for the feature workspace."
+            "description": "Path or summary of the current audit/review report."
           }
         ]
       },
@@ -1232,7 +1386,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Short human-readable blocker explanation. Use the same language as the task/user request when practical; include the missing access/input/check and next action needed."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1241,11 +1395,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "audit_report",
-            "description": "Path to the audit report after fixes or concise fix summary."
+            "description": "Path or summary of the current audit/review report."
           }
         ]
       },
@@ -1254,7 +1408,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Short human-readable blocker explanation. Use the same language as the task/user request when practical; include the missing access/input/check and next action needed."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1263,11 +1417,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "audit_report",
-            "description": "Path to the audit report for the feature workspace."
+            "description": "Path or summary of the current audit/review report."
           }
         ]
       },
@@ -1276,15 +1430,15 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "audit_report",
-            "description": "Path to the audit report for the feature workspace."
+            "description": "Path or summary of the current audit/review report."
           },
           {
             "name": "smoke_report",
-            "description": "Smoke test issue report with artifacts or concise summary."
+            "description": "Device smoke report or artifact path."
           }
         ]
       },
@@ -1293,7 +1447,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Short human-readable blocker explanation. Use the same language as the task/user request when practical; include the missing access/input/check and next action needed."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1311,7 +1465,7 @@
         "required_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -1320,11 +1474,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -1333,7 +1487,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1342,15 +1496,15 @@
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           }
         ]
       },
@@ -1359,7 +1513,7 @@
         "required_provision_fields": [
           {
             "name": "pr_report",
-            "description": "Why no pull request was created or updated."
+            "description": "PR creation, review, conflict, or post-CI regression report."
           }
         ]
       },
@@ -1368,7 +1522,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1376,12 +1530,20 @@
         "transition_group_id": "group-4e98fceb-2f43-4b59-94f9-f36e2458b7f0",
         "required_provision_fields": [
           {
-            "name": "ci_report",
-            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
-            "name": "pr_url",
-            "description": "URL of the created or updated pull request."
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "ci_report",
+            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
           }
         ]
       },
@@ -1390,7 +1552,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "ci_report",
@@ -1403,7 +1565,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why CI monitoring cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1412,49 +1574,88 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
       {
-        "transition_group_id": "group-2289b446-bf32-4815-87e2-e561447f772d",
+        "transition_group_id": "group-97a95f65-c303-45b0-a5d0-7d8634b7ba5d",
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the created or updated pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
-            "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
-          },
-          {
-            "name": "ci_report",
-            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+            "name": "merge_report",
+            "description": "GitHub PR state, mergedAt, mergeCommit, and cleanup or release notes."
           }
         ]
       },
       {
-        "transition_group_id": "group-fa1d36b6-c72c-4828-8116-333044f4c7c8",
+        "transition_group_id": "group-1005c60e-681a-456f-8530-8b94ded4ebda",
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
-            "name": "audit_report",
-            "description": "Path to the audit report for the feature workspace."
+            "name": "pr_report",
+            "description": "PR creation, review, conflict, or post-CI regression report."
+          }
+        ]
+      },
+      {
+        "transition_group_id": "group-a90ef3e6-c834-44eb-a12a-685cfe40959e",
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
-            "name": "blocker_reason",
-            "description": "Short human-readable blocker explanation. Use the same language as the task/user request when practical; include the missing access/input/check and next action needed."
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "waiting_reason",
+            "description": "Why the PR cannot advance yet and the exact user or external action needed."
+          }
+        ]
+      },
+      {
+        "transition_group_id": "group-7da26b5a-3af4-4e2a-a7e5-c796474d66a1",
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "cleanup_reason",
+            "description": "Explicit user instruction or reason for cleanup without merge."
+          }
+        ]
+      },
+      {
+        "transition_group_id": "group-8acf1f57-bf78-4b5d-9f91-4af25470abd1",
+        "required_provision_fields": [
+          {
+            "name": "closure_reason",
+            "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
           }
         ]
       }
@@ -1480,11 +1681,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace created by planning."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "plan_path",
-            "description": "Path to the generated plan.md inside the feature workspace."
+            "description": "Path to the plan.md used by this workflow transition."
           }
         ]
       },
@@ -1500,7 +1701,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Short human-readable blocker explanation. Use the same language as the task/user request when practical; include the missing access/input/check and next action needed."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1521,11 +1722,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "plan_path",
-            "description": "Path to plan.md inside the feature workspace."
+            "description": "Path to the plan.md used by this workflow transition."
           }
         ]
       },
@@ -1551,11 +1752,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "plan_path",
-            "description": "Path to plan.md inside the feature workspace."
+            "description": "Path to the plan.md used by this workflow transition."
           },
           {
             "name": "verification_report",
@@ -1575,7 +1776,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Short human-readable blocker explanation. Use the same language as the task/user request when practical; include the missing access/input/check and next action needed."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1596,11 +1797,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "audit_report",
-            "description": "Path to the audit report for the feature workspace."
+            "description": "Path or summary of the current audit/review report."
           }
         ]
       },
@@ -1621,11 +1822,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "audit_report",
-            "description": "Path to the audit report for the feature workspace."
+            "description": "Path or summary of the current audit/review report."
           }
         ]
       },
@@ -1646,11 +1847,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "audit_report",
-            "description": "Path to the audit report for the feature workspace."
+            "description": "Path or summary of the current audit/review report."
           }
         ]
       },
@@ -1666,7 +1867,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Short human-readable blocker explanation. Use the same language as the task/user request when practical; include the missing access/input/check and next action needed."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1687,11 +1888,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "audit_report",
-            "description": "Path to the audit report after fixes or concise fix summary."
+            "description": "Path or summary of the current audit/review report."
           }
         ]
       },
@@ -1707,7 +1908,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Short human-readable blocker explanation. Use the same language as the task/user request when practical; include the missing access/input/check and next action needed."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1728,11 +1929,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "audit_report",
-            "description": "Path to the audit report for the feature workspace."
+            "description": "Path or summary of the current audit/review report."
           }
         ]
       },
@@ -1758,15 +1959,15 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "audit_report",
-            "description": "Path to the audit report for the feature workspace."
+            "description": "Path or summary of the current audit/review report."
           },
           {
             "name": "smoke_report",
-            "description": "Smoke test issue report with artifacts or concise summary."
+            "description": "Device smoke report or artifact path."
           }
         ]
       },
@@ -1782,7 +1983,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Short human-readable blocker explanation. Use the same language as the task/user request when practical; include the missing access/input/check and next action needed."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1814,7 +2015,7 @@
         "required_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -1835,11 +2036,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -1855,7 +2056,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1881,15 +2082,15 @@
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           }
         ]
       },
@@ -1905,7 +2106,7 @@
         "required_provision_fields": [
           {
             "name": "pr_report",
-            "description": "Why no pull request was created or updated."
+            "description": "PR creation, review, conflict, or post-CI regression report."
           }
         ]
       },
@@ -1921,103 +2122,12 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
       {
         "edge_id": "edge-f47451d6-4188-42db-b359-f754e62dbd53",
-        "input_bindings": [
-          {
-            "name": "ci_report",
-            "source": "transition_output",
-            "field": "ci_report"
-          },
-          {
-            "name": "pr_url",
-            "source": "transition_output",
-            "field": "pr_url"
-          }
-        ],
-        "required_provision_fields": [
-          {
-            "name": "ci_report",
-            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
-          },
-          {
-            "name": "pr_url",
-            "description": "URL of the created or updated pull request."
-          }
-        ]
-      },
-      {
-        "edge_id": "edge-7ef6f721-963c-4e45-a52d-a0196bc375e1",
-        "input_bindings": [
-          {
-            "name": "workspace_path",
-            "source": "transition_output",
-            "field": "workspace_path"
-          },
-          {
-            "name": "ci_report",
-            "source": "transition_output",
-            "field": "ci_report"
-          }
-        ],
-        "required_provision_fields": [
-          {
-            "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
-          },
-          {
-            "name": "ci_report",
-            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
-          }
-        ]
-      },
-      {
-        "edge_id": "edge-d5ec5a8e-71b4-49da-8485-f26a26554f3c",
-        "input_bindings": [
-          {
-            "name": "blocker_reason",
-            "source": "transition_output",
-            "field": "blocker_reason"
-          }
-        ],
-        "required_provision_fields": [
-          {
-            "name": "blocker_reason",
-            "description": "Why CI monitoring cannot complete, in the task language when practical."
-          }
-        ]
-      },
-      {
-        "edge_id": "edge-0cadaa9a-929c-4be1-8a1a-0a5ac37e35f9",
-        "input_bindings": [
-          {
-            "name": "workspace_path",
-            "source": "transition_output",
-            "field": "workspace_path"
-          },
-          {
-            "name": "blocker_reason",
-            "source": "transition_output",
-            "field": "blocker_reason"
-          }
-        ],
-        "required_provision_fields": [
-          {
-            "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
-          },
-          {
-            "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
-          }
-        ]
-      },
-      {
-        "edge_id": "edge-8c123a54-1084-4840-9bed-b33875a8c593",
         "input_bindings": [
           {
             "name": "pr_url",
@@ -2043,15 +2153,15 @@
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the created or updated pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "ci_report",
@@ -2060,7 +2170,7 @@
         ]
       },
       {
-        "edge_id": "edge-c1c066fd-7607-4896-a4cf-50ee1135e488",
+        "edge_id": "edge-7ef6f721-963c-4e45-a52d-a0196bc375e1",
         "input_bindings": [
           {
             "name": "workspace_path",
@@ -2068,9 +2178,45 @@
             "field": "workspace_path"
           },
           {
-            "name": "audit_report",
+            "name": "ci_report",
             "source": "transition_output",
-            "field": "audit_report"
+            "field": "ci_report"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "ci_report",
+            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-d5ec5a8e-71b4-49da-8485-f26a26554f3c",
+        "input_bindings": [
+          {
+            "name": "blocker_reason",
+            "source": "transition_output",
+            "field": "blocker_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "blocker_reason",
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-0cadaa9a-929c-4be1-8a1a-0a5ac37e35f9",
+        "input_bindings": [
+          {
+            "name": "workspace_path",
+            "source": "transition_output",
+            "field": "workspace_path"
           },
           {
             "name": "blocker_reason",
@@ -2081,15 +2227,163 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/<feature> workspace."
-          },
-          {
-            "name": "audit_report",
-            "description": "Path to the audit report for the feature workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "blocker_reason",
-            "description": "Short human-readable blocker explanation. Use the same language as the task/user request when practical; include the missing access/input/check and next action needed."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-fb67e9ba-0627-4c54-a321-6f79a3556c31",
+        "input_bindings": [
+          {
+            "name": "pr_url",
+            "source": "transition_output",
+            "field": "pr_url"
+          },
+          {
+            "name": "branch_name",
+            "source": "transition_output",
+            "field": "branch_name"
+          },
+          {
+            "name": "merge_report",
+            "source": "transition_output",
+            "field": "merge_report"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "merge_report",
+            "description": "GitHub PR state, mergedAt, mergeCommit, and cleanup or release notes."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-3a7a9d71-ac1e-41e1-bcdd-a180864af363",
+        "input_bindings": [
+          {
+            "name": "workspace_path",
+            "source": "transition_output",
+            "field": "workspace_path"
+          },
+          {
+            "name": "pr_report",
+            "source": "transition_output",
+            "field": "pr_report"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "pr_report",
+            "description": "PR creation, review, conflict, or post-CI regression report."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-d3e9355d-027f-46cf-920f-813bc9ae5f57",
+        "input_bindings": [
+          {
+            "name": "pr_url",
+            "source": "transition_output",
+            "field": "pr_url"
+          },
+          {
+            "name": "branch_name",
+            "source": "transition_output",
+            "field": "branch_name"
+          },
+          {
+            "name": "workspace_path",
+            "source": "transition_output",
+            "field": "workspace_path"
+          },
+          {
+            "name": "waiting_reason",
+            "source": "transition_output",
+            "field": "waiting_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "waiting_reason",
+            "description": "Why the PR cannot advance yet and the exact user or external action needed."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-430596f4-9040-4a3d-848c-304bc7c05197",
+        "input_bindings": [
+          {
+            "name": "pr_url",
+            "source": "transition_output",
+            "field": "pr_url"
+          },
+          {
+            "name": "branch_name",
+            "source": "transition_output",
+            "field": "branch_name"
+          },
+          {
+            "name": "cleanup_reason",
+            "source": "transition_output",
+            "field": "cleanup_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "cleanup_reason",
+            "description": "Explicit user instruction or reason for cleanup without merge."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-7e76a35d-18f5-46d3-9fdf-e022a4e4be39",
+        "input_bindings": [
+          {
+            "name": "closure_reason",
+            "source": "transition_output",
+            "field": "closure_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "closure_reason",
+            "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
           }
         ]
       }

--- a/.kent/workflows/puber-refactor-with-audit.json
+++ b/.kent/workflows/puber-refactor-with-audit.json
@@ -3,7 +3,7 @@
     "id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
     "name": "Puber Refactor With Audit",
     "description": "Plan, audit, implement, review, fix, and conservatively clean up a Puber Android refactor or migration.",
-    "version": 68
+    "version": 152
   },
   "nodes": [
     {
@@ -61,9 +61,9 @@
     {
       "id": "node-57fd70be-e6ef-449e-bbc5-2e2316abf0f4",
       "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
-      "key": "blocked",
+      "key": "wont_do",
       "kind": "terminal",
-      "display_name": "Blocked"
+      "display_name": "Won't Do"
     },
     {
       "id": "node-eef2d0ef-ca80-49f5-a5b0-2cbb28e0d4b5",
@@ -89,6 +89,15 @@
       "key": "ci_monitor",
       "kind": "agent",
       "display_name": "Monitor CI",
+      "subagent_role": "default",
+      "completion_mode": "shell_command"
+    },
+    {
+      "id": "node-76de9680-9d35-4f30-926c-59cf91ce928c",
+      "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
+      "key": "waiting_pr",
+      "kind": "agent",
+      "display_name": "Waiting PR",
       "subagent_role": "default",
       "completion_mode": "shell_command"
     },
@@ -153,41 +162,41 @@
       "id": "group-dd24b644-7d09-4d95-b319-d7d8ab63c339",
       "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
       "source_node_id": "node-30f4fcb2-8a07-41bb-ab1f-7164872244e3",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Planning or audit is blocked by missing context, access, or user input."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "plan cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-ea1b058f-1636-40a3-9e3c-5099322948ec",
       "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
       "source_node_id": "node-993b1947-3f73-4109-bad1-c8d890df7a58",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Implementation is blocked by missing input, unsafe state, or verification failure."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "implement cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-9a4efa3a-d2ef-4474-acfa-a110be4e3d08",
       "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
       "source_node_id": "node-227ae295-a572-41a4-b257-67642857758d",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Review is blocked by missing context or verification."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "review cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-124b993a-2a32-4f65-9fec-f3ddab23803f",
       "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
       "source_node_id": "node-813ddb92-db58-4688-b8c7-77b8134f31be",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Fixing is blocked by missing input, unsafe state, or verification failure."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "fix cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-b25bf5b0-4ceb-40e6-bbac-e46b32220eb5",
       "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
       "source_node_id": "node-227ae295-a572-41a4-b257-67642857758d",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "Review passed; run mandatory compliance review before cleanup."
+      "transition_id": "compliance",
+      "display_name": "Compliance",
+      "description": "Work passed this stage; run mandatory compliance review before any PR/cleanup path."
     },
     {
       "id": "group-0efdf4fa-e622-492c-8109-368c4e5ebaee",
@@ -201,9 +210,9 @@
       "id": "group-0c6266bf-dd1f-4775-9899-d8f4ee1cdbe9",
       "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
       "source_node_id": "node-eef2d0ef-ca80-49f5-a5b0-2cbb28e0d4b5",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "Compliance review passed; create or update the task pull request before cleanup."
+      "transition_id": "ship_pr",
+      "display_name": "Ship PR",
+      "description": "Compliance passed; create or update the task PR before any terminal completion."
     },
     {
       "id": "group-f4cd0ac2-1c8f-48eb-9301-5799ed88a5a0",
@@ -217,9 +226,9 @@
       "id": "group-4b8d365e-1cb9-4bc1-a637-27887da99354",
       "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
       "source_node_id": "node-eef2d0ef-ca80-49f5-a5b0-2cbb28e0d4b5",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Compliance review is blocked by missing or contradictory required sources."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "compliance cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-bd26b6db-cab5-465f-9be0-59ca3f0f911e",
@@ -233,25 +242,25 @@
       "id": "group-8a94de24-3d25-40be-a6be-5b4ba59683ba",
       "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
       "source_node_id": "node-c3d52a51-d482-47ab-993a-45ad30ce22c9",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "PR is intentionally not applicable because there are no repository changes; run cleanup."
+      "transition_id": "no_pr",
+      "display_name": "No PR",
+      "description": "No PR is applicable because there are no repository changes or the task is explicitly report-only; cleanup can finish the task."
     },
     {
       "id": "group-d495dbc7-af89-4ec5-a99a-d9a91b031e19",
       "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
       "source_node_id": "node-c3d52a51-d482-47ab-993a-45ad30ce22c9",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "PR creation or update is blocked by git state, auth, remote, branch, or unsafe repository state."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "ship_pr cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-30b7d6db-f7c1-4027-b6be-6dc7a82938c8",
       "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
       "source_node_id": "node-92b2e510-465a-4f75-bb6d-4b2d0413d59c",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "PR checks passed or are intentionally skipped; run conservative cleanup."
+      "transition_id": "waiting_pr",
+      "display_name": "Waiting PR",
+      "description": "PR checks passed or were intentionally skipped; wait until the PR is merged before cleanup/done."
     },
     {
       "id": "group-8c707a90-8c60-4e14-8d14-bbaae7307236",
@@ -265,9 +274,9 @@
       "id": "group-f658f4d5-33a8-455a-bf4b-b3a6c67f2385",
       "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
       "source_node_id": "node-92b2e510-465a-4f75-bb6d-4b2d0413d59c",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "CI monitoring is blocked by GitHub access, missing check data, or unsafe repository state."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "ci_monitor cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-3f2ad7e9-f194-4210-aef9-41defb759b7d",
@@ -278,12 +287,44 @@
       "description": "PR creation/update hit a recoverable branch, rebase, conflict, or metadata issue; user approval required before recovery work."
     },
     {
-      "id": "group-86b8ea6e-fecf-4219-ad3f-578d91728364",
+      "id": "group-77c19afc-8de8-4599-9a8f-00c700f55429",
       "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
-      "source_node_id": "node-92b2e510-465a-4f75-bb6d-4b2d0413d59c",
-      "transition_id": "retry_later",
-      "display_name": "Retry Later",
-      "description": "CI or GitHub is temporarily unavailable, still starting, or missing an expected run; user approval required before retrying monitoring."
+      "source_node_id": "node-76de9680-9d35-4f30-926c-59cf91ce928c",
+      "transition_id": "pr_merged",
+      "display_name": "Pr Merged",
+      "description": "PR is confirmed merged; cleanup can finish the task."
+    },
+    {
+      "id": "group-b756fb18-8d6a-4a3b-b977-18128a269f1e",
+      "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
+      "source_node_id": "node-76de9680-9d35-4f30-926c-59cf91ce928c",
+      "transition_id": "needs_changes",
+      "display_name": "Needs Changes",
+      "description": "PR review, conflicts, or post-CI regressions need task-scoped fixes."
+    },
+    {
+      "id": "group-076d88e3-db5d-4f77-a94d-ced8fc18e1a9",
+      "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
+      "source_node_id": "node-76de9680-9d35-4f30-926c-59cf91ce928c",
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "PR is still waiting on a human or external process; remain in Waiting PR."
+    },
+    {
+      "id": "group-017cf0a8-5d35-4ed6-b7c3-cf5900852d4c",
+      "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
+      "source_node_id": "node-76de9680-9d35-4f30-926c-59cf91ce928c",
+      "transition_id": "close_without_merge",
+      "display_name": "Close Without Merge",
+      "description": "User explicitly closed/canceled the PR without merge; cleanup can finish."
+    },
+    {
+      "id": "group-6b6661bd-8914-471b-9c4e-3b0e294f5467",
+      "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
+      "source_node_id": "node-30f4fcb2-8a07-41bb-ab1f-7164872244e3",
+      "transition_id": "wont_do",
+      "display_name": "Wont Do",
+      "description": "Latest user comment explicitly cancels this task or declares it not planned; finish without treating it as a recoverable blocker."
     }
   ],
   "edges": [
@@ -298,7 +339,7 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Run the Puber refactor/migration planning flow for this Kent task.\n\nRead .kent/project-contract.md first. Use .kent/commands/refactor-start.md for refactors and .kent/commands/migration-start.md for migrations, based on the task body. Create an explicit .todo/refactor-<name> or .todo/migration-<name> workspace; do not infer or create .todo/.current.\n\nAnalyze scope with project-local agents only, produce plan.md, and do not implement production code yet. If the command text asks for user confirmation, satisfy this workflow by stopping at the implement transition with a clear plan summary.\n\nComplete with implement when an auditable plan is ready and provide workspace_path, plan_path, and audit_report. Complete with blocked if required context or product input is unavailable, and provide blocker_reason."
+      "prompt_template": "Run the Puber refactor/migration planning flow for this Kent task.\n\nRead .kent/project-contract.md first. Use .kent/commands/refactor-start.md for refactors and .kent/commands/migration-start.md for migrations, based on the task body. Create an explicit .todo/refactor-<name> or .todo/migration-<name> workspace; do not infer or create .todo/.current.\n\nAnalyze scope with project-local agents only, produce plan.md, and do not implement production code yet. If the command text asks for user confirmation, satisfy this workflow by stopping at the implement transition with a clear plan summary.\n\nComplete with implement when an auditable plan is ready and provide workspace_path, plan_path, and audit_report. Complete with needs_user_action if required context or product input is unavailable, and provide blocker_reason."
     },
     {
       "id": "edge-73734fd2-246f-46a6-ad43-c489d219194b",
@@ -306,24 +347,24 @@
       "transition_group_id": "group-55a6eba1-c9c0-499c-96b8-f0df139816b0",
       "key": "approve_implement",
       "target_node_id": "node-993b1947-3f73-4109-bad1-c8d890df7a58",
-      "requires_approval": true,
+      "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Implement the approved Puber refactor or migration plan.\n\nRead .kent/project-contract.md first. Use the explicit workspace {{.Params.workspace_path}} and plan {{.Params.plan_path}}; do not infer .todo/.current. Execute one next unchecked step at a time, preserving compilation after each step. Use ./tools/agentw in .kent/worktrees and ./gradlew in the main checkout.\n\nIf more unchecked steps remain, complete with continue_implementation and provide workspace_path plus plan_path again. If all implementation steps are complete, complete with review and provide workspace_path, plan_path, audit_report, changed_files, and verification_summary. Complete with blocked on unresolved blockers and provide blocker_reason.",
+      "prompt_template": "Implement the approved Puber refactor or migration plan.\n\nRead .kent/project-contract.md first. Use the explicit workspace {{.Params.workspace_path}} and plan {{.Params.plan_path}}; do not infer .todo/.current. Execute one next unchecked step at a time, preserving compilation after each step. Use ./tools/agentw in .kent/worktrees and ./gradlew in the main checkout.\n\nIf more unchecked steps remain, complete with continue_implementation and provide workspace_path plus plan_path again. If all implementation steps are complete, complete with review and provide workspace_path, plan_path, audit_report, changed_files, and verification_summary. Complete with needs_user_action on unresolved blockers and provide blocker_reason.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/refactor-* or .todo/migration-* workspace created by planning."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "plan_path",
-          "description": "Path to the generated plan.md inside the workspace."
+          "description": "Path to the plan.md used by this workflow transition."
         },
         {
           "key": "audit_report",
-          "description": "Planning audit summary, risk notes, and user-facing implementation constraints."
+          "description": "Path or summary of the current audit/review report."
         }
       ]
     },
@@ -338,15 +379,15 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Continue the approved Puber refactor or migration plan from {{.Params.plan_path}} in workspace {{.Params.workspace_path}}. Execute the next unchecked step, verify narrowly, update plan.md, and complete with continue_implementation, review, or blocked as appropriate.",
+      "prompt_template": "Continue the approved Puber refactor or migration plan from {{.Params.plan_path}} in workspace {{.Params.workspace_path}}. Execute the next unchecked step, verify narrowly, update plan.md, and complete with continue_implementation, review, or needs_user_action as appropriate.\n\nFor any needs_user_action transition, provide blocker_reason with the exact next user or external action needed.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/refactor-* or .todo/migration-* workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "plan_path",
-          "description": "Path to the plan.md being executed."
+          "description": "Path to the plan.md used by this workflow transition."
         }
       ]
     },
@@ -361,19 +402,19 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Review the Puber refactor or migration implementation read-only.\n\nRead .kent/project-contract.md first. Compare changes against {{.Params.plan_path}}, audit risks, AGENTS.md architecture rules, and {{.Params.verification_summary}}. Do not edit files in this node.\n\nComplete with done if accepted, needs_changes if fixes are required and provide workspace_path, review_report, and changed_files, or blocked if review cannot complete and provide blocker_reason.",
+      "prompt_template": "Review the Puber refactor or migration implementation read-only.\n\nRead .kent/project-contract.md first. Compare changes against {{.Params.plan_path}}, audit risks, AGENTS.md architecture rules, and {{.Params.verification_summary}}. Do not edit files in this node.\n\nComplete with compliance if accepted, needs_changes if fixes are required and provide workspace_path, review_report, and changed_files, or needs_user_action if review cannot complete and provide blocker_reason.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/refactor-* or .todo/migration-* workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "plan_path",
-          "description": "Path to the plan.md being executed."
+          "description": "Path to the plan.md used by this workflow transition."
         },
         {
           "key": "audit_report",
-          "description": "Planning audit summary and known risks."
+          "description": "Path or summary of the current audit/review report."
         },
         {
           "key": "changed_files",
@@ -391,16 +432,16 @@
       "transition_group_id": "group-ee2360ec-4e0a-49c8-bd89-433637459e42",
       "key": "fix",
       "target_node_id": "node-813ddb92-db58-4688-b8c7-77b8134f31be",
-      "requires_approval": true,
+      "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Fix the Puber refactor or migration review findings.\n\nRead .kent/project-contract.md first. Apply only the fixes requested in {{.Params.review_report}} inside {{.Params.workspace_path}}. Verify narrowly, then complete with review and provide workspace_path, review_report, and changed_files. Complete with blocked if unsafe or missing input and provide blocker_reason.",
+      "prompt_template": "Fix the Puber refactor or migration review findings.\n\nRead .kent/project-contract.md first. Apply only the fixes requested in {{.Params.review_report}} inside {{.Params.workspace_path}}. Verify narrowly, then complete with review and provide workspace_path, review_report, and changed_files. Complete with needs_user_action if unsafe or missing input and provide blocker_reason.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Workspace containing the implementation to fix."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "review_report",
@@ -423,11 +464,11 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Re-review the fixed Puber refactor or migration. Use {{.Params.review_report}} and {{.Params.changed_files}} as context. Complete with done, needs_changes, or blocked.",
+      "prompt_template": "Re-review the fixed Puber refactor or migration. Use {{.Params.review_report}} and {{.Params.changed_files}} as context. Complete with compliance, needs_changes, or needs_user_action.\n\nFor any needs_user_action transition, provide blocker_reason with the exact next user or external action needed.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Workspace containing the fixed implementation."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "review_report",
@@ -443,17 +484,18 @@
       "id": "edge-8575711d-c9ab-4e6e-b0c1-336845bb4687",
       "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
       "transition_group_id": "group-dd24b644-7d09-4d95-b319-d7d8ab63c339",
-      "key": "plan_blocked",
-      "target_node_id": "node-57fd70be-e6ef-449e-bbc5-2e2316abf0f4",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "plan_needs_user_action",
+      "target_node_id": "node-30f4fcb2-8a07-41bb-ab1f-7164872244e3",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why planning or audit cannot continue, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -461,17 +503,18 @@
       "id": "edge-9c33162d-d739-43b7-a832-670c3bc1d9d4",
       "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
       "transition_group_id": "group-ea1b058f-1636-40a3-9e3c-5099322948ec",
-      "key": "implementation_blocked",
-      "target_node_id": "node-57fd70be-e6ef-449e-bbc5-2e2316abf0f4",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "implement_needs_user_action",
+      "target_node_id": "node-993b1947-3f73-4109-bad1-c8d890df7a58",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why implementation cannot continue, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -479,17 +522,18 @@
       "id": "edge-0629cc0d-de9e-412f-94b0-9766a55ce247",
       "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
       "transition_group_id": "group-9a4efa3a-d2ef-4474-acfa-a110be4e3d08",
-      "key": "review_blocked",
-      "target_node_id": "node-57fd70be-e6ef-449e-bbc5-2e2316abf0f4",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "review_needs_user_action",
+      "target_node_id": "node-227ae295-a572-41a4-b257-67642857758d",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why review cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -497,17 +541,18 @@
       "id": "edge-fffaff4d-5492-47eb-a42f-47af2565979f",
       "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
       "transition_group_id": "group-124b993a-2a32-4f65-9fec-f3ddab23803f",
-      "key": "fix_blocked",
-      "target_node_id": "node-57fd70be-e6ef-449e-bbc5-2e2316abf0f4",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "fix_needs_user_action",
+      "target_node_id": "node-813ddb92-db58-4688-b8c7-77b8134f31be",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why fixing cannot continue, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -515,18 +560,18 @@
       "id": "edge-c7ad3417-54cc-4145-834d-072113afcc63",
       "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
       "transition_group_id": "group-b25bf5b0-4ceb-40e6-bbac-e46b32220eb5",
-      "key": "review_done",
+      "key": "review_compliance",
       "target_node_id": "node-eef2d0ef-ca80-49f5-a5b0-2cbb28e0d4b5",
       "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Run mandatory Puber Compliance Review before cleanup.\n\nRead .kent/commands/compliance-review.md, .kent/project-contract.md, and AGENTS.md first. Reviewed scope: completed refactor/migration in workspace {{.Params.workspace_path}}. Changed files: {{.Params.changed_files}}. Review only compliance with task requirements, plan/design/specs, AGENTS.md, and workflow contract. Do not edit files.\n\nComplete with done and provide compliance_report when no compliance violations are found. Complete with needs_changes and provide workspace_path plus compliance_report when fixes are required. Complete with blocked and provide blocker_reason if required sources are missing or contradictory.",
+      "prompt_template": "Run mandatory Puber Compliance Review before cleanup.\n\nRead .kent/commands/compliance-review.md, .kent/project-contract.md, and AGENTS.md first. Reviewed scope: completed refactor/migration in workspace {{.Params.workspace_path}}. Changed files: {{.Params.changed_files}}. Review only compliance with task requirements, plan/design/specs, AGENTS.md, and workflow contract. Do not edit files.\n\nComplete with ship_pr and provide compliance_report when no compliance violations are found. Complete with needs_changes and provide workspace_path plus compliance_report when fixes are required. Complete with needs_user_action and provide blocker_reason if required sources are missing or contradictory.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Workspace containing the implementation to fix."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "changed_files",
@@ -556,18 +601,18 @@
       "id": "edge-fd4f03aa-144b-400d-b2a5-3580e7801d3a",
       "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
       "transition_group_id": "group-0c6266bf-dd1f-4775-9899-d8f4ee1cdbe9",
-      "key": "compliance_done",
+      "key": "compliance_ship_pr",
       "target_node_id": "node-c3d52a51-d482-47ab-993a-45ad30ce22c9",
       "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Create or update the Puber pull request for this completed task.\n\nRead .kent/project-contract.md, .kent/commands/ship-pr.md, and AGENTS.md first. Compliance result: {{.Params.compliance_report}}.\n\nIf this task produced repository changes, commit only task-related files, push the current task branch to origin, and create or update a GitHub PR. Do not merge the PR. Do not push directly to master/main. If there are no repository changes and the task is report-only or smoke-only, complete with done and provide pr_report explaining why PR is not applicable.\n\nComplete with monitor_ci when a PR exists and provide pr_url, branch_name, and workspace_path. Complete with needs_changes when PR creation/update is blocked by recoverable repository, branch, or PR state such as merge conflicts, non-fast-forward push, branch needing rebase, or missing PR metadata that can be fixed in the task worktree; provide workspace_path and blocker_reason. Complete with done only for PR-not-applicable/no-diff cases and provide pr_report. Complete with blocked only when continuing would be unsafe without changing task scope, credentials, or project policy; provide blocker_reason.",
+      "prompt_template": "Create or update the Puber pull request for this completed task.\n\nRead .kent/project-contract.md, .kent/commands/ship-pr.md, and AGENTS.md first. Compliance result: {{.Params.compliance_report}}.\n\nIf this task produced repository changes, commit only task-related files, push the current task branch to origin, and create or update a GitHub PR. Do not merge the PR. Do not push directly to master/main. If there are no repository changes and the task is report-only or smoke-only, complete with no_pr and provide pr_report explaining why PR is not applicable.\n\nComplete with monitor_ci when a PR exists and provide pr_url, branch_name, and workspace_path. Complete with needs_changes when PR creation/update is needs_user_action by recoverable repository, branch, or PR state such as merge conflicts, non-fast-forward push, branch needing rebase, or missing PR metadata that can be fixed in the task worktree; provide workspace_path and blocker_reason. Complete with no_pr only for PR-not-applicable/no-diff cases and provide pr_report. Complete with needs_user_action only when continuing would be unsafe without changing task scope, credentials, or project policy; provide blocker_reason.",
       "parameters": [
         {
           "key": "compliance_report",
-          "description": "Compliance review report, including rule sources checked and any findings."
+          "description": "Compliance review report or summary."
         }
       ]
     },
@@ -577,20 +622,20 @@
       "transition_group_id": "group-f4cd0ac2-1c8f-48eb-9301-5799ed88a5a0",
       "key": "compliance_fix",
       "target_node_id": "node-813ddb92-db58-4688-b8c7-77b8134f31be",
-      "requires_approval": true,
+      "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Fix Puber refactor/migration compliance violations only.\n\nRead .kent/project-contract.md and .kent/commands/compliance-review.md first. Apply only the minimum changes required by compliance findings in {{.Params.compliance_report}} for workspace {{.Params.workspace_path}}. Verify narrowly, then complete with review and provide workspace_path, review_report, and changed_files. Complete with blocked and provide blocker_reason if unsafe or missing input.",
+      "prompt_template": "Fix Puber refactor/migration compliance violations only.\n\nRead .kent/project-contract.md and .kent/commands/compliance-review.md first. Apply only the minimum changes required by compliance findings in {{.Params.compliance_report}} for workspace {{.Params.workspace_path}}. Verify narrowly, then complete with review and provide workspace_path, review_report, and changed_files. Complete with needs_user_action and provide blocker_reason if unsafe or missing input.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Workspace containing the implementation to fix."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "compliance_report",
-          "description": "Compliance review report, including rule sources checked and any findings."
+          "description": "Compliance review report or summary."
         }
       ]
     },
@@ -598,17 +643,18 @@
       "id": "edge-561a2413-a29d-4fad-9e5b-d0176dae2e46",
       "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
       "transition_group_id": "group-4b8d365e-1cb9-4bc1-a637-27887da99354",
-      "key": "compliance_blocked",
-      "target_node_id": "node-57fd70be-e6ef-449e-bbc5-2e2316abf0f4",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "compliance_needs_user_action",
+      "target_node_id": "node-eef2d0ef-ca80-49f5-a5b0-2cbb28e0d4b5",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why compliance review cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -623,19 +669,19 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Monitor Puber PR checks.\n\nRead .kent/project-contract.md and AGENTS.md first. Inspect PR {{.Params.pr_url}} on branch {{.Params.branch_name}}. Use GitHub CLI when available. Do not merge the PR. Do not push new commits from this node.\n\nComplete with done if CI/checks pass, are absent, or are intentionally skipped with a clear reason; provide ci_report and pr_url. Complete with needs_changes if CI failed due to task changes and provide workspace_path plus ci_report. Complete with retry_later when checks cannot be inspected because GitHub/CI is still starting, rate-limited, temporarily unavailable, or an expected run has not appeared yet; provide pr_url, branch_name, workspace_path, and ci_report. Complete with blocked only if checks cannot be inspected and retrying would be unsafe or misleading; provide blocker_reason.",
+      "prompt_template": "Monitor Puber PR checks.\n\nRead .kent/project-contract.md and AGENTS.md first. Inspect PR {{.Params.pr_url}} on branch {{.Params.branch_name}}. Use GitHub CLI when available. Do not merge the PR. Do not push new commits from this node.\n\nComplete with waiting_pr if CI/checks pass, are absent, or are intentionally skipped with a clear reason; provide ci_report and pr_url. Complete with needs_changes if CI failed due to task changes and provide workspace_path plus ci_report. Complete with needs_user_action for temporary external waits; provide blocker_reason. Complete with needs_user_action only if checks cannot be inspected and retrying would be unsafe or misleading; provide blocker_reason.",
       "parameters": [
         {
           "key": "pr_url",
-          "description": "URL of the pull request."
+          "description": "URL of the created, updated, or monitored pull request."
         },
         {
           "key": "branch_name",
-          "description": "Name of the pushed task branch."
+          "description": "Name of the task or release branch associated with the pull request."
         },
         {
           "key": "workspace_path",
-          "description": "Path to the worktree or checkout used for PR creation."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         }
       ]
     },
@@ -654,7 +700,7 @@
       "parameters": [
         {
           "key": "pr_report",
-          "description": "Why no pull request was created or updated."
+          "description": "PR creation, review, conflict, or post-CI regression report."
         }
       ]
     },
@@ -662,17 +708,18 @@
       "id": "edge-ace12afc-ac67-4f52-ade4-907be9fee682",
       "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
       "transition_group_id": "group-d495dbc7-af89-4ec5-a99a-d9a91b031e19",
-      "key": "pr_blocked",
-      "target_node_id": "node-57fd70be-e6ef-449e-bbc5-2e2316abf0f4",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "ship_pr_needs_user_action",
+      "target_node_id": "node-c3d52a51-d482-47ab-993a-45ad30ce22c9",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why PR creation/update cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -680,22 +727,30 @@
       "id": "edge-2d9e02f3-088d-4fdf-99a7-9296735b0d21",
       "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
       "transition_group_id": "group-30b7d6db-f7c1-4027-b6be-6dc7a82938c8",
-      "key": "ci_done",
-      "target_node_id": "node-bac5102f-8ccd-40b3-9151-e29db141bb5c",
+      "key": "ci_waiting_pr",
+      "target_node_id": "node-76de9680-9d35-4f30-926c-59cf91ce928c",
       "requires_approval": false,
       "context_mode": "new_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Run conservative Puber task cleanup after PR/CI.\n\nRead .kent/project-contract.md first, then use .kent/commands/cleanup-task.md. PR: {{.Params.pr_url}}. CI report: {{.Params.ci_report}}. Do not delete any worktree containing unpushed or uncommitted user changes. Complete with done and provide cleanup_report.",
+      "prompt_template": "Hold this Puber task until its pull request is actually merged.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, PR {{.Params.pr_url}}, branch {{.Params.branch_name}}, workspace {{.Params.workspace_path}}, and CI report {{.Params.ci_report}}.\n\nUse `gh pr view --json state,mergedAt,mergeCommit,headRefName,baseRefName,url` when available. Do not merge the PR. Do not push commits from this node. Do not clean up while the PR is still open.\n\nComplete with pr_merged only when GitHub reports state=MERGED; provide pr_url, branch_name, and merge_report. Complete with needs_changes when PR review comments, merge conflicts, or post-CI regressions can be fixed within the task scope; provide workspace_path and pr_report. Complete with needs_user_action when the PR is still open, waiting for human review/approval/merge, or needs_user_action by an external process; add a task comment with the current PR status and exact human action, then provide pr_url, branch_name, workspace_path, and waiting_reason. Complete with close_without_merge only if the latest user comment explicitly says to close/cancel/skip this PR; provide pr_url, branch_name, and cleanup_reason.",
       "parameters": [
+        {
+          "key": "pr_url",
+          "description": "URL of the created, updated, or monitored pull request."
+        },
+        {
+          "key": "branch_name",
+          "description": "Name of the task or release branch associated with the pull request."
+        },
+        {
+          "key": "workspace_path",
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
+        },
         {
           "key": "ci_report",
           "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
-        },
-        {
-          "key": "pr_url",
-          "description": "URL of the created or updated pull request."
         }
       ]
     },
@@ -705,16 +760,16 @@
       "transition_group_id": "group-8c707a90-8c60-4e14-8d14-bbaae7307236",
       "key": "ci_fix",
       "target_node_id": "node-813ddb92-db58-4688-b8c7-77b8134f31be",
-      "requires_approval": true,
+      "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Fix Puber refactor/migration CI failures only.\n\nRead .kent/project-contract.md first. Apply only the minimum changes required by CI report {{.Params.ci_report}} in workspace {{.Params.workspace_path}}. Verify narrowly, then complete with review and provide workspace_path, review_report, and changed_files. Complete with blocked and provide blocker_reason if unsafe or missing input.",
+      "prompt_template": "Fix Puber refactor/migration CI failures only.\n\nRead .kent/project-contract.md first. Apply only the minimum changes required by CI report {{.Params.ci_report}} in workspace {{.Params.workspace_path}}. Verify narrowly, then complete with review and provide workspace_path, review_report, and changed_files. Complete with needs_user_action and provide blocker_reason if unsafe or missing input.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Workspace containing the implementation to fix."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "ci_report",
@@ -726,17 +781,18 @@
       "id": "edge-e63dad2b-c6a4-4c3d-ab3c-9129eb0b36d4",
       "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
       "transition_group_id": "group-f658f4d5-33a8-455a-bf4b-b3a6c67f2385",
-      "key": "ci_blocked",
-      "target_node_id": "node-57fd70be-e6ef-449e-bbc5-2e2316abf0f4",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "ci_monitor_needs_user_action",
+      "target_node_id": "node-92b2e510-465a-4f75-bb6d-4b2d0413d59c",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why CI monitoring cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -751,46 +807,141 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Fix recoverable Puber PR creation/update issues only.\n\nRead .kent/project-contract.md, .kent/commands/ship-pr.md, and AGENTS.md first. Previous PR blocker: {{.Params.blocker_reason}}. Work in {{.Params.workspace_path}}. Apply only the minimum changes needed to make the task branch/PR shippable, such as rebasing, resolving merge conflicts, fixing branch metadata, or repairing the PR-ready commit set. Do not expand product scope. Verify narrowly, then continue through the workflow's normal review/compliance path. Complete with blocked only if the recovery is unsafe or requires user credentials/policy changes.",
+      "prompt_template": "Fix recoverable Puber PR creation/update issues only.\n\nRead .kent/project-contract.md, .kent/commands/ship-pr.md, and AGENTS.md first. Previous PR blocker: {{.Params.blocker_reason}}. Work in {{.Params.workspace_path}}. Apply only the minimum changes needed to make the task branch/PR shippable, such as rebasing, resolving merge conflicts, fixing branch metadata, or repairing the PR-ready commit set. Do not expand product scope. Verify narrowly, then continue through the workflow's normal review/compliance path. Complete with needs_user_action only if the recovery is unsafe or requires user credentials/policy changes.\n\nFor any needs_user_action transition, provide blocker_reason with the exact next user or external action needed.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the worktree or checkout used for PR creation."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "blocker_reason",
-          "description": "Why PR creation/update cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
     {
-      "id": "edge-f179b95f-a2a5-4d7f-9614-2dea3124b5d2",
+      "id": "edge-f44ef096-b854-48bd-804b-7f8375dcf928",
       "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
-      "transition_group_id": "group-86b8ea6e-fecf-4219-ad3f-578d91728364",
-      "key": "ci_retry",
-      "target_node_id": "node-92b2e510-465a-4f75-bb6d-4b2d0413d59c",
+      "transition_group_id": "group-77c19afc-8de8-4599-9a8f-00c700f55429",
+      "key": "cleanup_after_merge",
+      "target_node_id": "node-bac5102f-8ccd-40b3-9151-e29db141bb5c",
+      "requires_approval": false,
+      "context_mode": "new_session",
+      "context_source": {
+        "kind": "immediate_source"
+      },
+      "prompt_template": "Run conservative Puber task cleanup after the pull request was confirmed merged.\n\nRead AGENTS.md, .kent/project-contract.md, .kent/commands/cleanup-task.md, PR {{.Params.pr_url}}, branch {{.Params.branch_name}}, and merge report {{.Params.merge_report}}. Verify the PR is merged with GitHub state, not only git ancestry, because squash merges are allowed. Do not delete any worktree containing unpushed commits, uncommitted user changes, or unclear ownership. Complete with done and provide cleanup_report.",
+      "parameters": [
+        {
+          "key": "pr_url",
+          "description": "URL of the created, updated, or monitored pull request."
+        },
+        {
+          "key": "branch_name",
+          "description": "Name of the task or release branch associated with the pull request."
+        },
+        {
+          "key": "merge_report",
+          "description": "GitHub PR state, mergedAt, mergeCommit, and cleanup or release notes."
+        }
+      ]
+    },
+    {
+      "id": "edge-c99632ec-df1e-4bc9-b530-a26ea9ae2f92",
+      "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
+      "transition_group_id": "group-b756fb18-8d6a-4a3b-b977-18128a269f1e",
+      "key": "pr_feedback",
+      "target_node_id": "node-813ddb92-db58-4688-b8c7-77b8134f31be",
+      "requires_approval": false,
+      "context_mode": "compact_and_continue_session",
+      "context_source": {
+        "kind": "immediate_source"
+      },
+      "prompt_template": "Fix Puber PR feedback only.\n\nRead AGENTS.md, .kent/project-contract.md, latest task comments, workspace {{.Params.workspace_path}}, and PR feedback report {{.Params.pr_report}}. Apply only task-scoped changes needed for PR review comments, merge conflicts, or post-CI regressions. Do not force-push unless the latest user comment explicitly permits force-push for this exact PR/branch. Verify narrowly, then return through the workflow's normal review/verify/compliance path with an updated report. If user input is required, complete with needs_user_action and provide blocker_reason.",
+      "parameters": [
+        {
+          "key": "workspace_path",
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
+        },
+        {
+          "key": "pr_report",
+          "description": "PR creation, review, conflict, or post-CI regression report."
+        }
+      ]
+    },
+    {
+      "id": "edge-bff7aad0-99f2-45c6-aa68-884a1b34db7b",
+      "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
+      "transition_group_id": "group-076d88e3-db5d-4f77-a94d-ced8fc18e1a9",
+      "key": "waiting_pr_needs_user_action",
+      "target_node_id": "node-76de9680-9d35-4f30-926c-59cf91ce928c",
       "requires_approval": true,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Retry Puber PR check monitoring after an approved temporary CI/GitHub wait.\n\nRead .kent/project-contract.md and AGENTS.md first. Previous CI status: {{.Params.ci_report}}. Inspect PR {{.Params.pr_url}} on branch {{.Params.branch_name}} again. Do not merge the PR. Do not push new commits from this node.\n\nComplete with done if CI/checks pass, are absent, or are intentionally skipped with a clear reason; provide ci_report and pr_url. Complete with needs_changes if CI failed due to task changes and provide workspace_path plus ci_report. Complete with retry_later if CI/GitHub is still temporarily unavailable and provide pr_url, branch_name, workspace_path, and ci_report. Complete with blocked only if retrying is no longer useful or safe; provide blocker_reason.",
+      "prompt_template": "Re-check the Puber pull request after the user resolved the external wait or approved another check.\n\nRead AGENTS.md, .kent/project-contract.md, latest task comments, PR {{.Params.pr_url}}, branch {{.Params.branch_name}}, workspace {{.Params.workspace_path}}, and previous waiting reason {{.Params.waiting_reason}}. Do not merge, push, or clean up unless the PR is confirmed merged.\n\nComplete with pr_merged only when GitHub reports state=MERGED. Complete with needs_changes for task-scoped PR review/conflict/regression fixes. Complete with needs_user_action again if the PR is still waiting externally. Complete with close_without_merge only on explicit latest user instruction.",
       "parameters": [
         {
           "key": "pr_url",
-          "description": "URL of the created or updated pull request."
+          "description": "URL of the created, updated, or monitored pull request."
         },
         {
           "key": "branch_name",
-          "description": "Name of the pushed task branch."
+          "description": "Name of the task or release branch associated with the pull request."
         },
         {
           "key": "workspace_path",
-          "description": "Workspace containing the implementation to fix."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
-          "key": "ci_report",
-          "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+          "key": "waiting_reason",
+          "description": "Why the PR cannot advance yet and the exact user or external action needed."
+        }
+      ]
+    },
+    {
+      "id": "edge-b7c8a9bd-b9db-418b-abc1-7a3a7b107d6c",
+      "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
+      "transition_group_id": "group-017cf0a8-5d35-4ed6-b7c3-cf5900852d4c",
+      "key": "cancel_cleanup",
+      "target_node_id": "node-bac5102f-8ccd-40b3-9151-e29db141bb5c",
+      "requires_approval": true,
+      "context_mode": "new_session",
+      "context_source": {
+        "kind": "immediate_source"
+      },
+      "prompt_template": "Run conservative Puber task cleanup after the user explicitly closed/canceled the PR without merge.\n\nRead AGENTS.md, .kent/project-contract.md, .kent/commands/cleanup-task.md, PR {{.Params.pr_url}}, branch {{.Params.branch_name}}, and cleanup reason {{.Params.cleanup_reason}}. Do not delete any worktree containing unpushed commits, uncommitted user changes, or unclear ownership. Complete with done and provide cleanup_report.",
+      "parameters": [
+        {
+          "key": "pr_url",
+          "description": "URL of the created, updated, or monitored pull request."
+        },
+        {
+          "key": "branch_name",
+          "description": "Name of the task or release branch associated with the pull request."
+        },
+        {
+          "key": "cleanup_reason",
+          "description": "Explicit user instruction or reason for cleanup without merge."
+        }
+      ]
+    },
+    {
+      "id": "edge-12f196b6-fc6b-4b41-9746-c102791a9aab",
+      "workflow_id": "workflow-bed92924-4c7e-4c24-8322-aa29d26573ca",
+      "transition_group_id": "group-6b6661bd-8914-471b-9c4e-3b0e294f5467",
+      "key": "plan_wont_do",
+      "target_node_id": "node-57fd70be-e6ef-449e-bbc5-2e2316abf0f4",
+      "requires_approval": true,
+      "context_mode": "new_session",
+      "context_source": {
+        "kind": "immediate_source"
+      },
+      "parameters": [
+        {
+          "key": "closure_reason",
+          "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
         }
       ]
     }
@@ -805,19 +956,23 @@
         "possible_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/refactor-* or .todo/migration-* workspace created by planning."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "plan_path",
-            "description": "Path to the generated plan.md inside the workspace."
+            "description": "Path to the plan.md used by this workflow transition."
           },
           {
             "name": "audit_report",
-            "description": "Planning audit summary, risk notes, and user-facing implementation constraints."
+            "description": "Path or summary of the current audit/review report."
           },
           {
             "name": "blocker_reason",
-            "description": "Why planning or audit cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          },
+          {
+            "name": "closure_reason",
+            "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
           }
         ]
       },
@@ -826,15 +981,15 @@
         "possible_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/refactor-* or .todo/migration-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "plan_path",
-            "description": "Path to the plan.md being executed."
+            "description": "Path to the plan.md used by this workflow transition."
           },
           {
             "name": "audit_report",
-            "description": "Planning audit summary and known risks."
+            "description": "Path or summary of the current audit/review report."
           },
           {
             "name": "changed_files",
@@ -846,7 +1001,7 @@
           },
           {
             "name": "blocker_reason",
-            "description": "Why implementation cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -855,7 +1010,7 @@
         "possible_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Workspace containing the implementation to fix."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "review_report",
@@ -867,7 +1022,7 @@
           },
           {
             "name": "blocker_reason",
-            "description": "Why review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -876,7 +1031,7 @@
         "possible_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Workspace containing the fixed implementation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "review_report",
@@ -888,7 +1043,7 @@
           },
           {
             "name": "blocker_reason",
-            "description": "Why fixing cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -909,15 +1064,15 @@
         "possible_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           },
           {
             "name": "workspace_path",
-            "description": "Workspace containing the implementation to fix."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -926,23 +1081,23 @@
         "possible_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "pr_report",
-            "description": "Why no pull request was created or updated."
+            "description": "PR creation, review, conflict, or post-CI regression report."
           },
           {
             "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -950,24 +1105,57 @@
         "node_id": "node-92b2e510-465a-4f75-bb6d-4b2d0413d59c",
         "possible_provision_fields": [
           {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
             "name": "ci_report",
             "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
           },
           {
-            "name": "pr_url",
-            "description": "URL of the created or updated pull request."
-          },
-          {
-            "name": "workspace_path",
-            "description": "Workspace containing the implementation to fix."
-          },
-          {
             "name": "blocker_reason",
-            "description": "Why CI monitoring cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          }
+        ]
+      },
+      {
+        "node_id": "node-76de9680-9d35-4f30-926c-59cf91ce928c",
+        "possible_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "merge_report",
+            "description": "GitHub PR state, mergedAt, mergeCommit, and cleanup or release notes."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "pr_report",
+            "description": "PR creation, review, conflict, or post-CI regression report."
+          },
+          {
+            "name": "waiting_reason",
+            "description": "Why the PR cannot advance yet and the exact user or external action needed."
+          },
+          {
+            "name": "cleanup_reason",
+            "description": "Explicit user instruction or reason for cleanup without merge."
           }
         ]
       },
@@ -984,15 +1172,15 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/refactor-* or .todo/migration-* workspace created by planning."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "plan_path",
-            "description": "Path to the generated plan.md inside the workspace."
+            "description": "Path to the plan.md used by this workflow transition."
           },
           {
             "name": "audit_report",
-            "description": "Planning audit summary, risk notes, and user-facing implementation constraints."
+            "description": "Path or summary of the current audit/review report."
           }
         ]
       },
@@ -1001,11 +1189,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/refactor-* or .todo/migration-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "plan_path",
-            "description": "Path to the plan.md being executed."
+            "description": "Path to the plan.md used by this workflow transition."
           }
         ]
       },
@@ -1014,15 +1202,15 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/refactor-* or .todo/migration-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "plan_path",
-            "description": "Path to the plan.md being executed."
+            "description": "Path to the plan.md used by this workflow transition."
           },
           {
             "name": "audit_report",
-            "description": "Planning audit summary and known risks."
+            "description": "Path or summary of the current audit/review report."
           },
           {
             "name": "changed_files",
@@ -1039,7 +1227,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Workspace containing the implementation to fix."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "review_report",
@@ -1056,7 +1244,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Workspace containing the fixed implementation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "review_report",
@@ -1073,7 +1261,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why planning or audit cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1082,7 +1270,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why implementation cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1091,7 +1279,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1100,7 +1288,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why fixing cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1109,7 +1297,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Workspace containing the implementation to fix."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "changed_files",
@@ -1131,7 +1319,7 @@
         "required_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -1140,11 +1328,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Workspace containing the implementation to fix."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -1153,7 +1341,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1162,15 +1350,15 @@
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           }
         ]
       },
@@ -1179,7 +1367,7 @@
         "required_provision_fields": [
           {
             "name": "pr_report",
-            "description": "Why no pull request was created or updated."
+            "description": "PR creation, review, conflict, or post-CI regression report."
           }
         ]
       },
@@ -1188,7 +1376,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1196,12 +1384,20 @@
         "transition_group_id": "group-30b7d6db-f7c1-4027-b6be-6dc7a82938c8",
         "required_provision_fields": [
           {
-            "name": "ci_report",
-            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
-            "name": "pr_url",
-            "description": "URL of the created or updated pull request."
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "ci_report",
+            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
           }
         ]
       },
@@ -1210,7 +1406,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Workspace containing the implementation to fix."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "ci_report",
@@ -1223,7 +1419,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why CI monitoring cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1232,32 +1428,88 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
       {
-        "transition_group_id": "group-86b8ea6e-fecf-4219-ad3f-578d91728364",
+        "transition_group_id": "group-77c19afc-8de8-4599-9a8f-00c700f55429",
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the created or updated pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "merge_report",
+            "description": "GitHub PR state, mergedAt, mergeCommit, and cleanup or release notes."
+          }
+        ]
+      },
+      {
+        "transition_group_id": "group-b756fb18-8d6a-4a3b-b977-18128a269f1e",
+        "required_provision_fields": [
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "pr_report",
+            "description": "PR creation, review, conflict, or post-CI regression report."
+          }
+        ]
+      },
+      {
+        "transition_group_id": "group-076d88e3-db5d-4f77-a94d-ced8fc18e1a9",
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Workspace containing the implementation to fix."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
-            "name": "ci_report",
-            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+            "name": "waiting_reason",
+            "description": "Why the PR cannot advance yet and the exact user or external action needed."
+          }
+        ]
+      },
+      {
+        "transition_group_id": "group-017cf0a8-5d35-4ed6-b7c3-cf5900852d4c",
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "cleanup_reason",
+            "description": "Explicit user instruction or reason for cleanup without merge."
+          }
+        ]
+      },
+      {
+        "transition_group_id": "group-6b6661bd-8914-471b-9c4e-3b0e294f5467",
+        "required_provision_fields": [
+          {
+            "name": "closure_reason",
+            "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
           }
         ]
       }
@@ -1288,15 +1540,15 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/refactor-* or .todo/migration-* workspace created by planning."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "plan_path",
-            "description": "Path to the generated plan.md inside the workspace."
+            "description": "Path to the plan.md used by this workflow transition."
           },
           {
             "name": "audit_report",
-            "description": "Planning audit summary, risk notes, and user-facing implementation constraints."
+            "description": "Path or summary of the current audit/review report."
           }
         ]
       },
@@ -1317,11 +1569,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/refactor-* or .todo/migration-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "plan_path",
-            "description": "Path to the plan.md being executed."
+            "description": "Path to the plan.md used by this workflow transition."
           }
         ]
       },
@@ -1357,15 +1609,15 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/refactor-* or .todo/migration-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "plan_path",
-            "description": "Path to the plan.md being executed."
+            "description": "Path to the plan.md used by this workflow transition."
           },
           {
             "name": "audit_report",
-            "description": "Planning audit summary and known risks."
+            "description": "Path or summary of the current audit/review report."
           },
           {
             "name": "changed_files",
@@ -1399,7 +1651,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Workspace containing the implementation to fix."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "review_report",
@@ -1433,7 +1685,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Workspace containing the fixed implementation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "review_report",
@@ -1457,7 +1709,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why planning or audit cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1473,7 +1725,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why implementation cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1489,7 +1741,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1505,7 +1757,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why fixing cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1526,7 +1778,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Workspace containing the implementation to fix."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "changed_files",
@@ -1562,7 +1814,7 @@
         "required_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -1583,11 +1835,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Workspace containing the implementation to fix."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -1603,7 +1855,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1629,15 +1881,15 @@
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           }
         ]
       },
@@ -1653,7 +1905,7 @@
         "required_provision_fields": [
           {
             "name": "pr_report",
-            "description": "Why no pull request was created or updated."
+            "description": "PR creation, review, conflict, or post-CI regression report."
           }
         ]
       },
@@ -1669,103 +1921,12 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
       {
         "edge_id": "edge-2d9e02f3-088d-4fdf-99a7-9296735b0d21",
-        "input_bindings": [
-          {
-            "name": "ci_report",
-            "source": "transition_output",
-            "field": "ci_report"
-          },
-          {
-            "name": "pr_url",
-            "source": "transition_output",
-            "field": "pr_url"
-          }
-        ],
-        "required_provision_fields": [
-          {
-            "name": "ci_report",
-            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
-          },
-          {
-            "name": "pr_url",
-            "description": "URL of the created or updated pull request."
-          }
-        ]
-      },
-      {
-        "edge_id": "edge-19cd0a78-9c95-47d6-8412-26c83b08ddb8",
-        "input_bindings": [
-          {
-            "name": "workspace_path",
-            "source": "transition_output",
-            "field": "workspace_path"
-          },
-          {
-            "name": "ci_report",
-            "source": "transition_output",
-            "field": "ci_report"
-          }
-        ],
-        "required_provision_fields": [
-          {
-            "name": "workspace_path",
-            "description": "Workspace containing the implementation to fix."
-          },
-          {
-            "name": "ci_report",
-            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
-          }
-        ]
-      },
-      {
-        "edge_id": "edge-e63dad2b-c6a4-4c3d-ab3c-9129eb0b36d4",
-        "input_bindings": [
-          {
-            "name": "blocker_reason",
-            "source": "transition_output",
-            "field": "blocker_reason"
-          }
-        ],
-        "required_provision_fields": [
-          {
-            "name": "blocker_reason",
-            "description": "Why CI monitoring cannot complete, in the task language when practical."
-          }
-        ]
-      },
-      {
-        "edge_id": "edge-d58e8c4b-3571-491b-ae44-8b767839eef4",
-        "input_bindings": [
-          {
-            "name": "workspace_path",
-            "source": "transition_output",
-            "field": "workspace_path"
-          },
-          {
-            "name": "blocker_reason",
-            "source": "transition_output",
-            "field": "blocker_reason"
-          }
-        ],
-        "required_provision_fields": [
-          {
-            "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
-          },
-          {
-            "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
-          }
-        ]
-      },
-      {
-        "edge_id": "edge-f179b95f-a2a5-4d7f-9614-2dea3124b5d2",
         "input_bindings": [
           {
             "name": "pr_url",
@@ -1791,19 +1952,237 @@
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the created or updated pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Workspace containing the implementation to fix."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "ci_report",
             "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-19cd0a78-9c95-47d6-8412-26c83b08ddb8",
+        "input_bindings": [
+          {
+            "name": "workspace_path",
+            "source": "transition_output",
+            "field": "workspace_path"
+          },
+          {
+            "name": "ci_report",
+            "source": "transition_output",
+            "field": "ci_report"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "ci_report",
+            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-e63dad2b-c6a4-4c3d-ab3c-9129eb0b36d4",
+        "input_bindings": [
+          {
+            "name": "blocker_reason",
+            "source": "transition_output",
+            "field": "blocker_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "blocker_reason",
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-d58e8c4b-3571-491b-ae44-8b767839eef4",
+        "input_bindings": [
+          {
+            "name": "workspace_path",
+            "source": "transition_output",
+            "field": "workspace_path"
+          },
+          {
+            "name": "blocker_reason",
+            "source": "transition_output",
+            "field": "blocker_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "blocker_reason",
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-f44ef096-b854-48bd-804b-7f8375dcf928",
+        "input_bindings": [
+          {
+            "name": "pr_url",
+            "source": "transition_output",
+            "field": "pr_url"
+          },
+          {
+            "name": "branch_name",
+            "source": "transition_output",
+            "field": "branch_name"
+          },
+          {
+            "name": "merge_report",
+            "source": "transition_output",
+            "field": "merge_report"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "merge_report",
+            "description": "GitHub PR state, mergedAt, mergeCommit, and cleanup or release notes."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-c99632ec-df1e-4bc9-b530-a26ea9ae2f92",
+        "input_bindings": [
+          {
+            "name": "workspace_path",
+            "source": "transition_output",
+            "field": "workspace_path"
+          },
+          {
+            "name": "pr_report",
+            "source": "transition_output",
+            "field": "pr_report"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "pr_report",
+            "description": "PR creation, review, conflict, or post-CI regression report."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-bff7aad0-99f2-45c6-aa68-884a1b34db7b",
+        "input_bindings": [
+          {
+            "name": "pr_url",
+            "source": "transition_output",
+            "field": "pr_url"
+          },
+          {
+            "name": "branch_name",
+            "source": "transition_output",
+            "field": "branch_name"
+          },
+          {
+            "name": "workspace_path",
+            "source": "transition_output",
+            "field": "workspace_path"
+          },
+          {
+            "name": "waiting_reason",
+            "source": "transition_output",
+            "field": "waiting_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "waiting_reason",
+            "description": "Why the PR cannot advance yet and the exact user or external action needed."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-b7c8a9bd-b9db-418b-abc1-7a3a7b107d6c",
+        "input_bindings": [
+          {
+            "name": "pr_url",
+            "source": "transition_output",
+            "field": "pr_url"
+          },
+          {
+            "name": "branch_name",
+            "source": "transition_output",
+            "field": "branch_name"
+          },
+          {
+            "name": "cleanup_reason",
+            "source": "transition_output",
+            "field": "cleanup_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "cleanup_reason",
+            "description": "Explicit user instruction or reason for cleanup without merge."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-12f196b6-fc6b-4b41-9746-c102791a9aab",
+        "input_bindings": [
+          {
+            "name": "closure_reason",
+            "source": "transition_output",
+            "field": "closure_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "closure_reason",
+            "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
           }
         ]
       }

--- a/.kent/workflows/puber-release-preparation.json
+++ b/.kent/workflows/puber-release-preparation.json
@@ -3,7 +3,7 @@
     "id": "workflow-bf83678e-423b-4262-be73-5cc9369497a3",
     "name": "Puber Release Preparation",
     "description": "Prepare a Puber release branch and version bump, push only after approval, and clean up safely.",
-    "version": 26
+    "version": 53
   },
   "nodes": [
     {
@@ -43,9 +43,9 @@
     {
       "id": "node-c49ac91b-b6c0-4a46-9f9f-809653db03db",
       "workflow_id": "workflow-bf83678e-423b-4262-be73-5cc9369497a3",
-      "key": "blocked",
+      "key": "wont_do",
       "kind": "terminal",
-      "display_name": "Blocked"
+      "display_name": "Won't Do"
     },
     {
       "id": "node-5174454b-79c1-43c3-827e-48d80812d065",
@@ -85,25 +85,25 @@
       "id": "group-bbd72be8-6346-48fc-bfff-eafd46c364c7",
       "workflow_id": "workflow-bf83678e-423b-4262-be73-5cc9369497a3",
       "source_node_id": "node-5dae0fea-29f2-451c-a819-679a065d7630",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Release preparation is blocked by missing version/base branch, dirty unsafe state, or git access."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "prepare cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-3b9d06ec-fb03-46d3-920d-34c5d4a5732e",
       "workflow_id": "workflow-bf83678e-423b-4262-be73-5cc9369497a3",
       "source_node_id": "node-c9126434-1ae1-4429-bb99-7cb17feba6b2",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "Release branch is finalized or push was intentionally skipped; run mandatory compliance review before cleanup."
+      "transition_id": "compliance",
+      "display_name": "Compliance",
+      "description": "Release stage passed; run mandatory compliance review before cleanup."
     },
     {
       "id": "group-edc2a10c-bd8b-4208-a2f2-22483ebebd67",
       "workflow_id": "workflow-bf83678e-423b-4262-be73-5cc9369497a3",
       "source_node_id": "node-c9126434-1ae1-4429-bb99-7cb17feba6b2",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Release verification or push is blocked."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "verify cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-c13f3b18-1488-494c-a1b8-d0bceb9fe7a2",
@@ -117,9 +117,9 @@
       "id": "group-7b5b54ad-670b-4b8d-9b37-30cd21bc10c1",
       "workflow_id": "workflow-bf83678e-423b-4262-be73-5cc9369497a3",
       "source_node_id": "node-5174454b-79c1-43c3-827e-48d80812d065",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "Compliance review found no violations; run conservative cleanup."
+      "transition_id": "cleanup",
+      "display_name": "Cleanup",
+      "description": "Compliance passed; run conservative cleanup before terminal done."
     },
     {
       "id": "group-da7cde94-4634-487f-b274-ba386d4285c8",
@@ -127,15 +127,23 @@
       "source_node_id": "node-5174454b-79c1-43c3-827e-48d80812d065",
       "transition_id": "needs_changes",
       "display_name": "Needs Changes",
-      "description": "Compliance review found release-preparation violations; user approval required before rework."
+      "description": "Compliance review found release-preparation violations; rework without manual approval."
     },
     {
       "id": "group-0a45a2c8-359a-4a38-9e80-703ac30b9cf9",
       "workflow_id": "workflow-bf83678e-423b-4262-be73-5cc9369497a3",
       "source_node_id": "node-5174454b-79c1-43c3-827e-48d80812d065",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Compliance review is blocked by missing or contradictory required sources."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "compliance cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
+    },
+    {
+      "id": "group-b0e1df30-ac8e-4e27-b483-6fa2332d523e",
+      "workflow_id": "workflow-bf83678e-423b-4262-be73-5cc9369497a3",
+      "source_node_id": "node-5dae0fea-29f2-451c-a819-679a065d7630",
+      "transition_id": "wont_do",
+      "display_name": "Wont Do",
+      "description": "Latest user comment explicitly cancels this legacy release task or declares it not planned; finish without treating it as a recoverable blocker."
     }
   ],
   "edges": [
@@ -150,7 +158,7 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Run Puber release branch preparation for this Kent task.\n\nRead .kent/project-contract.md first, then use .kent/commands/release-branch.md. Treat the task body as the desired base branch/version policy. If base branch or version policy is ambiguous and cannot be safely derived, complete blocked with blocker_reason instead of guessing.\n\nPrepare the local release branch and version bump. Do not push to remote unless explicitly authorized by a later approval. Prefer .kent/worktrees/release-<version> if the main worktree is dirty. Complete with verify when local release preparation is complete and provide release_version, release_branch, base_branch, worktree_path, commit_hash, and push_plan. Complete with blocked if preparation is blocked and provide blocker_reason."
+      "prompt_template": "Run Puber release branch preparation for this Kent task.\n\nRead .kent/project-contract.md first, then use .kent/commands/release-branch.md. Treat the task body as the desired base branch/version policy. If base branch or version policy is ambiguous and cannot be safely derived, complete needs_user_action with blocker_reason instead of guessing.\n\nPrepare the local release branch and version bump. Do not push to remote unless explicitly authorized by a later approval. Prefer .kent/worktrees/release-<version> if the main worktree is dirty. Complete with verify when local release preparation is complete and provide release_version, release_branch, base_branch, worktree_path, commit_hash, and push_plan. Complete with needs_user_action if preparation is needs_user_action and provide blocker_reason."
     },
     {
       "id": "edge-c9abd2f9-ddd0-4a54-a092-fbcb2d464153",
@@ -163,15 +171,15 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Verify and finalize the prepared Puber release branch.\n\nRead .kent/project-contract.md first. Check release {{.Params.release_version}} on branch {{.Params.release_branch}} at {{.Params.commit_hash}}. Verify the local branch status and version bump. Push only if the task/approval clearly authorizes the push described in {{.Params.push_plan}}; otherwise report that push was skipped.\n\nComplete with done if release preparation is finalized. Complete with blocked if verification or push is blocked and provide blocker_reason.",
+      "prompt_template": "Verify and finalize the prepared Puber release branch.\n\nRead .kent/project-contract.md first. Check release {{.Params.release_version}} on branch {{.Params.release_branch}} at {{.Params.commit_hash}}. Verify the local branch status and version bump. Push only if the task/approval clearly authorizes the push described in {{.Params.push_plan}}; otherwise report that push was skipped.\n\nComplete with compliance if release preparation is finalized. Complete with needs_user_action if verification or push is needs_user_action and provide blocker_reason.",
       "parameters": [
         {
           "key": "release_version",
-          "description": "Release version prepared by this task."
+          "description": "Release version prepared by this workflow."
         },
         {
           "key": "release_branch",
-          "description": "Local release branch prepared by this task."
+          "description": "Release branch containing the version bump."
         },
         {
           "key": "base_branch",
@@ -195,17 +203,18 @@
       "id": "edge-89dbd721-ef6a-44fb-a4b8-4dd468d8ce3e",
       "workflow_id": "workflow-bf83678e-423b-4262-be73-5cc9369497a3",
       "transition_group_id": "group-bbd72be8-6346-48fc-bfff-eafd46c364c7",
-      "key": "prepare_blocked",
-      "target_node_id": "node-c49ac91b-b6c0-4a46-9f9f-809653db03db",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "prepare_needs_user_action",
+      "target_node_id": "node-5dae0fea-29f2-451c-a819-679a065d7630",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this legacy Puber release workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog and do not broaden release scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why release preparation cannot continue, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -213,22 +222,22 @@
       "id": "edge-58db533b-47b1-47fe-9438-3ec1a5c025b0",
       "workflow_id": "workflow-bf83678e-423b-4262-be73-5cc9369497a3",
       "transition_group_id": "group-3b9d06ec-fb03-46d3-920d-34c5d4a5732e",
-      "key": "verify_done",
+      "key": "verify_compliance",
       "target_node_id": "node-5174454b-79c1-43c3-827e-48d80812d065",
       "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Run mandatory Puber Compliance Review before cleanup.\n\nRead .kent/commands/compliance-review.md, .kent/commands/release-branch.md, .kent/project-contract.md, and AGENTS.md first. Reviewed scope: release preparation for {{.Params.release_version}} on {{.Params.release_branch}} in {{.Params.worktree_path}}. Verify compliance with release workflow approval gates, git/worktree policy, task requirements, and AGENTS.md. Do not edit files.\n\nComplete with done and provide compliance_report when no compliance violations are found. Complete with needs_changes and provide release_version, release_branch, worktree_path, and compliance_report when rework is required. Complete with blocked and provide blocker_reason if required sources are missing or contradictory.",
+      "prompt_template": "Run mandatory Puber Compliance Review before cleanup.\n\nRead .kent/commands/compliance-review.md, .kent/commands/release-branch.md, .kent/project-contract.md, and AGENTS.md first. Reviewed scope: release preparation for {{.Params.release_version}} on {{.Params.release_branch}} in {{.Params.worktree_path}}. Verify compliance with release workflow approval gates, git/worktree policy, task requirements, and AGENTS.md. Do not edit files.\n\nComplete with cleanup and provide compliance_report when no compliance violations are found. Complete with needs_changes and provide release_version, release_branch, worktree_path, and compliance_report when rework is required. Complete with needs_user_action and provide blocker_reason if required sources are missing or contradictory.",
       "parameters": [
         {
           "key": "release_version",
-          "description": "Release version prepared by this task."
+          "description": "Release version prepared by this workflow."
         },
         {
           "key": "release_branch",
-          "description": "Local release branch prepared by this task."
+          "description": "Release branch containing the version bump."
         },
         {
           "key": "worktree_path",
@@ -240,17 +249,18 @@
       "id": "edge-8a4193bf-4b8d-4001-903b-725f47915dc6",
       "workflow_id": "workflow-bf83678e-423b-4262-be73-5cc9369497a3",
       "transition_group_id": "group-edc2a10c-bd8b-4208-a2f2-22483ebebd67",
-      "key": "verify_blocked",
-      "target_node_id": "node-c49ac91b-b6c0-4a46-9f9f-809653db03db",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "verify_needs_user_action",
+      "target_node_id": "node-c9126434-1ae1-4429-bb99-7cb17feba6b2",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this legacy Puber release workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog and do not broaden release scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why verification/finalization cannot continue, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -268,7 +278,7 @@
       "parameters": [
         {
           "key": "cleanup_report",
-          "description": "Summary of cleanup performed or deliberately skipped."
+          "description": "Cleanup report or summary."
         }
       ]
     },
@@ -276,7 +286,7 @@
       "id": "edge-1507f20a-c1f5-4264-8d81-92a99cb2d753",
       "workflow_id": "workflow-bf83678e-423b-4262-be73-5cc9369497a3",
       "transition_group_id": "group-7b5b54ad-670b-4b8d-9b37-30cd21bc10c1",
-      "key": "compliance_done",
+      "key": "compliance_cleanup",
       "target_node_id": "node-63c461dc-1648-4215-a62b-fc08cfd214d6",
       "requires_approval": false,
       "context_mode": "new_session",
@@ -287,7 +297,7 @@
       "parameters": [
         {
           "key": "compliance_report",
-          "description": "Compliance review report, including rule sources checked and any findings."
+          "description": "Compliance review report or summary."
         }
       ]
     },
@@ -297,20 +307,20 @@
       "transition_group_id": "group-da7cde94-4634-487f-b274-ba386d4285c8",
       "key": "compliance_verify",
       "target_node_id": "node-c9126434-1ae1-4429-bb99-7cb17feba6b2",
-      "requires_approval": true,
+      "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Rework Puber release preparation compliance findings only.\n\nRead .kent/project-contract.md, .kent/commands/release-branch.md, and .kent/commands/compliance-review.md first. Apply only the minimum approved changes required by {{.Params.compliance_report}} for release {{.Params.release_version}} on {{.Params.release_branch}} in {{.Params.worktree_path}}. Push only if the approval and task explicitly authorize it. Complete with done or blocked according to the release-preparation workflow contract.",
+      "prompt_template": "Rework Puber release preparation compliance findings only.\n\nRead .kent/project-contract.md, .kent/commands/release-branch.md, and .kent/commands/compliance-review.md first. Apply only the minimum approved changes required by {{.Params.compliance_report}} for release {{.Params.release_version}} on {{.Params.release_branch}} in {{.Params.worktree_path}}. Push only if the approval and task explicitly authorize it. Complete with compliance or needs_user_action according to the release-preparation workflow contract.\n\nFor any needs_user_action transition, provide blocker_reason with the exact next user or external action needed.",
       "parameters": [
         {
           "key": "release_version",
-          "description": "Release version prepared by this task."
+          "description": "Release version prepared by this workflow."
         },
         {
           "key": "release_branch",
-          "description": "Local release branch prepared by this task."
+          "description": "Release branch containing the version bump."
         },
         {
           "key": "worktree_path",
@@ -318,7 +328,7 @@
         },
         {
           "key": "compliance_report",
-          "description": "Compliance review report, including rule sources checked and any findings."
+          "description": "Compliance review report or summary."
         }
       ]
     },
@@ -326,17 +336,36 @@
       "id": "edge-fea9cf9f-8960-4933-bad6-5a8735f9e044",
       "workflow_id": "workflow-bf83678e-423b-4262-be73-5cc9369497a3",
       "transition_group_id": "group-0a45a2c8-359a-4a38-9e80-703ac30b9cf9",
-      "key": "compliance_blocked",
+      "key": "compliance_needs_user_action",
+      "target_node_id": "node-5174454b-79c1-43c3-827e-48d80812d065",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
+      "context_source": {
+        "kind": "immediate_source"
+      },
+      "prompt_template": "Resume this legacy Puber release workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog and do not broaden release scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker.",
+      "parameters": [
+        {
+          "key": "blocker_reason",
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+        }
+      ]
+    },
+    {
+      "id": "edge-91a78f73-a027-4d61-bb1c-29eaec99e758",
+      "workflow_id": "workflow-bf83678e-423b-4262-be73-5cc9369497a3",
+      "transition_group_id": "group-b0e1df30-ac8e-4e27-b483-6fa2332d523e",
+      "key": "prepare_wont_do",
       "target_node_id": "node-c49ac91b-b6c0-4a46-9f9f-809653db03db",
-      "requires_approval": false,
+      "requires_approval": true,
       "context_mode": "new_session",
       "context_source": {
         "kind": "immediate_source"
       },
       "parameters": [
         {
-          "key": "blocker_reason",
-          "description": "Why compliance review cannot complete, in the task language when practical."
+          "key": "closure_reason",
+          "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
         }
       ]
     }
@@ -351,11 +380,11 @@
         "possible_provision_fields": [
           {
             "name": "release_version",
-            "description": "Release version prepared by this task."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_branch",
-            "description": "Local release branch prepared by this task."
+            "description": "Release branch containing the version bump."
           },
           {
             "name": "base_branch",
@@ -375,7 +404,11 @@
           },
           {
             "name": "blocker_reason",
-            "description": "Why release preparation cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          },
+          {
+            "name": "closure_reason",
+            "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
           }
         ]
       },
@@ -384,11 +417,11 @@
         "possible_provision_fields": [
           {
             "name": "release_version",
-            "description": "Release version prepared by this task."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_branch",
-            "description": "Local release branch prepared by this task."
+            "description": "Release branch containing the version bump."
           },
           {
             "name": "worktree_path",
@@ -396,7 +429,7 @@
           },
           {
             "name": "blocker_reason",
-            "description": "Why verification/finalization cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -405,7 +438,7 @@
         "possible_provision_fields": [
           {
             "name": "cleanup_report",
-            "description": "Summary of cleanup performed or deliberately skipped."
+            "description": "Cleanup report or summary."
           }
         ]
       },
@@ -417,15 +450,15 @@
         "possible_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           },
           {
             "name": "release_version",
-            "description": "Release version prepared by this task."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_branch",
-            "description": "Local release branch prepared by this task."
+            "description": "Release branch containing the version bump."
           },
           {
             "name": "worktree_path",
@@ -433,7 +466,7 @@
           },
           {
             "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -450,11 +483,11 @@
         "required_provision_fields": [
           {
             "name": "release_version",
-            "description": "Release version prepared by this task."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_branch",
-            "description": "Local release branch prepared by this task."
+            "description": "Release branch containing the version bump."
           },
           {
             "name": "base_branch",
@@ -479,7 +512,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why release preparation cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -488,11 +521,11 @@
         "required_provision_fields": [
           {
             "name": "release_version",
-            "description": "Release version prepared by this task."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_branch",
-            "description": "Local release branch prepared by this task."
+            "description": "Release branch containing the version bump."
           },
           {
             "name": "worktree_path",
@@ -505,7 +538,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why verification/finalization cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -514,7 +547,7 @@
         "required_provision_fields": [
           {
             "name": "cleanup_report",
-            "description": "Summary of cleanup performed or deliberately skipped."
+            "description": "Cleanup report or summary."
           }
         ]
       },
@@ -523,7 +556,7 @@
         "required_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -532,11 +565,11 @@
         "required_provision_fields": [
           {
             "name": "release_version",
-            "description": "Release version prepared by this task."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_branch",
-            "description": "Local release branch prepared by this task."
+            "description": "Release branch containing the version bump."
           },
           {
             "name": "worktree_path",
@@ -544,7 +577,7 @@
           },
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -553,7 +586,16 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          }
+        ]
+      },
+      {
+        "transition_group_id": "group-b0e1df30-ac8e-4e27-b483-6fa2332d523e",
+        "required_provision_fields": [
+          {
+            "name": "closure_reason",
+            "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
           }
         ]
       }
@@ -599,11 +641,11 @@
         "required_provision_fields": [
           {
             "name": "release_version",
-            "description": "Release version prepared by this task."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_branch",
-            "description": "Local release branch prepared by this task."
+            "description": "Release branch containing the version bump."
           },
           {
             "name": "base_branch",
@@ -635,7 +677,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why release preparation cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -661,11 +703,11 @@
         "required_provision_fields": [
           {
             "name": "release_version",
-            "description": "Release version prepared by this task."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_branch",
-            "description": "Local release branch prepared by this task."
+            "description": "Release branch containing the version bump."
           },
           {
             "name": "worktree_path",
@@ -685,7 +727,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why verification/finalization cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -701,7 +743,7 @@
         "required_provision_fields": [
           {
             "name": "cleanup_report",
-            "description": "Summary of cleanup performed or deliberately skipped."
+            "description": "Cleanup report or summary."
           }
         ]
       },
@@ -717,7 +759,7 @@
         "required_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -748,11 +790,11 @@
         "required_provision_fields": [
           {
             "name": "release_version",
-            "description": "Release version prepared by this task."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_branch",
-            "description": "Local release branch prepared by this task."
+            "description": "Release branch containing the version bump."
           },
           {
             "name": "worktree_path",
@@ -760,7 +802,7 @@
           },
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -776,7 +818,23 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-91a78f73-a027-4d61-bb1c-29eaec99e758",
+        "input_bindings": [
+          {
+            "name": "closure_reason",
+            "source": "transition_output",
+            "field": "closure_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "closure_reason",
+            "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
           }
         ]
       }

--- a/.kent/workflows/puber-release-publication.json
+++ b/.kent/workflows/puber-release-publication.json
@@ -3,7 +3,7 @@
     "id": "workflow-04d0de0d-0820-4e56-b50b-45bd2cfe489e",
     "name": "Puber Release Publication",
     "description": "Qualify and publish a Puber release tag after approval, monitor automation if present, and clean up safely.",
-    "version": 35
+    "version": 71
   },
   "nodes": [
     {
@@ -52,9 +52,9 @@
     {
       "id": "node-1fa274d6-4f47-48f9-8a23-9ff39348b1cc",
       "workflow_id": "workflow-04d0de0d-0820-4e56-b50b-45bd2cfe489e",
-      "key": "blocked",
+      "key": "wont_do",
       "kind": "terminal",
-      "display_name": "Blocked"
+      "display_name": "Won't Do"
     },
     {
       "id": "node-58da8456-480b-42bf-9fa3-5e5d5d828ab9",
@@ -94,9 +94,9 @@
       "id": "group-78e65634-7646-4251-8f94-3c6fb4e80e74",
       "workflow_id": "workflow-04d0de0d-0820-4e56-b50b-45bd2cfe489e",
       "source_node_id": "node-3c841aaf-089c-4df8-b04a-dce1cb807063",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Release readiness cannot be proven."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "qualify cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-7f336a19-d972-4cbd-9d3c-e0c0a98191fd",
@@ -110,33 +110,33 @@
       "id": "group-4493b1e9-aa93-428f-a5a1-df9eca908189",
       "workflow_id": "workflow-04d0de0d-0820-4e56-b50b-45bd2cfe489e",
       "source_node_id": "node-34e4131d-97ab-4b9b-b099-2c2cecea8085",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "Tag publication is complete and monitoring is intentionally skipped; run mandatory compliance review before cleanup."
+      "transition_id": "compliance",
+      "display_name": "Compliance",
+      "description": "Release stage passed; run mandatory compliance review before cleanup."
     },
     {
       "id": "group-eeceacea-a2d9-4349-a866-93b29d3a63a7",
       "workflow_id": "workflow-04d0de0d-0820-4e56-b50b-45bd2cfe489e",
       "source_node_id": "node-34e4131d-97ab-4b9b-b099-2c2cecea8085",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Release tag creation or push is blocked or unsafe."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "tag cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-e195bee8-ea10-4a6c-b2a1-b94484c0c6a3",
       "workflow_id": "workflow-04d0de0d-0820-4e56-b50b-45bd2cfe489e",
       "source_node_id": "node-65c09083-e828-4029-a1c9-a4f0f907e106",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "Release automation passed or monitoring is intentionally skipped; run mandatory compliance review before cleanup."
+      "transition_id": "compliance",
+      "display_name": "Compliance",
+      "description": "Release stage passed; run mandatory compliance review before cleanup."
     },
     {
       "id": "group-26956053-2530-465c-ad7a-83f8b86b4fee",
       "workflow_id": "workflow-04d0de0d-0820-4e56-b50b-45bd2cfe489e",
       "source_node_id": "node-65c09083-e828-4029-a1c9-a4f0f907e106",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Release automation failed or needs manual intervention."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "monitor cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-d4d06574-c27e-4cd5-8246-7e725c888b6d",
@@ -150,9 +150,9 @@
       "id": "group-b04eeac3-7951-4456-a670-cb5452178b2b",
       "workflow_id": "workflow-04d0de0d-0820-4e56-b50b-45bd2cfe489e",
       "source_node_id": "node-58da8456-480b-42bf-9fa3-5e5d5d828ab9",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "Compliance review found no violations; run conservative cleanup."
+      "transition_id": "cleanup",
+      "display_name": "Cleanup",
+      "description": "Compliance passed; run conservative cleanup before terminal done."
     },
     {
       "id": "group-46a28b03-5911-4005-a8c9-7cad0ce0119e",
@@ -160,15 +160,23 @@
       "source_node_id": "node-58da8456-480b-42bf-9fa3-5e5d5d828ab9",
       "transition_id": "needs_changes",
       "display_name": "Needs Changes",
-      "description": "Compliance review found release-publication violations; user approval required before rework."
+      "description": "Compliance review found release-publication violations; rework without manual approval."
     },
     {
       "id": "group-e62637be-c734-46f4-b4e1-accb7da7fbfe",
       "workflow_id": "workflow-04d0de0d-0820-4e56-b50b-45bd2cfe489e",
       "source_node_id": "node-58da8456-480b-42bf-9fa3-5e5d5d828ab9",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Compliance review is blocked by missing or contradictory required sources."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "compliance cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
+    },
+    {
+      "id": "group-f37b9c6f-0403-4457-ba52-65570383feb1",
+      "workflow_id": "workflow-04d0de0d-0820-4e56-b50b-45bd2cfe489e",
+      "source_node_id": "node-3c841aaf-089c-4df8-b04a-dce1cb807063",
+      "transition_id": "wont_do",
+      "display_name": "Wont Do",
+      "description": "Latest user comment explicitly cancels this legacy release task or declares it not planned; finish without treating it as a recoverable blocker."
     }
   ],
   "edges": [
@@ -183,7 +191,7 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Qualify a Puber release for publication.\n\nRead .kent/project-contract.md first, then use .kent/commands/release-tag.md as the project release-tag reference. Treat the task body as the requested version/tag policy. Fetch/check master/main and existing tags, compute the intended release tag, and verify readiness. Do not create or push tags in this node.\n\nComplete with tag when the release candidate is ready for user approval and provide release_version, release_tag, target_commit, and readiness_report. Complete with blocked if readiness cannot be proven and provide blocker_reason."
+      "prompt_template": "Qualify a Puber release for publication.\n\nRead .kent/project-contract.md first, then use .kent/commands/release-tag.md as the project release-tag reference. Treat the task body as the requested version/tag policy. Fetch/check master/main and existing tags, compute the intended release tag, and verify readiness. Do not create or push tags in this node.\n\nComplete with tag when the release candidate is ready for user approval and provide release_version, release_tag, target_commit, and readiness_report. Complete with needs_user_action if readiness cannot be proven and provide blocker_reason."
     },
     {
       "id": "edge-07f694ab-bbe6-4cce-a9f9-4e22138bedff",
@@ -196,19 +204,19 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Create and push the approved Puber release tag.\n\nRead .kent/project-contract.md first. Use .kent/commands/release-tag.md, but only for release {{.Params.release_version}}, tag {{.Params.release_tag}}, target commit {{.Params.target_commit}}. Verify the tag does not already exist locally/remotely unless the task explicitly says to handle that case. This node may create and push the tag because the workflow transition requires user approval.\n\nComplete with monitor if publication automation should be monitored and provide release_version, release_tag, target_commit, and tag_push_status. Complete with done if tag publication is complete and monitoring is intentionally skipped. Complete with blocked if tag creation/push is unsafe or blocked and provide blocker_reason.",
+      "prompt_template": "Create and push the approved Puber release tag.\n\nRead .kent/project-contract.md first. Use .kent/commands/release-tag.md, but only for release {{.Params.release_version}}, tag {{.Params.release_tag}}, target commit {{.Params.target_commit}}. Verify the tag does not already exist locally/remotely unless the task explicitly says to handle that case. This node may create and push the tag because the workflow transition requires user approval.\n\nComplete with monitor if publication automation should be monitored and provide release_version, release_tag, target_commit, and tag_push_status. Complete with compliance if tag publication is complete and monitoring is intentionally skipped. Complete with needs_user_action if tag creation/push is unsafe or needs_user_action and provide blocker_reason.",
       "parameters": [
         {
           "key": "release_version",
-          "description": "Release version to publish."
+          "description": "Release version prepared by this workflow."
         },
         {
           "key": "release_tag",
-          "description": "Git tag to create and push."
+          "description": "Release tag to create or publish after PR merge."
         },
         {
           "key": "target_commit",
-          "description": "Commit on master/main that should receive the release tag."
+          "description": "Target commit for release tag publication."
         },
         {
           "key": "readiness_report",
@@ -220,17 +228,18 @@
       "id": "edge-40682703-37a0-499e-a5b9-8467a8b57b6b",
       "workflow_id": "workflow-04d0de0d-0820-4e56-b50b-45bd2cfe489e",
       "transition_group_id": "group-78e65634-7646-4251-8f94-3c6fb4e80e74",
-      "key": "qualify_blocked",
-      "target_node_id": "node-1fa274d6-4f47-48f9-8a23-9ff39348b1cc",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "qualify_needs_user_action",
+      "target_node_id": "node-3c841aaf-089c-4df8-b04a-dce1cb807063",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this legacy Puber release workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog and do not broaden release scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why release qualification cannot continue, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -245,23 +254,23 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Monitor Puber release publication after tag push.\n\nRead .kent/project-contract.md first. Check available GitHub/CI/release automation signals for release {{.Params.release_tag}} when configured. If no automation is configured, report that monitoring is skipped. Complete with done if green or intentionally skipped; complete with blocked if automation fails or cannot be inspected and provide blocker_reason.",
+      "prompt_template": "Monitor Puber release publication after tag push.\n\nRead .kent/project-contract.md first. Check available GitHub/CI/release automation signals for release {{.Params.release_tag}} when configured. If no automation is configured, report that monitoring is skipped. Complete with compliance if green or intentionally skipped; complete with needs_user_action if automation fails or cannot be inspected and provide blocker_reason.",
       "parameters": [
         {
           "key": "release_version",
-          "description": "Release version published."
+          "description": "Release version prepared by this workflow."
         },
         {
           "key": "release_tag",
-          "description": "Git tag that was created and pushed."
+          "description": "Release tag to create or publish after PR merge."
         },
         {
           "key": "target_commit",
-          "description": "Commit targeted by the release tag."
+          "description": "Target commit for release tag publication."
         },
         {
           "key": "tag_push_status",
-          "description": "Result of local/remote tag creation and push."
+          "description": "Release tag push status."
         }
       ]
     },
@@ -269,26 +278,26 @@
       "id": "edge-f9f15045-4f17-4e2d-90ac-f71d6c9dcd8d",
       "workflow_id": "workflow-04d0de0d-0820-4e56-b50b-45bd2cfe489e",
       "transition_group_id": "group-4493b1e9-aa93-428f-a5a1-df9eca908189",
-      "key": "tag_done",
+      "key": "tag_compliance",
       "target_node_id": "node-58da8456-480b-42bf-9fa3-5e5d5d828ab9",
       "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Run mandatory Puber Compliance Review before cleanup.\n\nRead .kent/commands/compliance-review.md, .kent/commands/release-tag.md, .kent/project-contract.md, and AGENTS.md first. Reviewed scope: release publication for {{.Params.release_version}} tag {{.Params.release_tag}} target {{.Params.target_commit}}. Verify compliance with release approval gates, tag policy, task requirements, and AGENTS.md. Do not edit files.\n\nComplete with done and provide compliance_report when no compliance violations are found. Complete with needs_changes and provide release_version, release_tag, target_commit, and compliance_report when rework is required. Complete with blocked and provide blocker_reason if required sources are missing or contradictory.",
+      "prompt_template": "Run mandatory Puber Compliance Review before cleanup.\n\nRead .kent/commands/compliance-review.md, .kent/commands/release-tag.md, .kent/project-contract.md, and AGENTS.md first. Reviewed scope: release publication for {{.Params.release_version}} tag {{.Params.release_tag}} target {{.Params.target_commit}}. Verify compliance with release approval gates, tag policy, task requirements, and AGENTS.md. Do not edit files.\n\nComplete with cleanup and provide compliance_report when no compliance violations are found. Complete with needs_changes and provide release_version, release_tag, target_commit, and compliance_report when rework is required. Complete with needs_user_action and provide blocker_reason if required sources are missing or contradictory.",
       "parameters": [
         {
           "key": "release_version",
-          "description": "Release version published."
+          "description": "Release version prepared by this workflow."
         },
         {
           "key": "release_tag",
-          "description": "Git tag that was created and pushed."
+          "description": "Release tag to create or publish after PR merge."
         },
         {
           "key": "target_commit",
-          "description": "Commit targeted by the release tag."
+          "description": "Target commit for release tag publication."
         }
       ]
     },
@@ -296,17 +305,18 @@
       "id": "edge-02e26583-ff31-463d-b20e-78855de34f36",
       "workflow_id": "workflow-04d0de0d-0820-4e56-b50b-45bd2cfe489e",
       "transition_group_id": "group-eeceacea-a2d9-4349-a866-93b29d3a63a7",
-      "key": "tag_blocked",
-      "target_node_id": "node-1fa274d6-4f47-48f9-8a23-9ff39348b1cc",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "tag_needs_user_action",
+      "target_node_id": "node-34e4131d-97ab-4b9b-b099-2c2cecea8085",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this legacy Puber release workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog and do not broaden release scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why tag publication cannot continue, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -314,26 +324,26 @@
       "id": "edge-101b7816-ae11-4e89-82e2-cf794c1736fc",
       "workflow_id": "workflow-04d0de0d-0820-4e56-b50b-45bd2cfe489e",
       "transition_group_id": "group-e195bee8-ea10-4a6c-b2a1-b94484c0c6a3",
-      "key": "monitor_done",
+      "key": "monitor_compliance",
       "target_node_id": "node-58da8456-480b-42bf-9fa3-5e5d5d828ab9",
       "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Run mandatory Puber Compliance Review before cleanup.\n\nRead .kent/commands/compliance-review.md, .kent/commands/release-tag.md, .kent/project-contract.md, and AGENTS.md first. Reviewed scope: release publication and monitoring for {{.Params.release_version}} tag {{.Params.release_tag}} target {{.Params.target_commit}}. Verify compliance with release approval gates, tag/monitoring policy, task requirements, and AGENTS.md. Do not edit files.\n\nComplete with done and provide compliance_report when no compliance violations are found. Complete with needs_changes and provide release_version, release_tag, target_commit, and compliance_report when rework is required. Complete with blocked and provide blocker_reason if required sources are missing or contradictory.",
+      "prompt_template": "Run mandatory Puber Compliance Review before cleanup.\n\nRead .kent/commands/compliance-review.md, .kent/commands/release-tag.md, .kent/project-contract.md, and AGENTS.md first. Reviewed scope: release publication and monitoring for {{.Params.release_version}} tag {{.Params.release_tag}} target {{.Params.target_commit}}. Verify compliance with release approval gates, tag/monitoring policy, task requirements, and AGENTS.md. Do not edit files.\n\nComplete with cleanup and provide compliance_report when no compliance violations are found. Complete with needs_changes and provide release_version, release_tag, target_commit, and compliance_report when rework is required. Complete with needs_user_action and provide blocker_reason if required sources are missing or contradictory.",
       "parameters": [
         {
           "key": "release_version",
-          "description": "Release version published."
+          "description": "Release version prepared by this workflow."
         },
         {
           "key": "release_tag",
-          "description": "Git tag that was created and pushed."
+          "description": "Release tag to create or publish after PR merge."
         },
         {
           "key": "target_commit",
-          "description": "Commit targeted by the release tag."
+          "description": "Target commit for release tag publication."
         }
       ]
     },
@@ -341,17 +351,18 @@
       "id": "edge-b0571df0-3f45-486a-bb93-a12d1590bb39",
       "workflow_id": "workflow-04d0de0d-0820-4e56-b50b-45bd2cfe489e",
       "transition_group_id": "group-26956053-2530-465c-ad7a-83f8b86b4fee",
-      "key": "monitor_blocked",
-      "target_node_id": "node-1fa274d6-4f47-48f9-8a23-9ff39348b1cc",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "monitor_needs_user_action",
+      "target_node_id": "node-65c09083-e828-4029-a1c9-a4f0f907e106",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this legacy Puber release workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog and do not broaden release scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why release monitoring cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -369,7 +380,7 @@
       "parameters": [
         {
           "key": "cleanup_report",
-          "description": "Summary of cleanup performed or deliberately skipped."
+          "description": "Cleanup report or summary."
         }
       ]
     },
@@ -377,7 +388,7 @@
       "id": "edge-15ab221d-c71a-4ce4-9b4d-cf5eacca6e4a",
       "workflow_id": "workflow-04d0de0d-0820-4e56-b50b-45bd2cfe489e",
       "transition_group_id": "group-b04eeac3-7951-4456-a670-cb5452178b2b",
-      "key": "compliance_done",
+      "key": "compliance_cleanup",
       "target_node_id": "node-5b384301-9ead-4397-8b64-478b972587c0",
       "requires_approval": false,
       "context_mode": "new_session",
@@ -388,7 +399,7 @@
       "parameters": [
         {
           "key": "compliance_report",
-          "description": "Compliance review report, including rule sources checked and any findings."
+          "description": "Compliance review report or summary."
         }
       ]
     },
@@ -398,28 +409,28 @@
       "transition_group_id": "group-46a28b03-5911-4005-a8c9-7cad0ce0119e",
       "key": "compliance_tag",
       "target_node_id": "node-34e4131d-97ab-4b9b-b099-2c2cecea8085",
-      "requires_approval": true,
+      "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Rework Puber release publication compliance findings only.\n\nRead .kent/project-contract.md, .kent/commands/release-tag.md, and .kent/commands/compliance-review.md first. Apply only the minimum approved changes required by {{.Params.compliance_report}} for release {{.Params.release_version}} tag {{.Params.release_tag}} target {{.Params.target_commit}}. Do not create, delete, or push tags unless the approval and task explicitly authorize it. Complete with monitor, done, or blocked according to the release-publication workflow contract.",
+      "prompt_template": "Rework Puber release publication compliance findings only.\n\nRead .kent/project-contract.md, .kent/commands/release-tag.md, and .kent/commands/compliance-review.md first. Apply only the minimum approved changes required by {{.Params.compliance_report}} for release {{.Params.release_version}} tag {{.Params.release_tag}} target {{.Params.target_commit}}. Do not create, delete, or push tags unless the approval and task explicitly authorize it. Complete with monitor, done, or needs_user_action according to the release-publication workflow contract.\n\nFor any needs_user_action transition, provide blocker_reason with the exact next user or external action needed.",
       "parameters": [
         {
           "key": "release_version",
-          "description": "Release version published."
+          "description": "Release version prepared by this workflow."
         },
         {
           "key": "release_tag",
-          "description": "Git tag that was created and pushed."
+          "description": "Release tag to create or publish after PR merge."
         },
         {
           "key": "target_commit",
-          "description": "Commit targeted by the release tag."
+          "description": "Target commit for release tag publication."
         },
         {
           "key": "compliance_report",
-          "description": "Compliance review report, including rule sources checked and any findings."
+          "description": "Compliance review report or summary."
         }
       ]
     },
@@ -427,17 +438,36 @@
       "id": "edge-25120bc8-11b4-4c86-8cf5-aebab6c79b92",
       "workflow_id": "workflow-04d0de0d-0820-4e56-b50b-45bd2cfe489e",
       "transition_group_id": "group-e62637be-c734-46f4-b4e1-accb7da7fbfe",
-      "key": "compliance_blocked",
+      "key": "compliance_needs_user_action",
+      "target_node_id": "node-58da8456-480b-42bf-9fa3-5e5d5d828ab9",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
+      "context_source": {
+        "kind": "immediate_source"
+      },
+      "prompt_template": "Resume this legacy Puber release workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog and do not broaden release scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker.",
+      "parameters": [
+        {
+          "key": "blocker_reason",
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+        }
+      ]
+    },
+    {
+      "id": "edge-d8ee127d-2b1f-4b31-86db-0ec8ea06c5fe",
+      "workflow_id": "workflow-04d0de0d-0820-4e56-b50b-45bd2cfe489e",
+      "transition_group_id": "group-f37b9c6f-0403-4457-ba52-65570383feb1",
+      "key": "qualify_wont_do",
       "target_node_id": "node-1fa274d6-4f47-48f9-8a23-9ff39348b1cc",
-      "requires_approval": false,
+      "requires_approval": true,
       "context_mode": "new_session",
       "context_source": {
         "kind": "immediate_source"
       },
       "parameters": [
         {
-          "key": "blocker_reason",
-          "description": "Why compliance review cannot complete, in the task language when practical."
+          "key": "closure_reason",
+          "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
         }
       ]
     }
@@ -452,15 +482,15 @@
         "possible_provision_fields": [
           {
             "name": "release_version",
-            "description": "Release version to publish."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_tag",
-            "description": "Git tag to create and push."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
             "name": "target_commit",
-            "description": "Commit on master/main that should receive the release tag."
+            "description": "Target commit for release tag publication."
           },
           {
             "name": "readiness_report",
@@ -468,7 +498,11 @@
           },
           {
             "name": "blocker_reason",
-            "description": "Why release qualification cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          },
+          {
+            "name": "closure_reason",
+            "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
           }
         ]
       },
@@ -477,23 +511,23 @@
         "possible_provision_fields": [
           {
             "name": "release_version",
-            "description": "Release version published."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_tag",
-            "description": "Git tag that was created and pushed."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
             "name": "target_commit",
-            "description": "Commit targeted by the release tag."
+            "description": "Target commit for release tag publication."
           },
           {
             "name": "tag_push_status",
-            "description": "Result of local/remote tag creation and push."
+            "description": "Release tag push status."
           },
           {
             "name": "blocker_reason",
-            "description": "Why tag publication cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -502,19 +536,19 @@
         "possible_provision_fields": [
           {
             "name": "release_version",
-            "description": "Release version published."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_tag",
-            "description": "Git tag that was created and pushed."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
             "name": "target_commit",
-            "description": "Commit targeted by the release tag."
+            "description": "Target commit for release tag publication."
           },
           {
             "name": "blocker_reason",
-            "description": "Why release monitoring cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -523,7 +557,7 @@
         "possible_provision_fields": [
           {
             "name": "cleanup_report",
-            "description": "Summary of cleanup performed or deliberately skipped."
+            "description": "Cleanup report or summary."
           }
         ]
       },
@@ -535,23 +569,23 @@
         "possible_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           },
           {
             "name": "release_version",
-            "description": "Release version published."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_tag",
-            "description": "Git tag that was created and pushed."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
             "name": "target_commit",
-            "description": "Commit targeted by the release tag."
+            "description": "Target commit for release tag publication."
           },
           {
             "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -568,15 +602,15 @@
         "required_provision_fields": [
           {
             "name": "release_version",
-            "description": "Release version to publish."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_tag",
-            "description": "Git tag to create and push."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
             "name": "target_commit",
-            "description": "Commit on master/main that should receive the release tag."
+            "description": "Target commit for release tag publication."
           },
           {
             "name": "readiness_report",
@@ -589,7 +623,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why release qualification cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -598,19 +632,19 @@
         "required_provision_fields": [
           {
             "name": "release_version",
-            "description": "Release version published."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_tag",
-            "description": "Git tag that was created and pushed."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
             "name": "target_commit",
-            "description": "Commit targeted by the release tag."
+            "description": "Target commit for release tag publication."
           },
           {
             "name": "tag_push_status",
-            "description": "Result of local/remote tag creation and push."
+            "description": "Release tag push status."
           }
         ]
       },
@@ -619,15 +653,15 @@
         "required_provision_fields": [
           {
             "name": "release_version",
-            "description": "Release version published."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_tag",
-            "description": "Git tag that was created and pushed."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
             "name": "target_commit",
-            "description": "Commit targeted by the release tag."
+            "description": "Target commit for release tag publication."
           }
         ]
       },
@@ -636,7 +670,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why tag publication cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -645,15 +679,15 @@
         "required_provision_fields": [
           {
             "name": "release_version",
-            "description": "Release version published."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_tag",
-            "description": "Git tag that was created and pushed."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
             "name": "target_commit",
-            "description": "Commit targeted by the release tag."
+            "description": "Target commit for release tag publication."
           }
         ]
       },
@@ -662,7 +696,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why release monitoring cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -671,7 +705,7 @@
         "required_provision_fields": [
           {
             "name": "cleanup_report",
-            "description": "Summary of cleanup performed or deliberately skipped."
+            "description": "Cleanup report or summary."
           }
         ]
       },
@@ -680,7 +714,7 @@
         "required_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -689,19 +723,19 @@
         "required_provision_fields": [
           {
             "name": "release_version",
-            "description": "Release version published."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_tag",
-            "description": "Git tag that was created and pushed."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
             "name": "target_commit",
-            "description": "Commit targeted by the release tag."
+            "description": "Target commit for release tag publication."
           },
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -710,7 +744,16 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          }
+        ]
+      },
+      {
+        "transition_group_id": "group-f37b9c6f-0403-4457-ba52-65570383feb1",
+        "required_provision_fields": [
+          {
+            "name": "closure_reason",
+            "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
           }
         ]
       }
@@ -746,15 +789,15 @@
         "required_provision_fields": [
           {
             "name": "release_version",
-            "description": "Release version to publish."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_tag",
-            "description": "Git tag to create and push."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
             "name": "target_commit",
-            "description": "Commit on master/main that should receive the release tag."
+            "description": "Target commit for release tag publication."
           },
           {
             "name": "readiness_report",
@@ -774,7 +817,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why release qualification cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -805,19 +848,19 @@
         "required_provision_fields": [
           {
             "name": "release_version",
-            "description": "Release version published."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_tag",
-            "description": "Git tag that was created and pushed."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
             "name": "target_commit",
-            "description": "Commit targeted by the release tag."
+            "description": "Target commit for release tag publication."
           },
           {
             "name": "tag_push_status",
-            "description": "Result of local/remote tag creation and push."
+            "description": "Release tag push status."
           }
         ]
       },
@@ -843,15 +886,15 @@
         "required_provision_fields": [
           {
             "name": "release_version",
-            "description": "Release version published."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_tag",
-            "description": "Git tag that was created and pushed."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
             "name": "target_commit",
-            "description": "Commit targeted by the release tag."
+            "description": "Target commit for release tag publication."
           }
         ]
       },
@@ -867,7 +910,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why tag publication cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -893,15 +936,15 @@
         "required_provision_fields": [
           {
             "name": "release_version",
-            "description": "Release version published."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_tag",
-            "description": "Git tag that was created and pushed."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
             "name": "target_commit",
-            "description": "Commit targeted by the release tag."
+            "description": "Target commit for release tag publication."
           }
         ]
       },
@@ -917,7 +960,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why release monitoring cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -933,7 +976,7 @@
         "required_provision_fields": [
           {
             "name": "cleanup_report",
-            "description": "Summary of cleanup performed or deliberately skipped."
+            "description": "Cleanup report or summary."
           }
         ]
       },
@@ -949,7 +992,7 @@
         "required_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -980,19 +1023,19 @@
         "required_provision_fields": [
           {
             "name": "release_version",
-            "description": "Release version published."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_tag",
-            "description": "Git tag that was created and pushed."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
             "name": "target_commit",
-            "description": "Commit targeted by the release tag."
+            "description": "Target commit for release tag publication."
           },
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -1008,7 +1051,23 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-d8ee127d-2b1f-4b31-86db-0ec8ea06c5fe",
+        "input_bindings": [
+          {
+            "name": "closure_reason",
+            "source": "transition_output",
+            "field": "closure_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "closure_reason",
+            "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
           }
         ]
       }

--- a/.kent/workflows/puber-release.json
+++ b/.kent/workflows/puber-release.json
@@ -3,7 +3,7 @@
     "id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
     "name": "Puber Release",
     "description": "Prepare the next Puber release, create the version bump PR, monitor CI, then publish the release tag after approval.",
-    "version": 77
+    "version": 158
   },
   "nodes": [
     {
@@ -79,9 +79,18 @@
     {
       "id": "node-a19c6feb-2c82-4c67-960a-31ee75b785d2",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
-      "key": "blocked",
+      "key": "wont_do",
       "kind": "terminal",
-      "display_name": "Blocked"
+      "display_name": "Won't Do"
+    },
+    {
+      "id": "node-c0d75fb3-8a2c-4109-b0b0-89afb43ace0a",
+      "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
+      "key": "waiting_pr",
+      "kind": "agent",
+      "display_name": "Waiting PR",
+      "subagent_role": "default",
+      "completion_mode": "shell_command"
     },
     {
       "id": "node-0ebf8742-e371-440f-97e2-fc3834a09906",
@@ -112,17 +121,17 @@
       "id": "group-56664f3b-6775-49a3-ae9e-add3a2147898",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
       "source_node_id": "node-86293208-dd6b-4ff6-89d4-d6567a8b4e55",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Release preparation is blocked."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "prepare cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-5dbd9798-10f9-431c-9e7b-24d3f3beb4f5",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
       "source_node_id": "node-77c2b3c6-04e4-4e03-a964-2aa5c47259c8",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "Compliance passed; create or update the release PR."
+      "transition_id": "ship_pr",
+      "display_name": "Ship PR",
+      "description": "Compliance passed; create or update the task PR before any terminal completion."
     },
     {
       "id": "group-59b9cc45-ff33-41ef-8b2f-16aaa02c6316",
@@ -136,9 +145,9 @@
       "id": "group-17cc1920-c194-4013-bfd8-0eaaa8df78f7",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
       "source_node_id": "node-77c2b3c6-04e4-4e03-a964-2aa5c47259c8",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Compliance review is blocked."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "compliance cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-924268b7-ec8c-4dfc-8c41-9a2030ad9fd2",
@@ -152,17 +161,17 @@
       "id": "group-986d01ca-05b8-473d-bf17-9bfa81b5669a",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
       "source_node_id": "node-b72f177e-2ffe-4bf9-a018-ba65361119fa",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Release PR creation or update is blocked."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "ship_pr cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-0583145f-ec64-45d3-a77f-3fbcb06990d6",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
       "source_node_id": "node-8497fa66-4fc6-457d-8c0b-7e1da150bd26",
-      "transition_id": "publish",
-      "display_name": "Publish",
-      "description": "Release PR checks passed; user approval required before tag publication. Approve only after the PR is merged into master."
+      "transition_id": "waiting_pr",
+      "display_name": "Waiting PR",
+      "description": "Release PR CI passed or was intentionally skipped; wait until the PR is merged before tag publication."
     },
     {
       "id": "group-c9c24869-2449-482e-b2aa-fe13a359295f",
@@ -176,9 +185,9 @@
       "id": "group-a16f76de-f9fb-4dda-b276-120863bf1005",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
       "source_node_id": "node-8497fa66-4fc6-457d-8c0b-7e1da150bd26",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Release PR CI monitoring is blocked."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "ci_monitor cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-2d2a3e16-2d20-4774-81c4-1f116cd43f40",
@@ -192,25 +201,25 @@
       "id": "group-e3ddd61b-3b97-4e7e-ad1a-4b1b47d4e3e1",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
       "source_node_id": "node-feeb41cd-253b-401b-add9-888b0237abe9",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Release tag publication is blocked."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "publish cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-901a4611-3b31-4a54-804e-6294786e30e2",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
       "source_node_id": "node-f5349410-9178-4fb1-a909-0b5dad73cfe4",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "Release tag publication and monitoring completed; run conservative cleanup."
+      "transition_id": "release_published",
+      "display_name": "Release Published",
+      "description": "Release tag/publication was completed and monitored; cleanup can finish the task."
     },
     {
       "id": "group-008b5b03-50eb-4276-a01a-f34c75ce4be6",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
       "source_node_id": "node-f5349410-9178-4fb1-a909-0b5dad73cfe4",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Release automation monitoring is blocked."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "monitor cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-79b1b062-9b8f-4598-8a9f-2ff1b3fdf1ec",
@@ -221,14 +230,6 @@
       "description": "Cleanup report is ready; finish the release task."
     },
     {
-      "id": "group-a8b20339-ff99-40a1-ae5c-52eee6de1f0c",
-      "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
-      "source_node_id": "node-77c2b3c6-04e4-4e03-a964-2aa5c47259c8",
-      "transition_id": "retry_later",
-      "display_name": "Retry Later",
-      "description": "Required compliance sources or user context are temporarily unavailable; user approval required before retrying review."
-    },
-    {
       "id": "group-e21a073b-10f2-402b-94e5-8b1239288c6a",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
       "source_node_id": "node-b72f177e-2ffe-4bf9-a018-ba65361119fa",
@@ -237,36 +238,44 @@
       "description": "Release PR creation/update hit a recoverable branch, rebase, conflict, push, or metadata issue; user approval required before recovery work."
     },
     {
-      "id": "group-bc018baf-d599-4df5-a3f4-b6e992f46491",
+      "id": "group-a7e0dff6-2d65-45b5-a937-fa2ae9db916c",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
-      "source_node_id": "node-8497fa66-4fc6-457d-8c0b-7e1da150bd26",
-      "transition_id": "retry_later",
-      "display_name": "Retry Later",
-      "description": "Release CI or GitHub is temporarily unavailable, still starting, or missing an expected run; user approval required before retrying monitoring."
+      "source_node_id": "node-c0d75fb3-8a2c-4109-b0b0-89afb43ace0a",
+      "transition_id": "pr_merged",
+      "display_name": "Pr Merged",
+      "description": "Release PR is merged; publish the approved tag after human approval."
     },
     {
-      "id": "group-c1e0d59b-b781-4d62-9ffc-ee47fabdfe95",
+      "id": "group-def5967b-a961-4139-b2ac-fea582269726",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
-      "source_node_id": "node-feeb41cd-253b-401b-add9-888b0237abe9",
-      "transition_id": "not_ready",
-      "display_name": "Not Ready",
-      "description": "Tag publication was approved before the release PR was merged or visible on origin/master; return to release PR monitoring after user action."
+      "source_node_id": "node-c0d75fb3-8a2c-4109-b0b0-89afb43ace0a",
+      "transition_id": "needs_changes",
+      "display_name": "Needs Changes",
+      "description": "Release PR needs task-scoped changes before it can be merged."
     },
     {
-      "id": "group-5871795e-997a-4747-ae57-c74588cabd1d",
+      "id": "group-668bcce6-ceef-498a-a66f-c0bcbb9b9f0e",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
-      "source_node_id": "node-feeb41cd-253b-401b-add9-888b0237abe9",
-      "transition_id": "retry_later",
-      "display_name": "Retry Later",
-      "description": "Release tag publication hit a temporary external availability issue; user approval required before retrying publication."
+      "source_node_id": "node-c0d75fb3-8a2c-4109-b0b0-89afb43ace0a",
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "Release PR is still waiting on a human or external process; remain in Waiting PR."
     },
     {
-      "id": "group-94f3424d-ea81-4e04-b33f-d79fcb548a83",
+      "id": "group-eeb67e0b-9098-4591-acf4-f5bd1d23fa30",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
-      "source_node_id": "node-f5349410-9178-4fb1-a909-0b5dad73cfe4",
-      "transition_id": "retry_later",
-      "display_name": "Retry Later",
-      "description": "Release automation is still starting or temporarily unavailable; user approval required before retrying monitoring."
+      "source_node_id": "node-c0d75fb3-8a2c-4109-b0b0-89afb43ace0a",
+      "transition_id": "close_without_merge",
+      "display_name": "Close Without Merge",
+      "description": "User explicitly canceled the release PR without merge; cleanup can finish."
+    },
+    {
+      "id": "group-c2158ca7-1390-49c6-b7be-149f04b70e56",
+      "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
+      "source_node_id": "node-86293208-dd6b-4ff6-89d4-d6567a8b4e55",
+      "transition_id": "wont_do",
+      "display_name": "Wont Do",
+      "description": "Latest user comment explicitly cancels this task or declares it not planned; finish without treating it as a recoverable blocker."
     }
   ],
   "edges": [
@@ -281,7 +290,7 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Run the Puber one-flow release process.\n\nRead .kent/project-contract.md, .kent/commands/release-branch.md, .kent/commands/release-tag.md, and AGENTS.md first. Treat the task body as release intent. Default to next minor release from origin/master. Use patch only when explicitly requested; use major only when explicitly requested. If .kent/commands/release.md exists, use it as supplementary unified guidance, but do not block solely because that file is absent.\n\nFetch origin/master and tags, compute the target version, create or reuse release/<version>, update app/build.gradle.kts currentVersion, commit the bump, and verify with focused compile checks. If local release signing secrets are unavailable, record that production packaging could not be locally proven, but do not block the version-bump PR solely for missing local signing secrets. Do not create or push a release tag in this node.\n\nComplete with compliance when the version bump branch is ready and provide release_version, release_type, release_branch, release_tag, workspace_path, version_bump_commit, and verification_summary. Complete with blocked and provide blocker_reason if the release cannot be prepared safely."
+      "prompt_template": "Run the Puber one-flow release process.\n\nRead .kent/project-contract.md, .kent/commands/release-branch.md, .kent/commands/release-tag.md, and AGENTS.md first. Treat the task body as release intent. Default to next minor release from origin/master. Use patch only when explicitly requested; use major only when explicitly requested. If .kent/commands/release.md exists, use it as supplementary unified guidance, but do not block solely because that file is absent.\n\nFetch origin/master and tags, compute the target version, create or reuse release/<version>, update app/build.gradle.kts currentVersion, commit the bump, and verify with focused compile checks. If local release signing secrets are unavailable, record that production packaging could not be locally proven, but do not block the version-bump PR solely for missing local signing secrets. Do not create or push a release tag in this node.\n\nComplete with compliance when the version bump branch is ready and provide release_version, release_type, release_branch, release_tag, workspace_path, version_bump_commit, and verification_summary. Complete with needs_user_action and provide blocker_reason if the release cannot be prepared safely."
     },
     {
       "id": "edge-94356a5f-0d82-4353-a5bd-cf00d8c420fb",
@@ -294,11 +303,11 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Run mandatory Puber Compliance Review for the prepared release.\n\nRead .kent/commands/compliance-review.md, .kent/project-contract.md, .kent/commands/release-branch.md, .kent/commands/release-tag.md, and AGENTS.md first. If .kent/commands/release.md exists, use it as supplementary unified guidance, but do not block solely because that file is absent. Reviewed scope: release {{.Params.release_version}} ({{.Params.release_type}}) on branch {{.Params.release_branch}} in workspace {{.Params.workspace_path}}, commit {{.Params.version_bump_commit}}, intended tag {{.Params.release_tag}}, verification {{.Params.verification_summary}}. Review only compliance with release rules, task requirements, AGENTS.md, and workflow contract. Do not edit files.\n\nComplete with done and provide compliance_report when no compliance violations are found. Complete with needs_changes and provide workspace_path plus compliance_report when release preparation must be fixed. Complete with retry_later when required sources or user-provided context are temporarily unavailable and provide release_version, release_type, release_branch, release_tag, workspace_path, version_bump_commit, verification_summary, and blocker_reason. Complete with blocked only if required sources are contradictory or continuing would be unsafe; provide blocker_reason.",
+      "prompt_template": "Run mandatory Puber Compliance Review for the prepared release.\n\nRead .kent/commands/compliance-review.md, .kent/project-contract.md, .kent/commands/release-branch.md, .kent/commands/release-tag.md, and AGENTS.md first. If .kent/commands/release.md exists, use it as supplementary unified guidance, but do not block solely because that file is absent. Reviewed scope: release {{.Params.release_version}} ({{.Params.release_type}}) on branch {{.Params.release_branch}} in workspace {{.Params.workspace_path}}, commit {{.Params.version_bump_commit}}, intended tag {{.Params.release_tag}}, verification {{.Params.verification_summary}}. Review only compliance with release rules, task requirements, AGENTS.md, and workflow contract. Do not edit files.\n\nComplete with ship_pr and provide compliance_report when no compliance violations are found. Complete with needs_changes and provide workspace_path plus compliance_report when release preparation must be fixed. Complete with needs_user_action for temporary external waits; provide blocker_reason. Complete with needs_user_action only if required sources are contradictory or continuing would be unsafe; provide blocker_reason.",
       "parameters": [
         {
           "key": "release_version",
-          "description": "Prepared release version, for example 1.4.0."
+          "description": "Release version prepared by this workflow."
         },
         {
           "key": "release_type",
@@ -310,11 +319,11 @@
         },
         {
           "key": "release_tag",
-          "description": "Release tag that should be created after the PR is merged, for example v1.4.0."
+          "description": "Release tag to create or publish after PR merge."
         },
         {
           "key": "workspace_path",
-          "description": "Path to the worktree or checkout containing the release bump."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "version_bump_commit",
@@ -330,17 +339,18 @@
       "id": "edge-9fd4165c-01fa-4291-b134-eb11981b5896",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
       "transition_group_id": "group-56664f3b-6775-49a3-ae9e-add3a2147898",
-      "key": "prepare_blocked",
-      "target_node_id": "node-a19c6feb-2c82-4c67-960a-31ee75b785d2",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "prepare_needs_user_action",
+      "target_node_id": "node-86293208-dd6b-4ff6-89d4-d6567a8b4e55",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why release preparation cannot continue, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -348,18 +358,18 @@
       "id": "edge-05335457-6fbd-4556-9bc8-1a0ddfa17f52",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
       "transition_group_id": "group-5dbd9798-10f9-431c-9e7b-24d3f3beb4f5",
-      "key": "compliance_done",
+      "key": "compliance_ship_pr",
       "target_node_id": "node-b72f177e-2ffe-4bf9-a018-ba65361119fa",
       "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Create or update the Puber release version-bump PR.\n\nRead .kent/project-contract.md, .kent/commands/ship-pr.md, .kent/commands/release-branch.md, .kent/commands/release-tag.md, and AGENTS.md first. If .kent/commands/release.md exists, use it as supplementary unified guidance, but do not block solely because that file is absent. Compliance result: {{.Params.compliance_report}}. Release context from preparation: version {{.Params.compliance.release_version}}, type {{.Params.compliance.release_type}}, branch {{.Params.compliance.release_branch}}, tag {{.Params.compliance.release_tag}}, workspace {{.Params.compliance.workspace_path}}.\n\nCommit only release-task changes if anything remains uncommitted, push {{.Params.compliance.release_branch}} to origin, and create or update a GitHub PR for the version bump. Do not merge the PR. Do not push directly to master. Do not create or push a release tag in this node.\n\nComplete with monitor_ci when a PR exists and provide pr_url, branch_name, workspace_path, release_version, and release_tag. Complete with needs_changes when PR creation/update is blocked by recoverable branch, rebase, conflict, push, or PR metadata state; provide workspace_path, release_version, release_type, release_branch, release_tag, and blocker_reason. Complete with blocked only if PR creation/update cannot continue safely without changing release scope, credentials, or project policy; provide blocker_reason.",
+      "prompt_template": "Create or update the Puber release version-bump PR.\n\nRead .kent/project-contract.md, .kent/commands/ship-pr.md, .kent/commands/release-branch.md, .kent/commands/release-tag.md, and AGENTS.md first. If .kent/commands/release.md exists, use it as supplementary unified guidance, but do not block solely because that file is absent. Compliance result: {{.Params.compliance_report}}. Release context from preparation: version {{.Params.compliance.release_version}}, type {{.Params.compliance.release_type}}, branch {{.Params.compliance.release_branch}}, tag {{.Params.compliance.release_tag}}, workspace {{.Params.compliance.workspace_path}}.\n\nCommit only release-task changes if anything remains uncommitted, push {{.Params.compliance.release_branch}} to origin, and create or update a GitHub PR for the version bump. Do not merge the PR. Do not push directly to master. Do not create or push a release tag in this node.\n\nComplete with monitor_ci when a PR exists and provide pr_url, branch_name, workspace_path, release_version, and release_tag. Complete with needs_changes when PR creation/update is needs_user_action by recoverable branch, rebase, conflict, push, or PR metadata state; provide workspace_path, release_version, release_type, release_branch, release_tag, and blocker_reason. Complete with needs_user_action only if PR creation/update cannot continue safely without changing release scope, credentials, or project policy; provide blocker_reason.",
       "parameters": [
         {
           "key": "compliance_report",
-          "description": "Compliance review report, including rule sources checked and any findings."
+          "description": "Compliance review report or summary."
         }
       ]
     },
@@ -369,20 +379,20 @@
       "transition_group_id": "group-59b9cc45-ff33-41ef-8b2f-16aaa02c6316",
       "key": "compliance_fix",
       "target_node_id": "node-86293208-dd6b-4ff6-89d4-d6567a8b4e55",
-      "requires_approval": true,
+      "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Fix Puber release preparation compliance violations only.\n\nRead .kent/project-contract.md, .kent/commands/release-branch.md, .kent/commands/release-tag.md, and .kent/commands/compliance-review.md first. If .kent/commands/release.md exists, use it as supplementary unified guidance, but do not block solely because that file is absent. Apply only the minimum changes required by {{.Params.compliance_report}} in workspace {{.Params.workspace_path}}. Verify narrowly, then complete with compliance and provide release_version, release_type, release_branch, release_tag, workspace_path, version_bump_commit, and verification_summary. Complete with blocked and provide blocker_reason if unsafe or missing input.",
+      "prompt_template": "Fix Puber release preparation compliance violations only.\n\nRead .kent/project-contract.md, .kent/commands/release-branch.md, .kent/commands/release-tag.md, and .kent/commands/compliance-review.md first. If .kent/commands/release.md exists, use it as supplementary unified guidance, but do not block solely because that file is absent. Apply only the minimum changes required by {{.Params.compliance_report}} in workspace {{.Params.workspace_path}}. Verify narrowly, then complete with compliance and provide release_version, release_type, release_branch, release_tag, workspace_path, version_bump_commit, and verification_summary. Complete with needs_user_action and provide blocker_reason if unsafe or missing input.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the worktree or checkout containing the release bump."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "compliance_report",
-          "description": "Compliance review report, including rule sources checked and any findings."
+          "description": "Compliance review report or summary."
         }
       ]
     },
@@ -390,17 +400,18 @@
       "id": "edge-97bb2c4a-612b-4884-b9c4-e9693cfa6f18",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
       "transition_group_id": "group-17cc1920-c194-4013-bfd8-0eaaa8df78f7",
-      "key": "compliance_blocked",
-      "target_node_id": "node-a19c6feb-2c82-4c67-960a-31ee75b785d2",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "compliance_needs_user_action",
+      "target_node_id": "node-77c2b3c6-04e4-4e03-a964-2aa5c47259c8",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why compliance review cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -415,19 +426,19 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Monitor the Puber release PR checks.\n\nRead .kent/project-contract.md, .kent/commands/release-branch.md, and .kent/commands/release-tag.md first. If .kent/commands/release.md exists, use it as supplementary unified guidance, but do not block solely because that file is absent. Inspect PR {{.Params.pr_url}} for release {{.Params.release_version}} / tag {{.Params.release_tag}} on branch {{.Params.branch_name}}. Use GitHub CLI when available. Do not merge the PR. Do not push new commits from this node.\n\nComplete with publish when checks pass or are intentionally absent; this transition requires user approval before tag publication. Provide pr_url, release_version, release_tag, branch_name, workspace_path, and ci_report. Complete with needs_changes if checks failed due to release changes and provide workspace_path plus ci_report. Complete with retry_later when checks cannot be inspected because GitHub/CI is still starting, rate-limited, temporarily unavailable, or an expected run has not appeared yet; provide pr_url, release_version, release_tag, branch_name, workspace_path, and ci_report. Complete with blocked only if checks cannot be inspected and retrying would be unsafe or misleading; provide blocker_reason.",
+      "prompt_template": "Monitor the Puber release PR checks.\n\nRead .kent/project-contract.md, .kent/commands/release-branch.md, and .kent/commands/release-tag.md first. If .kent/commands/release.md exists, use it as supplementary unified guidance, but do not block solely because that file is absent. Inspect PR {{.Params.pr_url}} for release {{.Params.release_version}} / tag {{.Params.release_tag}} on branch {{.Params.branch_name}}. Use GitHub CLI when available. Do not merge the PR. Do not push new commits from this node.\n\nComplete with publish when checks pass or are intentionally absent; this transition requires user approval before tag publication. Provide pr_url, release_version, release_tag, branch_name, workspace_path, and ci_report. Complete with needs_changes if checks failed due to release changes and provide workspace_path plus ci_report. Complete with needs_user_action for temporary external waits; provide blocker_reason. Complete with needs_user_action only if checks cannot be inspected and retrying would be unsafe or misleading; provide blocker_reason.",
       "parameters": [
         {
           "key": "pr_url",
-          "description": "URL of the release pull request."
+          "description": "URL of the created, updated, or monitored pull request."
         },
         {
           "key": "branch_name",
-          "description": "Name of the pushed release branch."
+          "description": "Name of the task or release branch associated with the pull request."
         },
         {
           "key": "workspace_path",
-          "description": "Path to the worktree or checkout used for PR creation."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "release_version",
@@ -435,7 +446,7 @@
         },
         {
           "key": "release_tag",
-          "description": "Release tag to create after the PR is merged."
+          "description": "Release tag to create or publish after PR merge."
         }
       ]
     },
@@ -443,17 +454,18 @@
       "id": "edge-c7370c49-63ec-4d62-9b7c-36f1cd0e4ed1",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
       "transition_group_id": "group-986d01ca-05b8-473d-bf17-9bfa81b5669a",
-      "key": "pr_blocked",
-      "target_node_id": "node-a19c6feb-2c82-4c67-960a-31ee75b785d2",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "ship_pr_needs_user_action",
+      "target_node_id": "node-b72f177e-2ffe-4bf9-a018-ba65361119fa",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why release PR creation/update cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -461,18 +473,26 @@
       "id": "edge-6c5fd08a-c3b0-49d6-824c-7f4289599b53",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
       "transition_group_id": "group-0583145f-ec64-45d3-a77f-3fbcb06990d6",
-      "key": "approve_publish",
-      "target_node_id": "node-feeb41cd-253b-401b-add9-888b0237abe9",
-      "requires_approval": true,
-      "context_mode": "compact_and_continue_session",
+      "key": "ci_waiting_pr",
+      "target_node_id": "node-c0d75fb3-8a2c-4109-b0b0-89afb43ace0a",
+      "requires_approval": false,
+      "context_mode": "new_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Publish the approved Puber release tag.\n\nRead .kent/project-contract.md, .kent/commands/release-tag.md, and AGENTS.md first. If .kent/commands/release.md exists, use it as supplementary unified guidance, but do not block solely because that file is absent. Before creating any tag, fetch origin/master and verify that PR {{.Params.pr_url}} is merged and origin/master contains currentVersion {{.Params.release_version}}. Verify {{.Params.release_tag}} does not exist locally/remotely unless it already points to the intended master commit. Create and push {{.Params.release_tag}} on the verified origin/master commit. Do not merge PRs and do not push directly to master.\n\nComplete with monitor and provide release_version, release_tag, target_commit, pr_url, and tag_push_status when the tag is pushed or already correct. Complete with not_ready if the PR is not merged yet or origin/master does not yet contain the version bump; provide pr_url, release_version, release_tag, branch_name, workspace_path, and ci_report. Complete with retry_later for temporary GitHub/network/tag-push availability problems where retrying later is safe; provide pr_url, release_version, release_tag, branch_name, workspace_path, ci_report, and blocker_reason. Complete with blocked only if publication is unsafe, such as the tag already pointing to a different commit; provide blocker_reason.",
+      "prompt_template": "Hold this Puber release until the release pull request is actually merged.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, release PR {{.Params.pr_url}}, branch {{.Params.branch_name}}, release version {{.Params.release_version}}, release tag {{.Params.release_tag}}, workspace {{.Params.workspace_path}}, and CI report {{.Params.ci_report}}.\n\nUse `gh pr view --json state,mergedAt,mergeCommit,headRefName,baseRefName,url` when available. Do not merge the PR. Do not create or push the release tag from this node. Do not clean up while the PR is still open.\n\nComplete with pr_merged only when GitHub reports state=MERGED; provide pr_url, branch_name, release_version, release_tag, workspace_path, and merge_report. Complete with needs_changes when release PR review comments, merge conflicts, or post-CI regressions can be fixed within release-preparation scope; provide workspace_path, release_version, release_tag, and pr_report. Complete with needs_user_action when the PR is still open, waiting for human review/approval/merge, or needs_user_action by an external process; add a task comment with the current PR status and exact human action, then provide pr_url, branch_name, release_version, release_tag, workspace_path, and waiting_reason. Complete with close_without_merge only if the latest user comment explicitly says to cancel this release PR; provide pr_url, branch_name, workspace_path, and cleanup_reason.",
       "parameters": [
         {
           "key": "pr_url",
-          "description": "URL of the release pull request."
+          "description": "URL of the created, updated, or monitored pull request."
+        },
+        {
+          "key": "branch_name",
+          "description": "Name of the task or release branch associated with the pull request."
+        },
+        {
+          "key": "workspace_path",
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "release_version",
@@ -480,15 +500,7 @@
         },
         {
           "key": "release_tag",
-          "description": "Release tag to create after the PR is merged."
-        },
-        {
-          "key": "branch_name",
-          "description": "Name of the pushed release branch."
-        },
-        {
-          "key": "workspace_path",
-          "description": "Path to the worktree or checkout containing the release bump."
+          "description": "Release tag to create or publish after PR merge."
         },
         {
           "key": "ci_report",
@@ -502,16 +514,16 @@
       "transition_group_id": "group-c9c24869-2449-482e-b2aa-fe13a359295f",
       "key": "ci_fix",
       "target_node_id": "node-86293208-dd6b-4ff6-89d4-d6567a8b4e55",
-      "requires_approval": true,
+      "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Fix Puber release PR CI failures only.\n\nRead .kent/project-contract.md, .kent/commands/release-branch.md, and .kent/commands/release-tag.md first. If .kent/commands/release.md exists, use it as supplementary unified guidance, but do not block solely because that file is absent. Apply only the minimum changes required by CI report {{.Params.ci_report}} in workspace {{.Params.workspace_path}}. Verify narrowly, then complete with compliance and provide release_version, release_type, release_branch, release_tag, workspace_path, version_bump_commit, and verification_summary. Complete with blocked and provide blocker_reason if unsafe or missing input.",
+      "prompt_template": "Fix Puber release PR CI failures only.\n\nRead .kent/project-contract.md, .kent/commands/release-branch.md, and .kent/commands/release-tag.md first. If .kent/commands/release.md exists, use it as supplementary unified guidance, but do not block solely because that file is absent. Apply only the minimum changes required by CI report {{.Params.ci_report}} in workspace {{.Params.workspace_path}}. Verify narrowly, then complete with compliance and provide release_version, release_type, release_branch, release_tag, workspace_path, version_bump_commit, and verification_summary. Complete with needs_user_action and provide blocker_reason if unsafe or missing input.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the worktree or checkout containing the release bump."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "ci_report",
@@ -523,17 +535,18 @@
       "id": "edge-e02a752c-4e67-4b1c-b06b-37995e9816f8",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
       "transition_group_id": "group-a16f76de-f9fb-4dda-b276-120863bf1005",
-      "key": "ci_blocked",
-      "target_node_id": "node-a19c6feb-2c82-4c67-960a-31ee75b785d2",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "ci_monitor_needs_user_action",
+      "target_node_id": "node-8497fa66-4fc6-457d-8c0b-7e1da150bd26",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why release PR CI monitoring cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -548,15 +561,15 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Monitor Puber release automation after tag publication.\n\nRead .kent/project-contract.md and .kent/commands/release-tag.md first. If .kent/commands/release.md exists, use it as supplementary unified guidance, but do not block solely because that file is absent. Check available GitHub/CI/release automation for {{.Params.release_tag}} when configured. If no automation is configured, report that monitoring is skipped. Complete with done if green or intentionally skipped. Complete with retry_later if release automation is still starting or temporarily unavailable and provide release_version, release_tag, target_commit, pr_url, tag_push_status, and release_report. Complete with blocked only if automation fails or cannot be inspected after retry would be misleading; provide blocker_reason.",
+      "prompt_template": "Monitor Puber release automation after tag publication.\n\nRead .kent/project-contract.md and .kent/commands/release-tag.md first. If .kent/commands/release.md exists, use it as supplementary unified guidance, but do not block solely because that file is absent. Check available GitHub/CI/release automation for {{.Params.release_tag}} when configured. If no automation is configured, report that monitoring is skipped. Complete with release_published if green or intentionally skipped. Complete with needs_user_action for temporary external waits; provide blocker_reason. Complete with needs_user_action only if automation fails or cannot be inspected after retry would be misleading; provide blocker_reason.",
       "parameters": [
         {
           "key": "release_version",
-          "description": "Published release version."
+          "description": "Release version prepared by this workflow."
         },
         {
           "key": "release_tag",
-          "description": "Pushed release tag."
+          "description": "Release tag to create or publish after PR merge."
         },
         {
           "key": "target_commit",
@@ -564,7 +577,7 @@
         },
         {
           "key": "pr_url",
-          "description": "URL of the merged release pull request."
+          "description": "URL of the created, updated, or monitored pull request."
         },
         {
           "key": "tag_push_status",
@@ -576,17 +589,18 @@
       "id": "edge-76cb7cc9-afdb-471b-9c30-0575d769d0fa",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
       "transition_group_id": "group-e3ddd61b-3b97-4e7e-ad1a-4b1b47d4e3e1",
-      "key": "publish_blocked",
-      "target_node_id": "node-a19c6feb-2c82-4c67-960a-31ee75b785d2",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "publish_needs_user_action",
+      "target_node_id": "node-feeb41cd-253b-401b-add9-888b0237abe9",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why release tag publication cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -594,7 +608,7 @@
       "id": "edge-f6e61b45-54eb-4c42-86e7-6d28ef4f7a4b",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
       "transition_group_id": "group-901a4611-3b31-4a54-804e-6294786e30e2",
-      "key": "release_done",
+      "key": "release_release_published",
       "target_node_id": "node-a0bedfe2-b399-456f-a0be-61ca70704811",
       "requires_approval": false,
       "context_mode": "new_session",
@@ -613,17 +627,18 @@
       "id": "edge-2a57cb62-d880-4e73-a460-bf834dcb2b64",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
       "transition_group_id": "group-008b5b03-50eb-4276-a01a-f34c75ce4be6",
-      "key": "monitor_blocked",
-      "target_node_id": "node-a19c6feb-2c82-4c67-960a-31ee75b785d2",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "monitor_needs_user_action",
+      "target_node_id": "node-f5349410-9178-4fb1-a909-0b5dad73cfe4",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why release automation monitoring cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -646,53 +661,6 @@
       ]
     },
     {
-      "id": "edge-cf64d3bb-e98a-4d84-ba3f-783f6e64ed78",
-      "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
-      "transition_group_id": "group-a8b20339-ff99-40a1-ae5c-52eee6de1f0c",
-      "key": "compliance_retry",
-      "target_node_id": "node-77c2b3c6-04e4-4e03-a964-2aa5c47259c8",
-      "requires_approval": true,
-      "context_mode": "compact_and_continue_session",
-      "context_source": {
-        "kind": "immediate_source"
-      },
-      "prompt_template": "Retry mandatory Puber Compliance Review for the prepared release after an approved temporary blocker wait.\n\nRead .kent/commands/compliance-review.md, .kent/project-contract.md, .kent/commands/release-branch.md, .kent/commands/release-tag.md, and AGENTS.md first. If .kent/commands/release.md exists, use it as supplementary unified guidance, but do not block solely because that file is absent. Previous blocker: {{.Params.blocker_reason}}. Reviewed scope: release {{.Params.release_version}} ({{.Params.release_type}}) on branch {{.Params.release_branch}} in workspace {{.Params.workspace_path}}, commit {{.Params.version_bump_commit}}, intended tag {{.Params.release_tag}}, verification {{.Params.verification_summary}}. Review only compliance with release rules, task requirements, AGENTS.md, and workflow contract. Do not edit files.\n\nComplete with done and provide compliance_report when no compliance violations are found. Complete with needs_changes and provide workspace_path plus compliance_report when release preparation must be fixed. Complete with retry_later if required sources or user-provided context are still temporarily unavailable and provide release_version, release_type, release_branch, release_tag, workspace_path, version_bump_commit, verification_summary, and blocker_reason. Complete with blocked only if continuing is unsafe; provide blocker_reason.",
-      "parameters": [
-        {
-          "key": "release_version",
-          "description": "Prepared release version, for example 1.4.0."
-        },
-        {
-          "key": "release_type",
-          "description": "Version bump type: minor by default, patch or major only when explicitly requested."
-        },
-        {
-          "key": "release_branch",
-          "description": "Release branch containing the version bump."
-        },
-        {
-          "key": "release_tag",
-          "description": "Release tag that should be created after the PR is merged, for example v1.4.0."
-        },
-        {
-          "key": "workspace_path",
-          "description": "Path to the worktree or checkout containing the release bump."
-        },
-        {
-          "key": "version_bump_commit",
-          "description": "Commit hash containing the version bump."
-        },
-        {
-          "key": "verification_summary",
-          "description": "Commands run and their pass/fail results."
-        },
-        {
-          "key": "blocker_reason",
-          "description": "Why compliance review cannot complete, in the task language when practical."
-        }
-      ]
-    },
-    {
       "id": "edge-6018e22d-2198-45ed-a4b3-bdfe93775e78",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
       "transition_group_id": "group-e21a073b-10f2-402b-94e5-8b1239288c6a",
@@ -703,11 +671,11 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Fix recoverable Puber release PR creation/update issues only.\n\nRead .kent/project-contract.md, .kent/commands/release-branch.md, .kent/commands/release-tag.md, .kent/commands/ship-pr.md, and AGENTS.md first. If .kent/commands/release.md exists, use it as supplementary unified guidance. Previous PR blocker: {{.Params.blocker_reason}}. Release context: version {{.Params.release_version}}, type {{.Params.release_type}}, branch {{.Params.release_branch}}, tag {{.Params.release_tag}}, workspace {{.Params.workspace_path}}.\n\nApply only the minimum changes needed to make the release branch/PR shippable, such as rebasing, resolving conflicts, fixing branch metadata, or repairing the version-bump commit. Do not create or push a release tag. Verify narrowly, then complete with compliance and provide release_version, release_type, release_branch, release_tag, workspace_path, version_bump_commit, and verification_summary. Complete with blocked only if recovery is unsafe or requires user credentials/policy changes.",
+      "prompt_template": "Fix recoverable Puber release PR creation/update issues only.\n\nRead .kent/project-contract.md, .kent/commands/release-branch.md, .kent/commands/release-tag.md, .kent/commands/ship-pr.md, and AGENTS.md first. If .kent/commands/release.md exists, use it as supplementary unified guidance. Previous PR blocker: {{.Params.blocker_reason}}. Release context: version {{.Params.release_version}}, type {{.Params.release_type}}, branch {{.Params.release_branch}}, tag {{.Params.release_tag}}, workspace {{.Params.workspace_path}}.\n\nApply only the minimum changes needed to make the release branch/PR shippable, such as rebasing, resolving conflicts, fixing branch metadata, or repairing the version-bump commit. Do not create or push a release tag. Verify narrowly, then complete with compliance and provide release_version, release_type, release_branch, release_tag, workspace_path, version_bump_commit, and verification_summary. Complete with needs_user_action only if recovery is unsafe or requires user credentials/policy changes.\n\nFor any needs_user_action transition, provide blocker_reason with the exact next user or external action needed.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the worktree or checkout used for PR creation."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "release_version",
@@ -723,30 +691,38 @@
         },
         {
           "key": "release_tag",
-          "description": "Release tag to create after the PR is merged."
+          "description": "Release tag to create or publish after PR merge."
         },
         {
           "key": "blocker_reason",
-          "description": "Why release PR creation/update cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
     {
-      "id": "edge-75fce052-321b-4f1a-855b-ce692f89e46b",
+      "id": "edge-b4ae17cc-edc6-47e2-b9ea-c4b00cd07600",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
-      "transition_group_id": "group-bc018baf-d599-4df5-a3f4-b6e992f46491",
-      "key": "ci_retry",
-      "target_node_id": "node-8497fa66-4fc6-457d-8c0b-7e1da150bd26",
+      "transition_group_id": "group-a7e0dff6-2d65-45b5-a937-fa2ae9db916c",
+      "key": "publish_after_merge",
+      "target_node_id": "node-feeb41cd-253b-401b-add9-888b0237abe9",
       "requires_approval": true,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Retry Puber release PR check monitoring after an approved temporary CI/GitHub wait.\n\nRead .kent/project-contract.md, .kent/commands/release-branch.md, and .kent/commands/release-tag.md first. Previous CI status: {{.Params.ci_report}}. Inspect PR {{.Params.pr_url}} for release {{.Params.release_version}} / tag {{.Params.release_tag}} on branch {{.Params.branch_name}} again. Do not merge the PR. Do not push new commits from this node.\n\nComplete with publish when checks pass or are intentionally absent; this transition requires user approval before tag publication. Provide pr_url, release_version, release_tag, branch_name, workspace_path, and ci_report. Complete with needs_changes if checks failed due to release changes and provide workspace_path plus ci_report. Complete with retry_later if CI/GitHub is still temporarily unavailable and provide pr_url, release_version, release_tag, branch_name, workspace_path, and ci_report. Complete with blocked only if retrying is no longer useful or safe; provide blocker_reason.",
+      "prompt_template": "Publish the approved Puber release tag after the release PR was confirmed merged.\n\nRead AGENTS.md, .kent/project-contract.md, latest task comments, release version {{.Params.release_version}}, release tag {{.Params.release_tag}}, PR {{.Params.pr_url}}, and merge report {{.Params.merge_report}}. This transition is intentionally approval-gated. Before tagging, verify the PR state is still MERGED and the tag does not already point to a conflicting commit. Do not change the release scope. Complete with monitor when the tag is published or already correct and provide release_version, release_tag, target_commit, pr_url, and tag_push_status. Complete with needs_user_action for temporary external waits; provide blocker_reason. Complete with needs_user_action if explicit user input or permission is required.",
       "parameters": [
         {
           "key": "pr_url",
-          "description": "URL of the release pull request."
+          "description": "URL of the created, updated, or monitored pull request."
+        },
+        {
+          "key": "branch_name",
+          "description": "Name of the task or release branch associated with the pull request."
+        },
+        {
+          "key": "workspace_path",
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "release_version",
@@ -754,140 +730,130 @@
         },
         {
           "key": "release_tag",
-          "description": "Release tag to create after the PR is merged."
+          "description": "Release tag to create or publish after PR merge."
         },
         {
-          "key": "branch_name",
-          "description": "Name of the pushed release branch."
-        },
-        {
-          "key": "workspace_path",
-          "description": "Path to the worktree or checkout containing the release bump."
-        },
-        {
-          "key": "ci_report",
-          "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+          "key": "merge_report",
+          "description": "GitHub PR state, mergedAt, mergeCommit, and cleanup or release notes."
         }
       ]
     },
     {
-      "id": "edge-3772a318-3329-4c26-82d1-7118a7ba5932",
+      "id": "edge-dcac956d-47aa-4a43-87e4-ccae167e11e3",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
-      "transition_group_id": "group-c1e0d59b-b781-4d62-9ffc-ee47fabdfe95",
-      "key": "publish_not_ready",
-      "target_node_id": "node-8497fa66-4fc6-457d-8c0b-7e1da150bd26",
+      "transition_group_id": "group-def5967b-a961-4139-b2ac-fea582269726",
+      "key": "pr_feedback",
+      "target_node_id": "node-86293208-dd6b-4ff6-89d4-d6567a8b4e55",
+      "requires_approval": false,
+      "context_mode": "compact_and_continue_session",
+      "context_source": {
+        "kind": "immediate_source"
+      },
+      "prompt_template": "Repair the Puber release PR only.\n\nRead AGENTS.md, .kent/project-contract.md, latest task comments, workspace {{.Params.workspace_path}}, release version {{.Params.release_version}}, release tag {{.Params.release_tag}}, and PR feedback report {{.Params.pr_report}}. Apply only release-preparation-scope fixes for review comments, merge conflicts, or post-CI regressions. Do not force-push unless the latest user comment explicitly permits force-push for this exact PR/branch. Verify narrowly, then return through compliance, PR update, CI, and waiting_pr. Complete with needs_user_action if explicit user input or permission is required.\n\nFor any needs_user_action transition, provide blocker_reason with the exact next user or external action needed.",
+      "parameters": [
+        {
+          "key": "workspace_path",
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
+        },
+        {
+          "key": "release_version",
+          "description": "Release version prepared by this workflow."
+        },
+        {
+          "key": "release_tag",
+          "description": "Release tag to create or publish after PR merge."
+        },
+        {
+          "key": "pr_report",
+          "description": "PR creation, review, conflict, or post-CI regression report."
+        }
+      ]
+    },
+    {
+      "id": "edge-37f43543-3ab7-4f60-bcf1-5ae7e8a2bcac",
+      "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
+      "transition_group_id": "group-668bcce6-ceef-498a-a66f-c0bcbb9b9f0e",
+      "key": "waiting_pr_needs_user_action",
+      "target_node_id": "node-c0d75fb3-8a2c-4109-b0b0-89afb43ace0a",
       "requires_approval": true,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Resume Puber release PR monitoring after tag publication was approved too early.\n\nRead .kent/project-contract.md, .kent/commands/release-branch.md, and .kent/commands/release-tag.md first. Previous publication readiness report: {{.Params.ci_report}}. Monitor PR {{.Params.pr_url}} for release {{.Params.release_version}} / tag {{.Params.release_tag}} on branch {{.Params.branch_name}}. Do not merge the PR. Do not push new commits from this node.\n\nComplete with publish when checks pass or are intentionally absent and the PR is ready for user-approved tag publication; provide pr_url, release_version, release_tag, branch_name, workspace_path, and ci_report. Complete with needs_changes if checks failed due to release changes and provide workspace_path plus ci_report. Complete with retry_later if CI/GitHub is temporarily unavailable and provide pr_url, release_version, release_tag, branch_name, workspace_path, and ci_report. Complete with blocked only if retrying is no longer useful or safe; provide blocker_reason.",
+      "prompt_template": "Re-check the Puber release pull request after the user resolved the external wait or approved another check.\n\nRead AGENTS.md, .kent/project-contract.md, latest task comments, PR {{.Params.pr_url}}, branch {{.Params.branch_name}}, release version {{.Params.release_version}}, release tag {{.Params.release_tag}}, workspace {{.Params.workspace_path}}, and previous waiting reason {{.Params.waiting_reason}}. Do not merge, tag, push, publish, or clean up unless the PR is confirmed merged and the next publish transition is explicitly approved.\n\nComplete with pr_merged only when GitHub reports state=MERGED. Complete with needs_changes for release-scope PR review/conflict/regression fixes. Complete with needs_user_action again if the PR is still waiting externally. Complete with close_without_merge only on explicit latest user instruction.",
       "parameters": [
         {
           "key": "pr_url",
-          "description": "URL of the merged release pull request."
-        },
-        {
-          "key": "release_version",
-          "description": "Published release version."
-        },
-        {
-          "key": "release_tag",
-          "description": "Pushed release tag."
+          "description": "URL of the created, updated, or monitored pull request."
         },
         {
           "key": "branch_name",
-          "description": "Name of the pushed release branch."
+          "description": "Name of the task or release branch associated with the pull request."
         },
         {
           "key": "workspace_path",
-          "description": "Path to the worktree or checkout containing the release bump."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
-          "key": "ci_report",
-          "description": "Publication readiness or CI/check status report."
+          "key": "release_version",
+          "description": "Release version prepared by this workflow."
+        },
+        {
+          "key": "release_tag",
+          "description": "Release tag to create or publish after PR merge."
+        },
+        {
+          "key": "waiting_reason",
+          "description": "Why the PR cannot advance yet and the exact user or external action needed."
         }
       ]
     },
     {
-      "id": "edge-66a9f114-a244-4321-ace5-ffd759cc3af4",
+      "id": "edge-bd3ab2d8-ced1-43b2-b740-ada232876991",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
-      "transition_group_id": "group-5871795e-997a-4747-ae57-c74588cabd1d",
-      "key": "publish_retry",
-      "target_node_id": "node-feeb41cd-253b-401b-add9-888b0237abe9",
+      "transition_group_id": "group-eeb67e0b-9098-4591-acf4-f5bd1d23fa30",
+      "key": "release_cancel_cleanup",
+      "target_node_id": "node-a0bedfe2-b399-456f-a0be-61ca70704811",
       "requires_approval": true,
-      "context_mode": "compact_and_continue_session",
+      "context_mode": "new_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Retry approved Puber release tag publication after a temporary external blocker.\n\nRead .kent/project-contract.md, .kent/commands/release-tag.md, and AGENTS.md first. Previous publication blocker: {{.Params.blocker_reason}}. Release context: PR {{.Params.pr_url}}, version {{.Params.release_version}}, tag {{.Params.release_tag}}, branch {{.Params.branch_name}}, workspace {{.Params.workspace_path}}. Before creating any tag, fetch origin/master and verify that the PR is merged and origin/master contains currentVersion {{.Params.release_version}}. Do not merge PRs and do not push directly to master.\n\nComplete with monitor and provide release_version, release_tag, target_commit, pr_url, and tag_push_status when the tag is pushed or already correct. Complete with not_ready if the PR is not merged yet or origin/master does not yet contain the version bump; provide pr_url, release_version, release_tag, branch_name, workspace_path, and ci_report. Complete with retry_later if the external publication blocker persists and retrying is safe; provide pr_url, release_version, release_tag, branch_name, workspace_path, ci_report, and blocker_reason. Complete with blocked only if publication is unsafe; provide blocker_reason.",
+      "prompt_template": "Run conservative Puber release cleanup after the user explicitly canceled the release PR without merge.\n\nRead AGENTS.md, .kent/project-contract.md, .kent/commands/cleanup-task.md, PR {{.Params.pr_url}}, branch {{.Params.branch_name}}, workspace {{.Params.workspace_path}}, and cleanup reason {{.Params.cleanup_reason}}. Do not delete any worktree containing unpushed commits, uncommitted user changes, or unclear ownership. Complete with done and provide cleanup_report.",
       "parameters": [
         {
           "key": "pr_url",
-          "description": "URL of the merged release pull request."
-        },
-        {
-          "key": "release_version",
-          "description": "Published release version."
-        },
-        {
-          "key": "release_tag",
-          "description": "Pushed release tag."
+          "description": "URL of the created, updated, or monitored pull request."
         },
         {
           "key": "branch_name",
-          "description": "Name of the pushed release branch."
+          "description": "Name of the task or release branch associated with the pull request."
         },
         {
           "key": "workspace_path",
-          "description": "Path to the worktree or checkout containing the release bump."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
-          "key": "ci_report",
-          "description": "Publication readiness or CI/check status report."
-        },
-        {
-          "key": "blocker_reason",
-          "description": "Why release tag publication cannot complete, in the task language when practical."
+          "key": "cleanup_reason",
+          "description": "Explicit user instruction or reason for cleanup without merge."
         }
       ]
     },
     {
-      "id": "edge-1782e3e8-0549-4b08-b6cb-0750d6c35fc2",
+      "id": "edge-9228ca82-9ab5-4dfe-b073-21ebe5d0b65f",
       "workflow_id": "workflow-42287243-1486-45e6-8f8d-3ecddba896be",
-      "transition_group_id": "group-94f3424d-ea81-4e04-b33f-d79fcb548a83",
-      "key": "monitor_retry",
-      "target_node_id": "node-f5349410-9178-4fb1-a909-0b5dad73cfe4",
+      "transition_group_id": "group-c2158ca7-1390-49c6-b7be-149f04b70e56",
+      "key": "prepare_wont_do",
+      "target_node_id": "node-a19c6feb-2c82-4c67-960a-31ee75b785d2",
       "requires_approval": true,
-      "context_mode": "compact_and_continue_session",
+      "context_mode": "new_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Retry Puber release automation monitoring after an approved temporary wait.\n\nRead .kent/project-contract.md and .kent/commands/release-tag.md first. Previous release monitoring report: {{.Params.release_report}}. Check available GitHub/CI/release automation for {{.Params.release_tag}} on commit {{.Params.target_commit}} again. If no automation is configured, report that monitoring is skipped.\n\nComplete with done if green or intentionally skipped. Complete with retry_later if release automation is still starting or temporarily unavailable and provide release_version, release_tag, target_commit, pr_url, tag_push_status, and release_report. Complete with blocked only if automation fails or cannot be inspected after retry would be misleading; provide blocker_reason.",
       "parameters": [
         {
-          "key": "release_version",
-          "description": "Published release version."
-        },
-        {
-          "key": "release_tag",
-          "description": "Pushed release tag."
-        },
-        {
-          "key": "target_commit",
-          "description": "Master commit targeted by the release tag."
-        },
-        {
-          "key": "pr_url",
-          "description": "URL of the merged release pull request."
-        },
-        {
-          "key": "tag_push_status",
-          "description": "Result of local/remote tag creation and push."
-        },
-        {
-          "key": "release_report",
-          "description": "Release publication and automation monitoring report."
+          "key": "closure_reason",
+          "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
         }
       ]
     }
@@ -902,7 +868,7 @@
         "possible_provision_fields": [
           {
             "name": "release_version",
-            "description": "Prepared release version, for example 1.4.0."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_type",
@@ -914,11 +880,11 @@
           },
           {
             "name": "release_tag",
-            "description": "Release tag that should be created after the PR is merged, for example v1.4.0."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout containing the release bump."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "version_bump_commit",
@@ -930,7 +896,11 @@
           },
           {
             "name": "blocker_reason",
-            "description": "Why release preparation cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          },
+          {
+            "name": "closure_reason",
+            "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
           }
         ]
       },
@@ -939,39 +909,15 @@
         "possible_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout containing the release bump."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
-          },
-          {
-            "name": "release_version",
-            "description": "Prepared release version, for example 1.4.0."
-          },
-          {
-            "name": "release_type",
-            "description": "Version bump type: minor by default, patch or major only when explicitly requested."
-          },
-          {
-            "name": "release_branch",
-            "description": "Release branch containing the version bump."
-          },
-          {
-            "name": "release_tag",
-            "description": "Release tag that should be created after the PR is merged, for example v1.4.0."
-          },
-          {
-            "name": "version_bump_commit",
-            "description": "Commit hash containing the version bump."
-          },
-          {
-            "name": "verification_summary",
-            "description": "Commands run and their pass/fail results."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -980,15 +926,15 @@
         "possible_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the release pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed release branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "release_version",
@@ -996,11 +942,11 @@
           },
           {
             "name": "release_tag",
-            "description": "Release tag to create after the PR is merged."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
             "name": "blocker_reason",
-            "description": "Why release PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           },
           {
             "name": "release_type",
@@ -1017,7 +963,15 @@
         "possible_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the release pull request."
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "release_version",
@@ -1025,15 +979,7 @@
           },
           {
             "name": "release_tag",
-            "description": "Release tag to create after the PR is merged."
-          },
-          {
-            "name": "branch_name",
-            "description": "Name of the pushed release branch."
-          },
-          {
-            "name": "workspace_path",
-            "description": "Path to the worktree or checkout containing the release bump."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
             "name": "ci_report",
@@ -1041,7 +987,7 @@
           },
           {
             "name": "blocker_reason",
-            "description": "Why release PR CI monitoring cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1050,11 +996,11 @@
         "possible_provision_fields": [
           {
             "name": "release_version",
-            "description": "Published release version."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_tag",
-            "description": "Pushed release tag."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
             "name": "target_commit",
@@ -1062,7 +1008,7 @@
           },
           {
             "name": "pr_url",
-            "description": "URL of the merged release pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "tag_push_status",
@@ -1070,19 +1016,7 @@
           },
           {
             "name": "blocker_reason",
-            "description": "Why release tag publication cannot complete, in the task language when practical."
-          },
-          {
-            "name": "branch_name",
-            "description": "Name of the pushed release branch."
-          },
-          {
-            "name": "workspace_path",
-            "description": "Path to the worktree or checkout containing the release bump."
-          },
-          {
-            "name": "ci_report",
-            "description": "Publication readiness or CI/check status report."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1095,27 +1029,7 @@
           },
           {
             "name": "blocker_reason",
-            "description": "Why release automation monitoring cannot complete, in the task language when practical."
-          },
-          {
-            "name": "release_version",
-            "description": "Published release version."
-          },
-          {
-            "name": "release_tag",
-            "description": "Pushed release tag."
-          },
-          {
-            "name": "target_commit",
-            "description": "Master commit targeted by the release tag."
-          },
-          {
-            "name": "pr_url",
-            "description": "URL of the merged release pull request."
-          },
-          {
-            "name": "tag_push_status",
-            "description": "Result of local/remote tag creation and push."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1132,6 +1046,47 @@
         "node_id": "node-a19c6feb-2c82-4c67-960a-31ee75b785d2"
       },
       {
+        "node_id": "node-c0d75fb3-8a2c-4109-b0b0-89afb43ace0a",
+        "possible_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "release_version",
+            "description": "Release version prepared by this workflow."
+          },
+          {
+            "name": "release_tag",
+            "description": "Release tag to create or publish after PR merge."
+          },
+          {
+            "name": "merge_report",
+            "description": "GitHub PR state, mergedAt, mergeCommit, and cleanup or release notes."
+          },
+          {
+            "name": "pr_report",
+            "description": "PR creation, review, conflict, or post-CI regression report."
+          },
+          {
+            "name": "waiting_reason",
+            "description": "Why the PR cannot advance yet and the exact user or external action needed."
+          },
+          {
+            "name": "cleanup_reason",
+            "description": "Explicit user instruction or reason for cleanup without merge."
+          }
+        ]
+      },
+      {
         "node_id": "node-0ebf8742-e371-440f-97e2-fc3834a09906"
       }
     ],
@@ -1144,7 +1099,7 @@
         "required_provision_fields": [
           {
             "name": "release_version",
-            "description": "Prepared release version, for example 1.4.0."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_type",
@@ -1156,11 +1111,11 @@
           },
           {
             "name": "release_tag",
-            "description": "Release tag that should be created after the PR is merged, for example v1.4.0."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout containing the release bump."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "version_bump_commit",
@@ -1177,7 +1132,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why release preparation cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1186,7 +1141,7 @@
         "required_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -1195,11 +1150,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout containing the release bump."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -1208,7 +1163,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1217,15 +1172,15 @@
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the release pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed release branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "release_version",
@@ -1233,7 +1188,7 @@
           },
           {
             "name": "release_tag",
-            "description": "Release tag to create after the PR is merged."
+            "description": "Release tag to create or publish after PR merge."
           }
         ]
       },
@@ -1242,7 +1197,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why release PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1251,7 +1206,15 @@
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the release pull request."
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "release_version",
@@ -1259,15 +1222,7 @@
           },
           {
             "name": "release_tag",
-            "description": "Release tag to create after the PR is merged."
-          },
-          {
-            "name": "branch_name",
-            "description": "Name of the pushed release branch."
-          },
-          {
-            "name": "workspace_path",
-            "description": "Path to the worktree or checkout containing the release bump."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
             "name": "ci_report",
@@ -1280,7 +1235,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout containing the release bump."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "ci_report",
@@ -1293,7 +1248,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why release PR CI monitoring cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1302,11 +1257,11 @@
         "required_provision_fields": [
           {
             "name": "release_version",
-            "description": "Published release version."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_tag",
-            "description": "Pushed release tag."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
             "name": "target_commit",
@@ -1314,7 +1269,7 @@
           },
           {
             "name": "pr_url",
-            "description": "URL of the merged release pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "tag_push_status",
@@ -1327,7 +1282,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why release tag publication cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1345,7 +1300,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why release automation monitoring cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1359,48 +1314,11 @@
         ]
       },
       {
-        "transition_group_id": "group-a8b20339-ff99-40a1-ae5c-52eee6de1f0c",
-        "required_provision_fields": [
-          {
-            "name": "release_version",
-            "description": "Prepared release version, for example 1.4.0."
-          },
-          {
-            "name": "release_type",
-            "description": "Version bump type: minor by default, patch or major only when explicitly requested."
-          },
-          {
-            "name": "release_branch",
-            "description": "Release branch containing the version bump."
-          },
-          {
-            "name": "release_tag",
-            "description": "Release tag that should be created after the PR is merged, for example v1.4.0."
-          },
-          {
-            "name": "workspace_path",
-            "description": "Path to the worktree or checkout containing the release bump."
-          },
-          {
-            "name": "version_bump_commit",
-            "description": "Commit hash containing the version bump."
-          },
-          {
-            "name": "verification_summary",
-            "description": "Commands run and their pass/fail results."
-          },
-          {
-            "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
-          }
-        ]
-      },
-      {
         "transition_group_id": "group-e21a073b-10f2-402b-94e5-8b1239288c6a",
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "release_version",
@@ -1416,20 +1334,28 @@
           },
           {
             "name": "release_tag",
-            "description": "Release tag to create after the PR is merged."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
             "name": "blocker_reason",
-            "description": "Why release PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
       {
-        "transition_group_id": "group-bc018baf-d599-4df5-a3f4-b6e992f46491",
+        "transition_group_id": "group-a7e0dff6-2d65-45b5-a937-fa2ae9db916c",
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the release pull request."
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "release_version",
@@ -1437,110 +1363,91 @@
           },
           {
             "name": "release_tag",
-            "description": "Release tag to create after the PR is merged."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
-            "name": "branch_name",
-            "description": "Name of the pushed release branch."
-          },
-          {
-            "name": "workspace_path",
-            "description": "Path to the worktree or checkout containing the release bump."
-          },
-          {
-            "name": "ci_report",
-            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+            "name": "merge_report",
+            "description": "GitHub PR state, mergedAt, mergeCommit, and cleanup or release notes."
           }
         ]
       },
       {
-        "transition_group_id": "group-c1e0d59b-b781-4d62-9ffc-ee47fabdfe95",
+        "transition_group_id": "group-def5967b-a961-4139-b2ac-fea582269726",
         "required_provision_fields": [
           {
-            "name": "pr_url",
-            "description": "URL of the merged release pull request."
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "release_version",
-            "description": "Published release version."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_tag",
-            "description": "Pushed release tag."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
-            "name": "branch_name",
-            "description": "Name of the pushed release branch."
-          },
-          {
-            "name": "workspace_path",
-            "description": "Path to the worktree or checkout containing the release bump."
-          },
-          {
-            "name": "ci_report",
-            "description": "Publication readiness or CI/check status report."
+            "name": "pr_report",
+            "description": "PR creation, review, conflict, or post-CI regression report."
           }
         ]
       },
       {
-        "transition_group_id": "group-5871795e-997a-4747-ae57-c74588cabd1d",
+        "transition_group_id": "group-668bcce6-ceef-498a-a66f-c0bcbb9b9f0e",
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the merged release pull request."
-          },
-          {
-            "name": "release_version",
-            "description": "Published release version."
-          },
-          {
-            "name": "release_tag",
-            "description": "Pushed release tag."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed release branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout containing the release bump."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
-            "name": "ci_report",
-            "description": "Publication readiness or CI/check status report."
+            "name": "release_version",
+            "description": "Release version prepared by this workflow."
           },
           {
-            "name": "blocker_reason",
-            "description": "Why release tag publication cannot complete, in the task language when practical."
+            "name": "release_tag",
+            "description": "Release tag to create or publish after PR merge."
+          },
+          {
+            "name": "waiting_reason",
+            "description": "Why the PR cannot advance yet and the exact user or external action needed."
           }
         ]
       },
       {
-        "transition_group_id": "group-94f3424d-ea81-4e04-b33f-d79fcb548a83",
+        "transition_group_id": "group-eeb67e0b-9098-4591-acf4-f5bd1d23fa30",
         "required_provision_fields": [
           {
-            "name": "release_version",
-            "description": "Published release version."
-          },
-          {
-            "name": "release_tag",
-            "description": "Pushed release tag."
-          },
-          {
-            "name": "target_commit",
-            "description": "Master commit targeted by the release tag."
-          },
-          {
             "name": "pr_url",
-            "description": "URL of the merged release pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
-            "name": "tag_push_status",
-            "description": "Result of local/remote tag creation and push."
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
-            "name": "release_report",
-            "description": "Release publication and automation monitoring report."
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "cleanup_reason",
+            "description": "Explicit user instruction or reason for cleanup without merge."
+          }
+        ]
+      },
+      {
+        "transition_group_id": "group-c2158ca7-1390-49c6-b7be-149f04b70e56",
+        "required_provision_fields": [
+          {
+            "name": "closure_reason",
+            "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
           }
         ]
       }
@@ -1591,7 +1498,7 @@
         "required_provision_fields": [
           {
             "name": "release_version",
-            "description": "Prepared release version, for example 1.4.0."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_type",
@@ -1603,11 +1510,11 @@
           },
           {
             "name": "release_tag",
-            "description": "Release tag that should be created after the PR is merged, for example v1.4.0."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout containing the release bump."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "version_bump_commit",
@@ -1631,7 +1538,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why release preparation cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1647,7 +1554,7 @@
         "required_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -1668,11 +1575,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout containing the release bump."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -1688,7 +1595,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1724,15 +1631,15 @@
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the release pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed release branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "release_version",
@@ -1740,7 +1647,7 @@
           },
           {
             "name": "release_tag",
-            "description": "Release tag to create after the PR is merged."
+            "description": "Release tag to create or publish after PR merge."
           }
         ]
       },
@@ -1756,7 +1663,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why release PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1769,16 +1676,6 @@
             "field": "pr_url"
           },
           {
-            "name": "release_version",
-            "source": "transition_output",
-            "field": "release_version"
-          },
-          {
-            "name": "release_tag",
-            "source": "transition_output",
-            "field": "release_tag"
-          },
-          {
             "name": "branch_name",
             "source": "transition_output",
             "field": "branch_name"
@@ -1789,6 +1686,16 @@
             "field": "workspace_path"
           },
           {
+            "name": "release_version",
+            "source": "transition_output",
+            "field": "release_version"
+          },
+          {
+            "name": "release_tag",
+            "source": "transition_output",
+            "field": "release_tag"
+          },
+          {
             "name": "ci_report",
             "source": "transition_output",
             "field": "ci_report"
@@ -1797,7 +1704,15 @@
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the release pull request."
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "release_version",
@@ -1805,15 +1720,7 @@
           },
           {
             "name": "release_tag",
-            "description": "Release tag to create after the PR is merged."
-          },
-          {
-            "name": "branch_name",
-            "description": "Name of the pushed release branch."
-          },
-          {
-            "name": "workspace_path",
-            "description": "Path to the worktree or checkout containing the release bump."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
             "name": "ci_report",
@@ -1838,7 +1745,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout containing the release bump."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "ci_report",
@@ -1858,7 +1765,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why release PR CI monitoring cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1894,11 +1801,11 @@
         "required_provision_fields": [
           {
             "name": "release_version",
-            "description": "Published release version."
+            "description": "Release version prepared by this workflow."
           },
           {
             "name": "release_tag",
-            "description": "Pushed release tag."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
             "name": "target_commit",
@@ -1906,7 +1813,7 @@
           },
           {
             "name": "pr_url",
-            "description": "URL of the merged release pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "tag_push_status",
@@ -1926,7 +1833,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why release tag publication cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1958,7 +1865,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why release automation monitoring cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1975,85 +1882,6 @@
           {
             "name": "cleanup_report",
             "description": "Summary of cleanup performed or deliberately skipped."
-          }
-        ]
-      },
-      {
-        "edge_id": "edge-cf64d3bb-e98a-4d84-ba3f-783f6e64ed78",
-        "input_bindings": [
-          {
-            "name": "release_version",
-            "source": "transition_output",
-            "field": "release_version"
-          },
-          {
-            "name": "release_type",
-            "source": "transition_output",
-            "field": "release_type"
-          },
-          {
-            "name": "release_branch",
-            "source": "transition_output",
-            "field": "release_branch"
-          },
-          {
-            "name": "release_tag",
-            "source": "transition_output",
-            "field": "release_tag"
-          },
-          {
-            "name": "workspace_path",
-            "source": "transition_output",
-            "field": "workspace_path"
-          },
-          {
-            "name": "version_bump_commit",
-            "source": "transition_output",
-            "field": "version_bump_commit"
-          },
-          {
-            "name": "verification_summary",
-            "source": "transition_output",
-            "field": "verification_summary"
-          },
-          {
-            "name": "blocker_reason",
-            "source": "transition_output",
-            "field": "blocker_reason"
-          }
-        ],
-        "required_provision_fields": [
-          {
-            "name": "release_version",
-            "description": "Prepared release version, for example 1.4.0."
-          },
-          {
-            "name": "release_type",
-            "description": "Version bump type: minor by default, patch or major only when explicitly requested."
-          },
-          {
-            "name": "release_branch",
-            "description": "Release branch containing the version bump."
-          },
-          {
-            "name": "release_tag",
-            "description": "Release tag that should be created after the PR is merged, for example v1.4.0."
-          },
-          {
-            "name": "workspace_path",
-            "description": "Path to the worktree or checkout containing the release bump."
-          },
-          {
-            "name": "version_bump_commit",
-            "description": "Commit hash containing the version bump."
-          },
-          {
-            "name": "verification_summary",
-            "description": "Commands run and their pass/fail results."
-          },
-          {
-            "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
           }
         ]
       },
@@ -2094,7 +1922,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "release_version",
@@ -2110,31 +1938,21 @@
           },
           {
             "name": "release_tag",
-            "description": "Release tag to create after the PR is merged."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
             "name": "blocker_reason",
-            "description": "Why release PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
       {
-        "edge_id": "edge-75fce052-321b-4f1a-855b-ce692f89e46b",
+        "edge_id": "edge-b4ae17cc-edc6-47e2-b9ea-c4b00cd07600",
         "input_bindings": [
           {
             "name": "pr_url",
             "source": "transition_output",
             "field": "pr_url"
-          },
-          {
-            "name": "release_version",
-            "source": "transition_output",
-            "field": "release_version"
-          },
-          {
-            "name": "release_tag",
-            "source": "transition_output",
-            "field": "release_tag"
           },
           {
             "name": "branch_name",
@@ -2147,15 +1965,33 @@
             "field": "workspace_path"
           },
           {
-            "name": "ci_report",
+            "name": "release_version",
             "source": "transition_output",
-            "field": "ci_report"
+            "field": "release_version"
+          },
+          {
+            "name": "release_tag",
+            "source": "transition_output",
+            "field": "release_tag"
+          },
+          {
+            "name": "merge_report",
+            "source": "transition_output",
+            "field": "merge_report"
           }
         ],
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the release pull request."
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "release_version",
@@ -2163,29 +1999,21 @@
           },
           {
             "name": "release_tag",
-            "description": "Release tag to create after the PR is merged."
+            "description": "Release tag to create or publish after PR merge."
           },
           {
-            "name": "branch_name",
-            "description": "Name of the pushed release branch."
-          },
-          {
-            "name": "workspace_path",
-            "description": "Path to the worktree or checkout containing the release bump."
-          },
-          {
-            "name": "ci_report",
-            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+            "name": "merge_report",
+            "description": "GitHub PR state, mergedAt, mergeCommit, and cleanup or release notes."
           }
         ]
       },
       {
-        "edge_id": "edge-3772a318-3329-4c26-82d1-7118a7ba5932",
+        "edge_id": "edge-dcac956d-47aa-4a43-87e4-ccae167e11e3",
         "input_bindings": [
           {
-            "name": "pr_url",
+            "name": "workspace_path",
             "source": "transition_output",
-            "field": "pr_url"
+            "field": "workspace_path"
           },
           {
             "name": "release_version",
@@ -2196,6 +2024,39 @@
             "name": "release_tag",
             "source": "transition_output",
             "field": "release_tag"
+          },
+          {
+            "name": "pr_report",
+            "source": "transition_output",
+            "field": "pr_report"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "release_version",
+            "description": "Release version prepared by this workflow."
+          },
+          {
+            "name": "release_tag",
+            "description": "Release tag to create or publish after PR merge."
+          },
+          {
+            "name": "pr_report",
+            "description": "PR creation, review, conflict, or post-CI regression report."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-37f43543-3ab7-4f60-bcf1-5ae7e8a2bcac",
+        "input_bindings": [
+          {
+            "name": "pr_url",
+            "source": "transition_output",
+            "field": "pr_url"
           },
           {
             "name": "branch_name",
@@ -2208,47 +2069,6 @@
             "field": "workspace_path"
           },
           {
-            "name": "ci_report",
-            "source": "transition_output",
-            "field": "ci_report"
-          }
-        ],
-        "required_provision_fields": [
-          {
-            "name": "pr_url",
-            "description": "URL of the merged release pull request."
-          },
-          {
-            "name": "release_version",
-            "description": "Published release version."
-          },
-          {
-            "name": "release_tag",
-            "description": "Pushed release tag."
-          },
-          {
-            "name": "branch_name",
-            "description": "Name of the pushed release branch."
-          },
-          {
-            "name": "workspace_path",
-            "description": "Path to the worktree or checkout containing the release bump."
-          },
-          {
-            "name": "ci_report",
-            "description": "Publication readiness or CI/check status report."
-          }
-        ]
-      },
-      {
-        "edge_id": "edge-66a9f114-a244-4321-ace5-ffd759cc3af4",
-        "input_bindings": [
-          {
-            "name": "pr_url",
-            "source": "transition_output",
-            "field": "pr_url"
-          },
-          {
             "name": "release_version",
             "source": "transition_output",
             "field": "release_version"
@@ -2257,6 +2077,47 @@
             "name": "release_tag",
             "source": "transition_output",
             "field": "release_tag"
+          },
+          {
+            "name": "waiting_reason",
+            "source": "transition_output",
+            "field": "waiting_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "release_version",
+            "description": "Release version prepared by this workflow."
+          },
+          {
+            "name": "release_tag",
+            "description": "Release tag to create or publish after PR merge."
+          },
+          {
+            "name": "waiting_reason",
+            "description": "Why the PR cannot advance yet and the exact user or external action needed."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-bd3ab2d8-ced1-43b2-b740-ada232876991",
+        "input_bindings": [
+          {
+            "name": "pr_url",
+            "source": "transition_output",
+            "field": "pr_url"
           },
           {
             "name": "branch_name",
@@ -2269,105 +2130,43 @@
             "field": "workspace_path"
           },
           {
-            "name": "ci_report",
+            "name": "cleanup_reason",
             "source": "transition_output",
-            "field": "ci_report"
-          },
-          {
-            "name": "blocker_reason",
-            "source": "transition_output",
-            "field": "blocker_reason"
+            "field": "cleanup_reason"
           }
         ],
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the merged release pull request."
-          },
-          {
-            "name": "release_version",
-            "description": "Published release version."
-          },
-          {
-            "name": "release_tag",
-            "description": "Pushed release tag."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed release branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout containing the release bump."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
-            "name": "ci_report",
-            "description": "Publication readiness or CI/check status report."
-          },
-          {
-            "name": "blocker_reason",
-            "description": "Why release tag publication cannot complete, in the task language when practical."
+            "name": "cleanup_reason",
+            "description": "Explicit user instruction or reason for cleanup without merge."
           }
         ]
       },
       {
-        "edge_id": "edge-1782e3e8-0549-4b08-b6cb-0750d6c35fc2",
+        "edge_id": "edge-9228ca82-9ab5-4dfe-b073-21ebe5d0b65f",
         "input_bindings": [
           {
-            "name": "release_version",
+            "name": "closure_reason",
             "source": "transition_output",
-            "field": "release_version"
-          },
-          {
-            "name": "release_tag",
-            "source": "transition_output",
-            "field": "release_tag"
-          },
-          {
-            "name": "target_commit",
-            "source": "transition_output",
-            "field": "target_commit"
-          },
-          {
-            "name": "pr_url",
-            "source": "transition_output",
-            "field": "pr_url"
-          },
-          {
-            "name": "tag_push_status",
-            "source": "transition_output",
-            "field": "tag_push_status"
-          },
-          {
-            "name": "release_report",
-            "source": "transition_output",
-            "field": "release_report"
+            "field": "closure_reason"
           }
         ],
         "required_provision_fields": [
           {
-            "name": "release_version",
-            "description": "Published release version."
-          },
-          {
-            "name": "release_tag",
-            "description": "Pushed release tag."
-          },
-          {
-            "name": "target_commit",
-            "description": "Master commit targeted by the release tag."
-          },
-          {
-            "name": "pr_url",
-            "description": "URL of the merged release pull request."
-          },
-          {
-            "name": "tag_push_status",
-            "description": "Result of local/remote tag creation and push."
-          },
-          {
-            "name": "release_report",
-            "description": "Release publication and automation monitoring report."
+            "name": "closure_reason",
+            "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
           }
         ]
       }

--- a/.kent/workflows/puber-smoke-test.json
+++ b/.kent/workflows/puber-smoke-test.json
@@ -3,7 +3,7 @@
     "id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
     "name": "Puber Smoke Test",
     "description": "Run focused Puber Android TV smoke tests, optionally fix approved findings, and clean up safely.",
-    "version": 68
+    "version": 144
   },
   "nodes": [
     {
@@ -43,9 +43,9 @@
     {
       "id": "node-89a1477a-eadb-4b3f-9d16-a7f2dea1498b",
       "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
-      "key": "blocked",
+      "key": "wont_do",
       "kind": "terminal",
-      "display_name": "Blocked"
+      "display_name": "Won't Do"
     },
     {
       "id": "node-99d57195-577d-4ee3-9086-d8339dff7c69",
@@ -71,6 +71,15 @@
       "key": "ci_monitor",
       "kind": "agent",
       "display_name": "Monitor CI",
+      "subagent_role": "default",
+      "completion_mode": "shell_command"
+    },
+    {
+      "id": "node-468dab3c-6389-4624-bf49-13e7b544c468",
+      "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
+      "key": "waiting_pr",
+      "kind": "agent",
+      "display_name": "Waiting PR",
       "subagent_role": "default",
       "completion_mode": "shell_command"
     },
@@ -103,17 +112,17 @@
       "id": "group-994f8b45-b450-4a58-a211-bc13f9faac3e",
       "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
       "source_node_id": "node-1ec7322f-4f0b-472d-87b3-129e4f184bb0",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "Smoke test passed or is accepted; run mandatory compliance review before cleanup."
+      "transition_id": "compliance",
+      "display_name": "Compliance",
+      "description": "Work passed this stage; run mandatory compliance review before any PR/cleanup path."
     },
     {
       "id": "group-ff5aa281-cdb0-46a3-bd91-0a287a66bfd2",
       "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
       "source_node_id": "node-1ec7322f-4f0b-472d-87b3-129e4f184bb0",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Smoke test is blocked by missing device, MCP, build, credentials, or navigation context."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "smoke cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-4fe2662b-c00a-4ae3-b180-355ced99e974",
@@ -127,9 +136,9 @@
       "id": "group-e1a6dce2-a696-4a00-9513-e82bb0add0b4",
       "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
       "source_node_id": "node-a8823a49-9b62-44f8-8ac2-3cc3d7a2eb08",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Smoke finding fix is blocked."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "fix cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-fea7464d-6509-4e83-80a4-5098d8a7fca2",
@@ -143,9 +152,9 @@
       "id": "group-f9ba75f9-24a2-4372-9728-e067af4ab0a8",
       "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
       "source_node_id": "node-99d57195-577d-4ee3-9086-d8339dff7c69",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "Compliance review passed; create or update the task pull request before cleanup."
+      "transition_id": "ship_pr",
+      "display_name": "Ship PR",
+      "description": "Compliance passed; create or update the task PR before any terminal completion."
     },
     {
       "id": "group-3a5afe26-6e0a-4a04-b1b5-3a7dd845b8e1",
@@ -159,9 +168,9 @@
       "id": "group-d529ee06-3111-44e0-9aae-f911d7176c89",
       "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
       "source_node_id": "node-99d57195-577d-4ee3-9086-d8339dff7c69",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Compliance review is blocked by missing or contradictory required sources."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "compliance cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-466fefdd-6202-47dc-97f6-d67bc7a585f1",
@@ -175,25 +184,25 @@
       "id": "group-4a58298e-77b9-4af5-96bf-f202c22b515a",
       "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
       "source_node_id": "node-5ada6e8d-1e36-4c6a-9ca2-1f7b6e334b59",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "PR is intentionally not applicable because there are no repository changes; run cleanup."
+      "transition_id": "no_pr",
+      "display_name": "No PR",
+      "description": "No PR is applicable because there are no repository changes or the task is explicitly report-only; cleanup can finish the task."
     },
     {
       "id": "group-44695473-4148-4303-9440-085c007fd513",
       "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
       "source_node_id": "node-5ada6e8d-1e36-4c6a-9ca2-1f7b6e334b59",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "PR creation or update is blocked by git state, auth, remote, branch, or unsafe repository state."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "ship_pr cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-9bbe17aa-20d5-4992-bc40-e7cfb1825bab",
       "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
       "source_node_id": "node-d4c0080d-88fe-49d3-b5b2-f7d662cc6be9",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "PR checks passed or are intentionally skipped; run conservative cleanup."
+      "transition_id": "waiting_pr",
+      "display_name": "Waiting PR",
+      "description": "PR checks passed or were intentionally skipped; wait until the PR is merged before cleanup/done."
     },
     {
       "id": "group-104771b1-e0c0-4d01-872a-cccddf8508cd",
@@ -207,9 +216,9 @@
       "id": "group-006c973d-f955-449a-bb81-b31dd8b34a24",
       "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
       "source_node_id": "node-d4c0080d-88fe-49d3-b5b2-f7d662cc6be9",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "CI monitoring is blocked by GitHub access, missing check data, or unsafe repository state."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "ci_monitor cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-6e4c4804-a437-4104-ae83-50636b721a45",
@@ -220,20 +229,44 @@
       "description": "PR creation/update hit a recoverable branch, rebase, conflict, or metadata issue; user approval required before recovery work."
     },
     {
-      "id": "group-577dc04b-4042-42a6-88ce-3b33ac7d929e",
+      "id": "group-5ba04cc4-ab2d-46ec-bdae-15b06790f87d",
       "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
-      "source_node_id": "node-d4c0080d-88fe-49d3-b5b2-f7d662cc6be9",
-      "transition_id": "retry_later",
-      "display_name": "Retry Later",
-      "description": "CI or GitHub is temporarily unavailable, still starting, or missing an expected run; user approval required before retrying monitoring."
+      "source_node_id": "node-468dab3c-6389-4624-bf49-13e7b544c468",
+      "transition_id": "pr_merged",
+      "display_name": "Pr Merged",
+      "description": "PR is confirmed merged; cleanup can finish the task."
     },
     {
-      "id": "group-f0e033a4-349f-46be-bf5b-325feb0526e3",
+      "id": "group-232c28c1-8ad2-4891-aba3-12b4f565d023",
+      "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
+      "source_node_id": "node-468dab3c-6389-4624-bf49-13e7b544c468",
+      "transition_id": "needs_changes",
+      "display_name": "Needs Changes",
+      "description": "PR review, conflicts, or post-CI regressions need task-scoped fixes."
+    },
+    {
+      "id": "group-5b70c7c6-f86e-408a-9e12-3fdc83a3c7b5",
+      "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
+      "source_node_id": "node-468dab3c-6389-4624-bf49-13e7b544c468",
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "PR is still waiting on a human or external process; remain in Waiting PR."
+    },
+    {
+      "id": "group-ff588392-1d47-441d-a49d-2719ba89331f",
+      "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
+      "source_node_id": "node-468dab3c-6389-4624-bf49-13e7b544c468",
+      "transition_id": "close_without_merge",
+      "display_name": "Close Without Merge",
+      "description": "User explicitly closed/canceled the PR without merge; cleanup can finish."
+    },
+    {
+      "id": "group-4719f5bc-d2af-4c9d-8ad9-e8004240accf",
       "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
       "source_node_id": "node-1ec7322f-4f0b-472d-87b3-129e4f184bb0",
-      "transition_id": "retry_later",
-      "display_name": "Retry Later",
-      "description": "Device, MCP, build, or emulator-lock access is temporarily unavailable; user approval required before retrying smoke."
+      "transition_id": "wont_do",
+      "display_name": "Wont Do",
+      "description": "Latest user comment explicitly cancels this task or declares it not planned; finish without treating it as a recoverable blocker."
     }
   ],
   "edges": [
@@ -248,7 +281,7 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Run the Puber smoke-test flow for this Kent task.\n\nRead .kent/project-contract.md first, then use .kent/commands/smoke-test.md. Treat the task body as the target feature/screen and device notes. Before touching any emulator/device, use .kent/adapters/mobile/emulator-resource-lock.sh to discover running adb emulators and acquire any free emulator-specific lock. Pass the selected serial to every adb command with adb -s. Physical devices, including a real TV, are forbidden unless the task/user explicitly names or allows that physical device. Never rely on adb default target selection. If all running emulators are busy, inspect lock owners and start a second emulator only when the task/user explicitly allows parallel device usage and you can acquire a distinct lock for it. Install a trap immediately after acquiring a lock so it is released on failure.\n\nFollow AGENTS.md MCP Mobile Testing rules: always build a fresh devDebug APK before device testing, install it with explicit adb -s \"$DEVICE_SERIAL\" install -r app/build/outputs/apk/dev/debug/app-dev-debug.apk, force-stop the app, and launch com.kino.puber.stage/com.kino.puber.MainActivity. Do not use Gradle install* tasks for smoke tests. Do this even if the task/user says the app is already running. Prefer UI tree/assertions over screenshots, and save artifacts only for issues. Release the mobile resource lock after reporting.\n\nDo not edit production code in this smoke node. Complete with done if the smoke test passes or is accepted. Complete with needs_changes if you found an actionable app issue and provide smoke_report, reproduction_steps, and artifacts_path. Complete with retry_later if device/MCP/build/access/resource locking is temporarily unavailable and provide blocker_reason. Complete with blocked only for unrecoverable smoke blockers that cannot be solved by waiting, freeing an emulator, or user approval; provide blocker_reason."
+      "prompt_template": "Run the Puber smoke-test flow for this Kent task.\n\nRead .kent/project-contract.md first, then use .kent/commands/smoke-test.md. Treat the task body as the target feature/screen and device notes. Before touching any emulator/device, use .kent/adapters/mobile/emulator-resource-lock.sh to discover running adb emulators and acquire any free emulator-specific lock. Pass the selected serial to every adb command with adb -s. Physical devices, including a real TV, are forbidden unless the task/user explicitly provides permission and an explicit serial for that physical device. Never rely on adb default target selection. If all running emulators are busy, inspect lock owners and start a second emulator only when the task/user explicitly allows parallel device usage and you can acquire a distinct lock for it. Install a trap immediately after acquiring a lock so it is released on failure.\n\nFollow AGENTS.md MCP Mobile Testing rules: always build a fresh devDebug APK before device testing, install it with explicit adb -s \"$DEVICE_SERIAL\" install -r app/build/outputs/apk/dev/debug/app-dev-debug.apk, force-stop the app, and launch com.kino.puber.stage/com.kino.puber.MainActivity. Do not use Gradle install* tasks for smoke tests. Do this even if the task/user says the app is already running. Prefer UI tree/assertions over screenshots, and save artifacts only for issues. Release the mobile resource lock after reporting.\n\nDo not edit production code in this smoke node. Complete with compliance if the smoke test passes or is accepted. Complete with needs_changes if you found an actionable app issue and provide smoke_report, reproduction_steps, and artifacts_path. Complete with needs_user_action for temporary external waits; provide blocker_reason. Complete with needs_user_action only for unrecoverable smoke blockers that cannot be solved by waiting, freeing an emulator, or user approval; provide blocker_reason."
     },
     {
       "id": "edge-16af50c0-868d-4b74-94c5-cebf92c4a1bb",
@@ -256,16 +289,16 @@
       "transition_group_id": "group-149ada3e-5137-4fe4-a2f4-f9d978eb8c81",
       "key": "fix_finding",
       "target_node_id": "node-a8823a49-9b62-44f8-8ac2-3cc3d7a2eb08",
-      "requires_approval": true,
+      "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Fix the approved Puber smoke-test finding.\n\nRead .kent/project-contract.md first. Apply the smallest robust fix for {{.Params.smoke_report}}. Verify with focused Gradle/test commands and, if practical, the reproduction steps {{.Params.reproduction_steps}}. Use ./tools/agentw in .kent/worktrees and ./gradlew in the main checkout.\n\nComplete with smoke and provide fix_report, changed_files, and verification_summary. Complete with blocked if unsafe or missing input and provide blocker_reason.",
+      "prompt_template": "Fix the approved Puber smoke-test finding.\n\nRead .kent/project-contract.md first. Apply the smallest robust fix for {{.Params.smoke_report}}. Verify with focused Gradle/test commands and, if practical, the reproduction steps {{.Params.reproduction_steps}}. Use ./tools/agentw in .kent/worktrees and ./gradlew in the main checkout.\n\nComplete with smoke and provide fix_report, changed_files, and verification_summary. Complete with needs_user_action if unsafe or missing input and provide blocker_reason.",
       "parameters": [
         {
           "key": "smoke_report",
-          "description": "Smoke test findings and expected versus actual behavior."
+          "description": "Device smoke report or artifact path."
         },
         {
           "key": "reproduction_steps",
@@ -281,30 +314,31 @@
       "id": "edge-ae6c796c-a9e5-405e-aaf2-ea11f6f0ae31",
       "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
       "transition_group_id": "group-994f8b45-b450-4a58-a211-bc13f9faac3e",
-      "key": "smoke_done",
+      "key": "smoke_compliance",
       "target_node_id": "node-99d57195-577d-4ee3-9086-d8339dff7c69",
       "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Run mandatory Puber Compliance Review before cleanup.\n\nRead .kent/commands/compliance-review.md, .kent/commands/smoke-test.md, .kent/project-contract.md, and AGENTS.md first. Reviewed scope: completed smoke-test work product and process. Verify compliance with mandatory fresh devDebug install/restart, MCP testing rules, task requirements, and workflow contract. Do not edit files.\n\nComplete with done and provide compliance_report when no compliance violations are found. Complete with needs_changes and provide compliance_report when smoke rework is required. Complete with blocked and provide blocker_reason if required sources are missing or contradictory."
+      "prompt_template": "Run mandatory Puber Compliance Review before cleanup.\n\nRead .kent/commands/compliance-review.md, .kent/commands/smoke-test.md, .kent/project-contract.md, and AGENTS.md first. Reviewed scope: completed smoke-test work product and process. Verify compliance with mandatory fresh devDebug install/restart, MCP testing rules, task requirements, and workflow contract. Do not edit files.\n\nComplete with ship_pr and provide compliance_report when no compliance violations are found. Complete with needs_changes and provide compliance_report when smoke rework is required. Complete with needs_user_action and provide blocker_reason if required sources are missing or contradictory."
     },
     {
       "id": "edge-4a84d29b-cb6a-4381-9197-1182ada3dd82",
       "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
       "transition_group_id": "group-ff5aa281-cdb0-46a3-bd91-0a287a66bfd2",
-      "key": "smoke_blocked",
-      "target_node_id": "node-89a1477a-eadb-4b3f-9d16-a7f2dea1498b",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "smoke_needs_user_action",
+      "target_node_id": "node-1ec7322f-4f0b-472d-87b3-129e4f184bb0",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why smoke testing cannot continue, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -319,7 +353,7 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Re-run the focused Puber smoke test after the fix.\n\nRead .kent/project-contract.md first. Use {{.Params.fix_report}} and {{.Params.verification_summary}} as context. Follow .kent/commands/smoke-test.md and AGENTS.md MCP rules, including running-emulator pool locking, adb -s for every adb command, no physical devices unless explicitly allowed by the task/user, trap-based lock release, fresh devDebug build, and explicit adb -s APK install before testing. Do not use Gradle install* tasks. Do not edit files in this node. Release the mobile resource lock after reporting. Complete with done, needs_changes, or blocked.",
+      "prompt_template": "Re-run the focused Puber smoke test after the fix.\n\nRead .kent/project-contract.md first. Use {{.Params.fix_report}} and {{.Params.verification_summary}} as context. Follow .kent/commands/smoke-test.md and AGENTS.md MCP rules, including running-emulator pool locking, adb -s for every adb command, no physical devices unless the task/user explicitly provides permission and an explicit serial, trap-based lock release, fresh devDebug build, and explicit adb -s APK install before testing. Do not use Gradle install* tasks. Do not edit files in this node. Release the mobile resource lock after reporting. Complete with compliance, needs_changes, or needs_user_action.\n\nFor any needs_user_action transition, provide blocker_reason with the exact next user or external action needed.",
       "parameters": [
         {
           "key": "fix_report",
@@ -339,17 +373,18 @@
       "id": "edge-4fb860fe-b23f-42c0-b2cc-cf8e3b862151",
       "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
       "transition_group_id": "group-e1a6dce2-a696-4a00-9513-e82bb0add0b4",
-      "key": "fix_blocked",
-      "target_node_id": "node-89a1477a-eadb-4b3f-9d16-a7f2dea1498b",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "fix_needs_user_action",
+      "target_node_id": "node-a8823a49-9b62-44f8-8ac2-3cc3d7a2eb08",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why fixing cannot continue, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -375,18 +410,18 @@
       "id": "edge-eb028b96-a67e-4a63-aed0-3f48e9cc82b3",
       "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
       "transition_group_id": "group-f9ba75f9-24a2-4372-9728-e067af4ab0a8",
-      "key": "compliance_done",
+      "key": "compliance_ship_pr",
       "target_node_id": "node-5ada6e8d-1e36-4c6a-9ca2-1f7b6e334b59",
       "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Create or update the Puber pull request for this completed task.\n\nRead .kent/project-contract.md, .kent/commands/ship-pr.md, and AGENTS.md first. Compliance result: {{.Params.compliance_report}}.\n\nIf this task produced repository changes, commit only task-related files, push the current task branch to origin, and create or update a GitHub PR. Do not merge the PR. Do not push directly to master/main. If there are no repository changes and the task is report-only or smoke-only, complete with done and provide pr_report explaining why PR is not applicable.\n\nComplete with monitor_ci when a PR exists and provide pr_url, branch_name, and workspace_path. Complete with needs_changes when PR creation/update is blocked by recoverable repository, branch, or PR state such as merge conflicts, non-fast-forward push, branch needing rebase, or missing PR metadata that can be fixed in the task worktree; provide workspace_path and blocker_reason. Complete with done only for PR-not-applicable/no-diff cases and provide pr_report. Complete with blocked only when continuing would be unsafe without changing task scope, credentials, or project policy; provide blocker_reason.",
+      "prompt_template": "Create or update the Puber pull request for this completed task.\n\nRead .kent/project-contract.md, .kent/commands/ship-pr.md, and AGENTS.md first. Compliance result: {{.Params.compliance_report}}.\n\nIf this task produced repository changes, commit only task-related files, push the current task branch to origin, and create or update a GitHub PR. Do not merge the PR. Do not push directly to master/main. If there are no repository changes and the task is report-only or smoke-only, complete with no_pr and provide pr_report explaining why PR is not applicable.\n\nComplete with monitor_ci when a PR exists and provide pr_url, branch_name, and workspace_path. Complete with needs_changes when PR creation/update is needs_user_action by recoverable repository, branch, or PR state such as merge conflicts, non-fast-forward push, branch needing rebase, or missing PR metadata that can be fixed in the task worktree; provide workspace_path and blocker_reason. Complete with no_pr only for PR-not-applicable/no-diff cases and provide pr_report. Complete with needs_user_action only when continuing would be unsafe without changing task scope, credentials, or project policy; provide blocker_reason.",
       "parameters": [
         {
           "key": "compliance_report",
-          "description": "Compliance review report, including rule sources checked and any findings."
+          "description": "Compliance review report or summary."
         }
       ]
     },
@@ -396,16 +431,16 @@
       "transition_group_id": "group-3a5afe26-6e0a-4a04-b1b5-3a7dd845b8e1",
       "key": "compliance_smoke",
       "target_node_id": "node-1ec7322f-4f0b-472d-87b3-129e4f184bb0",
-      "requires_approval": true,
+      "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Rework the Puber smoke test to resolve compliance findings only.\n\nRead .kent/commands/compliance-review.md and .kent/commands/smoke-test.md first. Re-run or supplement smoke testing only as required by {{.Params.compliance_report}}. Acquire a shared mobile resource lock from the running emulator pool before touching any emulator/device, use adb -s for every adb command, do not use physical devices unless explicitly allowed by the task/user, install a trap to release the lock, always build and install a fresh devDebug APK with explicit adb -s before device testing, and release the lock after reporting. Do not use Gradle install* tasks. Do not edit production code in this node. Complete with done, needs_changes, or blocked according to the smoke workflow contract.",
+      "prompt_template": "Rework the Puber smoke test to resolve compliance findings only.\n\nRead .kent/commands/compliance-review.md and .kent/commands/smoke-test.md first. Re-run or supplement smoke testing only as required by {{.Params.compliance_report}}. Acquire a shared mobile resource lock from the running emulator pool before touching any emulator/device, use adb -s for every adb command, do not use physical devices unless the task/user explicitly provides permission and an explicit serial, install a trap to release the lock, always build and install a fresh devDebug APK with explicit adb -s before device testing, and release the lock after reporting. Do not use Gradle install* tasks. Do not edit production code in this node. Complete with compliance, needs_changes, or needs_user_action according to the smoke workflow contract.\n\nFor any needs_user_action transition, provide blocker_reason with the exact next user or external action needed.",
       "parameters": [
         {
           "key": "compliance_report",
-          "description": "Compliance review report, including rule sources checked and any findings."
+          "description": "Compliance review report or summary."
         }
       ]
     },
@@ -413,17 +448,18 @@
       "id": "edge-10e635a3-6525-4e74-a184-d6896c3fd86f",
       "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
       "transition_group_id": "group-d529ee06-3111-44e0-9aae-f911d7176c89",
-      "key": "compliance_blocked",
-      "target_node_id": "node-89a1477a-eadb-4b3f-9d16-a7f2dea1498b",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "compliance_needs_user_action",
+      "target_node_id": "node-99d57195-577d-4ee3-9086-d8339dff7c69",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why compliance review cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -438,19 +474,19 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Monitor Puber PR checks.\n\nRead .kent/project-contract.md and AGENTS.md first. Inspect PR {{.Params.pr_url}} on branch {{.Params.branch_name}}. Use GitHub CLI when available. Do not merge the PR. Do not push new commits from this node.\n\nComplete with done if CI/checks pass, are absent, or are intentionally skipped with a clear reason; provide ci_report and pr_url. Complete with needs_changes if CI failed due to task changes and provide workspace_path plus ci_report. Complete with retry_later when checks cannot be inspected because GitHub/CI is still starting, rate-limited, temporarily unavailable, or an expected run has not appeared yet; provide pr_url, branch_name, workspace_path, and ci_report. Complete with blocked only if checks cannot be inspected and retrying would be unsafe or misleading; provide blocker_reason.",
+      "prompt_template": "Monitor Puber PR checks.\n\nRead .kent/project-contract.md and AGENTS.md first. Inspect PR {{.Params.pr_url}} on branch {{.Params.branch_name}}. Use GitHub CLI when available. Do not merge the PR. Do not push new commits from this node.\n\nComplete with waiting_pr if CI/checks pass, are absent, or are intentionally skipped with a clear reason; provide ci_report and pr_url. Complete with needs_changes if CI failed due to task changes and provide workspace_path plus ci_report. Complete with needs_user_action for temporary external waits; provide blocker_reason. Complete with needs_user_action only if checks cannot be inspected and retrying would be unsafe or misleading; provide blocker_reason.",
       "parameters": [
         {
           "key": "pr_url",
-          "description": "URL of the pull request."
+          "description": "URL of the created, updated, or monitored pull request."
         },
         {
           "key": "branch_name",
-          "description": "Name of the pushed task branch."
+          "description": "Name of the task or release branch associated with the pull request."
         },
         {
           "key": "workspace_path",
-          "description": "Path to the worktree or checkout used for PR creation."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         }
       ]
     },
@@ -469,7 +505,7 @@
       "parameters": [
         {
           "key": "pr_report",
-          "description": "Why no pull request was created or updated."
+          "description": "PR creation, review, conflict, or post-CI regression report."
         }
       ]
     },
@@ -477,17 +513,18 @@
       "id": "edge-c7200ad3-c810-42bd-9a69-e9c5f19d9232",
       "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
       "transition_group_id": "group-44695473-4148-4303-9440-085c007fd513",
-      "key": "pr_blocked",
-      "target_node_id": "node-89a1477a-eadb-4b3f-9d16-a7f2dea1498b",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "ship_pr_needs_user_action",
+      "target_node_id": "node-5ada6e8d-1e36-4c6a-9ca2-1f7b6e334b59",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why PR creation/update cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -495,22 +532,30 @@
       "id": "edge-b4464c1a-0d89-4c43-9ff7-f0b245660495",
       "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
       "transition_group_id": "group-9bbe17aa-20d5-4992-bc40-e7cfb1825bab",
-      "key": "ci_done",
-      "target_node_id": "node-28ccfbc5-149f-42d5-b4a8-1fda911cdbb2",
+      "key": "ci_waiting_pr",
+      "target_node_id": "node-468dab3c-6389-4624-bf49-13e7b544c468",
       "requires_approval": false,
       "context_mode": "new_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Run conservative Puber task cleanup after PR/CI.\n\nRead .kent/project-contract.md first, then use .kent/commands/cleanup-task.md. PR: {{.Params.pr_url}}. CI report: {{.Params.ci_report}}. Do not delete any worktree containing unpushed or uncommitted user changes. Complete with done and provide cleanup_report.",
+      "prompt_template": "Hold this Puber task until its pull request is actually merged.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, PR {{.Params.pr_url}}, branch {{.Params.branch_name}}, workspace {{.Params.workspace_path}}, and CI report {{.Params.ci_report}}.\n\nUse `gh pr view --json state,mergedAt,mergeCommit,headRefName,baseRefName,url` when available. Do not merge the PR. Do not push commits from this node. Do not clean up while the PR is still open.\n\nComplete with pr_merged only when GitHub reports state=MERGED; provide pr_url, branch_name, and merge_report. Complete with needs_changes when PR review comments, merge conflicts, or post-CI regressions can be fixed within the task scope; provide workspace_path and pr_report. Complete with needs_user_action when the PR is still open, waiting for human review/approval/merge, or needs_user_action by an external process; add a task comment with the current PR status and exact human action, then provide pr_url, branch_name, workspace_path, and waiting_reason. Complete with close_without_merge only if the latest user comment explicitly says to close/cancel/skip this PR; provide pr_url, branch_name, and cleanup_reason.",
       "parameters": [
+        {
+          "key": "pr_url",
+          "description": "URL of the created, updated, or monitored pull request."
+        },
+        {
+          "key": "branch_name",
+          "description": "Name of the task or release branch associated with the pull request."
+        },
+        {
+          "key": "workspace_path",
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
+        },
         {
           "key": "ci_report",
           "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
-        },
-        {
-          "key": "pr_url",
-          "description": "URL of the created or updated pull request."
         }
       ]
     },
@@ -520,16 +565,16 @@
       "transition_group_id": "group-104771b1-e0c0-4d01-872a-cccddf8508cd",
       "key": "ci_fix",
       "target_node_id": "node-a8823a49-9b62-44f8-8ac2-3cc3d7a2eb08",
-      "requires_approval": true,
+      "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Fix Puber smoke-finding CI failures only.\n\nRead .kent/project-contract.md first. Apply only the minimum changes required by CI report {{.Params.ci_report}}. Verify narrowly, then complete with smoke and provide fix_report, changed_files, and verification_summary. Complete with blocked and provide blocker_reason if unsafe or missing input.",
+      "prompt_template": "Fix Puber smoke-finding CI failures only.\n\nRead .kent/project-contract.md first. Apply only the minimum changes required by CI report {{.Params.ci_report}}. Verify narrowly, then complete with smoke and provide fix_report, changed_files, and verification_summary. Complete with needs_user_action and provide blocker_reason if unsafe or missing input.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the task workspace or worktree used for PR creation."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "ci_report",
@@ -541,17 +586,18 @@
       "id": "edge-929510ef-f7eb-4df8-be67-222a179e8fc6",
       "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
       "transition_group_id": "group-006c973d-f955-449a-bb81-b31dd8b34a24",
-      "key": "ci_blocked",
-      "target_node_id": "node-89a1477a-eadb-4b3f-9d16-a7f2dea1498b",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "ci_monitor_needs_user_action",
+      "target_node_id": "node-d4c0080d-88fe-49d3-b5b2-f7d662cc6be9",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why CI monitoring cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -566,65 +612,141 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Fix recoverable Puber PR creation/update issues only.\n\nRead .kent/project-contract.md, .kent/commands/ship-pr.md, and AGENTS.md first. Previous PR blocker: {{.Params.blocker_reason}}. Work in {{.Params.workspace_path}}. Apply only the minimum changes needed to make the task branch/PR shippable, such as rebasing, resolving merge conflicts, fixing branch metadata, or repairing the PR-ready commit set. Do not expand product scope. Verify narrowly, then continue through the workflow's normal review/compliance path. Complete with blocked only if the recovery is unsafe or requires user credentials/policy changes.",
+      "prompt_template": "Fix recoverable Puber PR creation/update issues only.\n\nRead .kent/project-contract.md, .kent/commands/ship-pr.md, and AGENTS.md first. Previous PR blocker: {{.Params.blocker_reason}}. Work in {{.Params.workspace_path}}. Apply only the minimum changes needed to make the task branch/PR shippable, such as rebasing, resolving merge conflicts, fixing branch metadata, or repairing the PR-ready commit set. Do not expand product scope. Verify narrowly, then continue through the workflow's normal review/compliance path. Complete with needs_user_action only if the recovery is unsafe or requires user credentials/policy changes.\n\nFor any needs_user_action transition, provide blocker_reason with the exact next user or external action needed.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the worktree or checkout used for PR creation."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "blocker_reason",
-          "description": "Why PR creation/update cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
     {
-      "id": "edge-dc8e9bed-e437-494f-9de2-5aacde485b77",
+      "id": "edge-34fa2755-feff-4de2-ac36-9520ec8ecb6f",
       "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
-      "transition_group_id": "group-577dc04b-4042-42a6-88ce-3b33ac7d929e",
-      "key": "ci_retry",
-      "target_node_id": "node-d4c0080d-88fe-49d3-b5b2-f7d662cc6be9",
-      "requires_approval": true,
-      "context_mode": "compact_and_continue_session",
+      "transition_group_id": "group-5ba04cc4-ab2d-46ec-bdae-15b06790f87d",
+      "key": "cleanup_after_merge",
+      "target_node_id": "node-28ccfbc5-149f-42d5-b4a8-1fda911cdbb2",
+      "requires_approval": false,
+      "context_mode": "new_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Retry Puber PR check monitoring after an approved temporary CI/GitHub wait.\n\nRead .kent/project-contract.md and AGENTS.md first. Previous CI status: {{.Params.ci_report}}. Inspect PR {{.Params.pr_url}} on branch {{.Params.branch_name}} again. Do not merge the PR. Do not push new commits from this node.\n\nComplete with done if CI/checks pass, are absent, or are intentionally skipped with a clear reason; provide ci_report and pr_url. Complete with needs_changes if CI failed due to task changes and provide workspace_path plus ci_report. Complete with retry_later if CI/GitHub is still temporarily unavailable and provide pr_url, branch_name, workspace_path, and ci_report. Complete with blocked only if retrying is no longer useful or safe; provide blocker_reason.",
+      "prompt_template": "Run conservative Puber task cleanup after the pull request was confirmed merged.\n\nRead AGENTS.md, .kent/project-contract.md, .kent/commands/cleanup-task.md, PR {{.Params.pr_url}}, branch {{.Params.branch_name}}, and merge report {{.Params.merge_report}}. Verify the PR is merged with GitHub state, not only git ancestry, because squash merges are allowed. Do not delete any worktree containing unpushed commits, uncommitted user changes, or unclear ownership. Complete with done and provide cleanup_report.",
       "parameters": [
         {
           "key": "pr_url",
-          "description": "URL of the created or updated pull request."
+          "description": "URL of the created, updated, or monitored pull request."
         },
         {
           "key": "branch_name",
-          "description": "Name of the pushed task branch."
+          "description": "Name of the task or release branch associated with the pull request."
         },
         {
-          "key": "workspace_path",
-          "description": "Path to the task workspace or worktree used for PR creation."
-        },
-        {
-          "key": "ci_report",
-          "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+          "key": "merge_report",
+          "description": "GitHub PR state, mergedAt, mergeCommit, and cleanup or release notes."
         }
       ]
     },
     {
-      "id": "edge-c8e20165-5c59-45db-a532-d05ae80c167e",
+      "id": "edge-cff32a6b-93e2-4e79-bd23-6bf412b89e43",
       "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
-      "transition_group_id": "group-f0e033a4-349f-46be-bf5b-325feb0526e3",
-      "key": "smoke_retry",
-      "target_node_id": "node-1ec7322f-4f0b-472d-87b3-129e4f184bb0",
+      "transition_group_id": "group-232c28c1-8ad2-4891-aba3-12b4f565d023",
+      "key": "pr_feedback",
+      "target_node_id": "node-a8823a49-9b62-44f8-8ac2-3cc3d7a2eb08",
+      "requires_approval": false,
+      "context_mode": "compact_and_continue_session",
+      "context_source": {
+        "kind": "immediate_source"
+      },
+      "prompt_template": "Fix Puber PR feedback only.\n\nRead AGENTS.md, .kent/project-contract.md, latest task comments, workspace {{.Params.workspace_path}}, and PR feedback report {{.Params.pr_report}}. Apply only task-scoped changes needed for PR review comments, merge conflicts, or post-CI regressions. Do not force-push unless the latest user comment explicitly permits force-push for this exact PR/branch. Verify narrowly, then return through the workflow's normal review/verify/compliance path with an updated report. If user input is required, complete with needs_user_action and provide blocker_reason.",
+      "parameters": [
+        {
+          "key": "workspace_path",
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
+        },
+        {
+          "key": "pr_report",
+          "description": "PR creation, review, conflict, or post-CI regression report."
+        }
+      ]
+    },
+    {
+      "id": "edge-6f908743-c30a-4519-86ee-a219fc8a6c31",
+      "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
+      "transition_group_id": "group-5b70c7c6-f86e-408a-9e12-3fdc83a3c7b5",
+      "key": "waiting_pr_needs_user_action",
+      "target_node_id": "node-468dab3c-6389-4624-bf49-13e7b544c468",
       "requires_approval": true,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Retry the Puber smoke-test flow after an approved temporary blocker wait.\n\nRead .kent/project-contract.md and .kent/commands/smoke-test.md first. Previous blocker: {{.Params.blocker_reason}}. Treat the task body as the target feature/screen and device notes. Follow the same emulator locking, physical-device prohibition, fresh devDebug build/install, and adb -s rules as the original smoke node.\n\nDo not edit production code in this smoke node. Complete with done if the smoke test passes or is accepted. Complete with needs_changes if you found an actionable app issue and provide smoke_report, reproduction_steps, and artifacts_path. Complete with retry_later if device/MCP/build/access/resource locking is still temporarily unavailable and provide blocker_reason. Complete with blocked only for unrecoverable smoke blockers; provide blocker_reason.",
+      "prompt_template": "Re-check the Puber pull request after the user resolved the external wait or approved another check.\n\nRead AGENTS.md, .kent/project-contract.md, latest task comments, PR {{.Params.pr_url}}, branch {{.Params.branch_name}}, workspace {{.Params.workspace_path}}, and previous waiting reason {{.Params.waiting_reason}}. Do not merge, push, or clean up unless the PR is confirmed merged.\n\nComplete with pr_merged only when GitHub reports state=MERGED. Complete with needs_changes for task-scoped PR review/conflict/regression fixes. Complete with needs_user_action again if the PR is still waiting externally. Complete with close_without_merge only on explicit latest user instruction.",
       "parameters": [
         {
-          "key": "blocker_reason",
-          "description": "Why smoke testing cannot continue, in the task language when practical."
+          "key": "pr_url",
+          "description": "URL of the created, updated, or monitored pull request."
+        },
+        {
+          "key": "branch_name",
+          "description": "Name of the task or release branch associated with the pull request."
+        },
+        {
+          "key": "workspace_path",
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
+        },
+        {
+          "key": "waiting_reason",
+          "description": "Why the PR cannot advance yet and the exact user or external action needed."
+        }
+      ]
+    },
+    {
+      "id": "edge-e4123c5a-9388-40c6-a99e-e75f518d7aba",
+      "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
+      "transition_group_id": "group-ff588392-1d47-441d-a49d-2719ba89331f",
+      "key": "cancel_cleanup",
+      "target_node_id": "node-28ccfbc5-149f-42d5-b4a8-1fda911cdbb2",
+      "requires_approval": true,
+      "context_mode": "new_session",
+      "context_source": {
+        "kind": "immediate_source"
+      },
+      "prompt_template": "Run conservative Puber task cleanup after the user explicitly closed/canceled the PR without merge.\n\nRead AGENTS.md, .kent/project-contract.md, .kent/commands/cleanup-task.md, PR {{.Params.pr_url}}, branch {{.Params.branch_name}}, and cleanup reason {{.Params.cleanup_reason}}. Do not delete any worktree containing unpushed commits, uncommitted user changes, or unclear ownership. Complete with done and provide cleanup_report.",
+      "parameters": [
+        {
+          "key": "pr_url",
+          "description": "URL of the created, updated, or monitored pull request."
+        },
+        {
+          "key": "branch_name",
+          "description": "Name of the task or release branch associated with the pull request."
+        },
+        {
+          "key": "cleanup_reason",
+          "description": "Explicit user instruction or reason for cleanup without merge."
+        }
+      ]
+    },
+    {
+      "id": "edge-584c28ac-62bf-465a-81a3-26aaec7abf2f",
+      "workflow_id": "workflow-0b5d2d8a-ce13-402c-98ff-11823327e173",
+      "transition_group_id": "group-4719f5bc-d2af-4c9d-8ad9-e8004240accf",
+      "key": "smoke_wont_do",
+      "target_node_id": "node-89a1477a-eadb-4b3f-9d16-a7f2dea1498b",
+      "requires_approval": true,
+      "context_mode": "new_session",
+      "context_source": {
+        "kind": "immediate_source"
+      },
+      "parameters": [
+        {
+          "key": "closure_reason",
+          "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
         }
       ]
     }
@@ -639,7 +761,7 @@
         "possible_provision_fields": [
           {
             "name": "smoke_report",
-            "description": "Smoke test findings and expected versus actual behavior."
+            "description": "Device smoke report or artifact path."
           },
           {
             "name": "reproduction_steps",
@@ -651,7 +773,11 @@
           },
           {
             "name": "blocker_reason",
-            "description": "Why smoke testing cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          },
+          {
+            "name": "closure_reason",
+            "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
           }
         ]
       },
@@ -672,7 +798,7 @@
           },
           {
             "name": "blocker_reason",
-            "description": "Why fixing cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -693,11 +819,11 @@
         "possible_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           },
           {
             "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -706,23 +832,23 @@
         "possible_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "pr_report",
-            "description": "Why no pull request was created or updated."
+            "description": "PR creation, review, conflict, or post-CI regression report."
           },
           {
             "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -730,24 +856,57 @@
         "node_id": "node-d4c0080d-88fe-49d3-b5b2-f7d662cc6be9",
         "possible_provision_fields": [
           {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
             "name": "ci_report",
             "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
           },
           {
-            "name": "pr_url",
-            "description": "URL of the created or updated pull request."
-          },
-          {
-            "name": "workspace_path",
-            "description": "Path to the task workspace or worktree used for PR creation."
-          },
-          {
             "name": "blocker_reason",
-            "description": "Why CI monitoring cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          }
+        ]
+      },
+      {
+        "node_id": "node-468dab3c-6389-4624-bf49-13e7b544c468",
+        "possible_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "merge_report",
+            "description": "GitHub PR state, mergedAt, mergeCommit, and cleanup or release notes."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "pr_report",
+            "description": "PR creation, review, conflict, or post-CI regression report."
+          },
+          {
+            "name": "waiting_reason",
+            "description": "Why the PR cannot advance yet and the exact user or external action needed."
+          },
+          {
+            "name": "cleanup_reason",
+            "description": "Explicit user instruction or reason for cleanup without merge."
           }
         ]
       },
@@ -764,7 +923,7 @@
         "required_provision_fields": [
           {
             "name": "smoke_report",
-            "description": "Smoke test findings and expected versus actual behavior."
+            "description": "Device smoke report or artifact path."
           },
           {
             "name": "reproduction_steps",
@@ -784,7 +943,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why smoke testing cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -810,7 +969,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why fixing cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -828,7 +987,7 @@
         "required_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -837,7 +996,7 @@
         "required_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -846,7 +1005,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -855,15 +1014,15 @@
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           }
         ]
       },
@@ -872,7 +1031,7 @@
         "required_provision_fields": [
           {
             "name": "pr_report",
-            "description": "Why no pull request was created or updated."
+            "description": "PR creation, review, conflict, or post-CI regression report."
           }
         ]
       },
@@ -881,7 +1040,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -889,12 +1048,20 @@
         "transition_group_id": "group-9bbe17aa-20d5-4992-bc40-e7cfb1825bab",
         "required_provision_fields": [
           {
-            "name": "ci_report",
-            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
-            "name": "pr_url",
-            "description": "URL of the created or updated pull request."
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "ci_report",
+            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
           }
         ]
       },
@@ -903,7 +1070,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the task workspace or worktree used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "ci_report",
@@ -916,7 +1083,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why CI monitoring cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -925,41 +1092,88 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
       {
-        "transition_group_id": "group-577dc04b-4042-42a6-88ce-3b33ac7d929e",
+        "transition_group_id": "group-5ba04cc4-ab2d-46ec-bdae-15b06790f87d",
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the created or updated pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
-            "name": "workspace_path",
-            "description": "Path to the task workspace or worktree used for PR creation."
-          },
-          {
-            "name": "ci_report",
-            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+            "name": "merge_report",
+            "description": "GitHub PR state, mergedAt, mergeCommit, and cleanup or release notes."
           }
         ]
       },
       {
-        "transition_group_id": "group-f0e033a4-349f-46be-bf5b-325feb0526e3",
+        "transition_group_id": "group-232c28c1-8ad2-4891-aba3-12b4f565d023",
         "required_provision_fields": [
           {
-            "name": "blocker_reason",
-            "description": "Why smoke testing cannot continue, in the task language when practical."
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "pr_report",
+            "description": "PR creation, review, conflict, or post-CI regression report."
+          }
+        ]
+      },
+      {
+        "transition_group_id": "group-5b70c7c6-f86e-408a-9e12-3fdc83a3c7b5",
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "waiting_reason",
+            "description": "Why the PR cannot advance yet and the exact user or external action needed."
+          }
+        ]
+      },
+      {
+        "transition_group_id": "group-ff588392-1d47-441d-a49d-2719ba89331f",
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "cleanup_reason",
+            "description": "Explicit user instruction or reason for cleanup without merge."
+          }
+        ]
+      },
+      {
+        "transition_group_id": "group-4719f5bc-d2af-4c9d-8ad9-e8004240accf",
+        "required_provision_fields": [
+          {
+            "name": "closure_reason",
+            "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
           }
         ]
       }
@@ -990,7 +1204,7 @@
         "required_provision_fields": [
           {
             "name": "smoke_report",
-            "description": "Smoke test findings and expected versus actual behavior."
+            "description": "Device smoke report or artifact path."
           },
           {
             "name": "reproduction_steps",
@@ -1017,7 +1231,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why smoke testing cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1067,7 +1281,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why fixing cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1099,7 +1313,7 @@
         "required_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -1115,7 +1329,7 @@
         "required_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -1131,7 +1345,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1157,15 +1371,15 @@
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           }
         ]
       },
@@ -1181,7 +1395,7 @@
         "required_provision_fields": [
           {
             "name": "pr_report",
-            "description": "Why no pull request was created or updated."
+            "description": "PR creation, review, conflict, or post-CI regression report."
           }
         ]
       },
@@ -1197,103 +1411,12 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
       {
         "edge_id": "edge-b4464c1a-0d89-4c43-9ff7-f0b245660495",
-        "input_bindings": [
-          {
-            "name": "ci_report",
-            "source": "transition_output",
-            "field": "ci_report"
-          },
-          {
-            "name": "pr_url",
-            "source": "transition_output",
-            "field": "pr_url"
-          }
-        ],
-        "required_provision_fields": [
-          {
-            "name": "ci_report",
-            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
-          },
-          {
-            "name": "pr_url",
-            "description": "URL of the created or updated pull request."
-          }
-        ]
-      },
-      {
-        "edge_id": "edge-97df31a8-4e7a-4d60-9525-005d37d8cf84",
-        "input_bindings": [
-          {
-            "name": "workspace_path",
-            "source": "transition_output",
-            "field": "workspace_path"
-          },
-          {
-            "name": "ci_report",
-            "source": "transition_output",
-            "field": "ci_report"
-          }
-        ],
-        "required_provision_fields": [
-          {
-            "name": "workspace_path",
-            "description": "Path to the task workspace or worktree used for PR creation."
-          },
-          {
-            "name": "ci_report",
-            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
-          }
-        ]
-      },
-      {
-        "edge_id": "edge-929510ef-f7eb-4df8-be67-222a179e8fc6",
-        "input_bindings": [
-          {
-            "name": "blocker_reason",
-            "source": "transition_output",
-            "field": "blocker_reason"
-          }
-        ],
-        "required_provision_fields": [
-          {
-            "name": "blocker_reason",
-            "description": "Why CI monitoring cannot complete, in the task language when practical."
-          }
-        ]
-      },
-      {
-        "edge_id": "edge-4e74cbe0-4b41-4658-84d3-ff92680a2867",
-        "input_bindings": [
-          {
-            "name": "workspace_path",
-            "source": "transition_output",
-            "field": "workspace_path"
-          },
-          {
-            "name": "blocker_reason",
-            "source": "transition_output",
-            "field": "blocker_reason"
-          }
-        ],
-        "required_provision_fields": [
-          {
-            "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
-          },
-          {
-            "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
-          }
-        ]
-      },
-      {
-        "edge_id": "edge-dc8e9bed-e437-494f-9de2-5aacde485b77",
         "input_bindings": [
           {
             "name": "pr_url",
@@ -1319,15 +1442,15 @@
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the created or updated pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the task workspace or worktree used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "ci_report",
@@ -1336,7 +1459,32 @@
         ]
       },
       {
-        "edge_id": "edge-c8e20165-5c59-45db-a532-d05ae80c167e",
+        "edge_id": "edge-97df31a8-4e7a-4d60-9525-005d37d8cf84",
+        "input_bindings": [
+          {
+            "name": "workspace_path",
+            "source": "transition_output",
+            "field": "workspace_path"
+          },
+          {
+            "name": "ci_report",
+            "source": "transition_output",
+            "field": "ci_report"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "ci_report",
+            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-929510ef-f7eb-4df8-be67-222a179e8fc6",
         "input_bindings": [
           {
             "name": "blocker_reason",
@@ -1347,7 +1495,184 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why smoke testing cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-4e74cbe0-4b41-4658-84d3-ff92680a2867",
+        "input_bindings": [
+          {
+            "name": "workspace_path",
+            "source": "transition_output",
+            "field": "workspace_path"
+          },
+          {
+            "name": "blocker_reason",
+            "source": "transition_output",
+            "field": "blocker_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "blocker_reason",
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-34fa2755-feff-4de2-ac36-9520ec8ecb6f",
+        "input_bindings": [
+          {
+            "name": "pr_url",
+            "source": "transition_output",
+            "field": "pr_url"
+          },
+          {
+            "name": "branch_name",
+            "source": "transition_output",
+            "field": "branch_name"
+          },
+          {
+            "name": "merge_report",
+            "source": "transition_output",
+            "field": "merge_report"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "merge_report",
+            "description": "GitHub PR state, mergedAt, mergeCommit, and cleanup or release notes."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-cff32a6b-93e2-4e79-bd23-6bf412b89e43",
+        "input_bindings": [
+          {
+            "name": "workspace_path",
+            "source": "transition_output",
+            "field": "workspace_path"
+          },
+          {
+            "name": "pr_report",
+            "source": "transition_output",
+            "field": "pr_report"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "pr_report",
+            "description": "PR creation, review, conflict, or post-CI regression report."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-6f908743-c30a-4519-86ee-a219fc8a6c31",
+        "input_bindings": [
+          {
+            "name": "pr_url",
+            "source": "transition_output",
+            "field": "pr_url"
+          },
+          {
+            "name": "branch_name",
+            "source": "transition_output",
+            "field": "branch_name"
+          },
+          {
+            "name": "workspace_path",
+            "source": "transition_output",
+            "field": "workspace_path"
+          },
+          {
+            "name": "waiting_reason",
+            "source": "transition_output",
+            "field": "waiting_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "waiting_reason",
+            "description": "Why the PR cannot advance yet and the exact user or external action needed."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-e4123c5a-9388-40c6-a99e-e75f518d7aba",
+        "input_bindings": [
+          {
+            "name": "pr_url",
+            "source": "transition_output",
+            "field": "pr_url"
+          },
+          {
+            "name": "branch_name",
+            "source": "transition_output",
+            "field": "branch_name"
+          },
+          {
+            "name": "cleanup_reason",
+            "source": "transition_output",
+            "field": "cleanup_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "cleanup_reason",
+            "description": "Explicit user instruction or reason for cleanup without merge."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-584c28ac-62bf-465a-81a3-26aaec7abf2f",
+        "input_bindings": [
+          {
+            "name": "closure_reason",
+            "source": "transition_output",
+            "field": "closure_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "closure_reason",
+            "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
           }
         ]
       }

--- a/.kent/workflows/puber-test-coverage.json
+++ b/.kent/workflows/puber-test-coverage.json
@@ -3,7 +3,7 @@
     "id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
     "name": "Puber Test Coverage",
     "description": "Plan, add, review, fix, and clean up focused Puber Android test coverage improvements.",
-    "version": 66
+    "version": 151
   },
   "nodes": [
     {
@@ -61,9 +61,9 @@
     {
       "id": "node-b62d081c-5f62-4dd8-8b41-fb7d0fde82c9",
       "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
-      "key": "blocked",
+      "key": "wont_do",
       "kind": "terminal",
-      "display_name": "Blocked"
+      "display_name": "Won't Do"
     },
     {
       "id": "node-45ab8ea5-535c-423f-838f-e7be753779d7",
@@ -89,6 +89,15 @@
       "key": "ci_monitor",
       "kind": "agent",
       "display_name": "Monitor CI",
+      "subagent_role": "default",
+      "completion_mode": "shell_command"
+    },
+    {
+      "id": "node-1a60efe4-9427-43bc-aa41-a60470f895b8",
+      "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
+      "key": "waiting_pr",
+      "kind": "agent",
+      "display_name": "Waiting PR",
       "subagent_role": "default",
       "completion_mode": "shell_command"
     },
@@ -153,41 +162,41 @@
       "id": "group-39e19d14-f096-439b-a5d9-9744a3679407",
       "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
       "source_node_id": "node-5769cf7c-2c95-4c1e-b98e-bd4dec7be4f5",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Coverage planning is blocked."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "plan cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-dfd99cbf-98ce-438a-8017-667180578a53",
       "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
       "source_node_id": "node-eb273699-01a9-4407-823b-5772eb14389b",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Test implementation is blocked."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "implement cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-78094524-99fe-4931-8ea4-7cc2fcc34bae",
       "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
       "source_node_id": "node-65fd665a-57a9-462d-b336-b7e039071db9",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Test review is blocked."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "review cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-6d3aff4d-bf81-4214-9baf-1107228c2232",
       "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
       "source_node_id": "node-d9f0e401-7a7b-4993-99a1-a18d3d075fee",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Test fix pass is blocked."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "fix cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-b6c17969-a249-4fc0-87fe-1e89b990f5eb",
       "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
       "source_node_id": "node-65fd665a-57a9-462d-b336-b7e039071db9",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "Test review passed; run mandatory compliance review before cleanup."
+      "transition_id": "compliance",
+      "display_name": "Compliance",
+      "description": "Work passed this stage; run mandatory compliance review before any PR/cleanup path."
     },
     {
       "id": "group-a0533a4f-543e-45ab-8109-8d559aec6f45",
@@ -201,9 +210,9 @@
       "id": "group-e767d574-2b68-40bd-a3d0-9a0d97914407",
       "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
       "source_node_id": "node-45ab8ea5-535c-423f-838f-e7be753779d7",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "Compliance review passed; create or update the task pull request before cleanup."
+      "transition_id": "ship_pr",
+      "display_name": "Ship PR",
+      "description": "Compliance passed; create or update the task PR before any terminal completion."
     },
     {
       "id": "group-ef0a8461-7237-41ac-9909-8041c59cd59c",
@@ -217,9 +226,9 @@
       "id": "group-d920c2d3-5daf-4026-b6b1-594ff38b227e",
       "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
       "source_node_id": "node-45ab8ea5-535c-423f-838f-e7be753779d7",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "Compliance review is blocked by missing or contradictory required sources."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "compliance cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-85106cbe-4ef0-4138-9864-a216d3841d1b",
@@ -233,25 +242,25 @@
       "id": "group-2156051c-0dee-43c4-8043-f5dbf26cd81f",
       "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
       "source_node_id": "node-64b0c5de-26d8-478b-9629-f424e68454b6",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "PR is intentionally not applicable because there are no repository changes; run cleanup."
+      "transition_id": "no_pr",
+      "display_name": "No PR",
+      "description": "No PR is applicable because there are no repository changes or the task is explicitly report-only; cleanup can finish the task."
     },
     {
       "id": "group-2a80ced0-fbfa-446f-8352-1151f789dcbf",
       "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
       "source_node_id": "node-64b0c5de-26d8-478b-9629-f424e68454b6",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "PR creation or update is blocked by git state, auth, remote, branch, or unsafe repository state."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "ship_pr cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-110d29fb-0617-4277-a4a6-55407f7e66e3",
       "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
       "source_node_id": "node-796ba26f-05bd-4ebf-99a9-b39cabf09d51",
-      "transition_id": "done",
-      "display_name": "Done",
-      "description": "PR checks passed or are intentionally skipped; run conservative cleanup."
+      "transition_id": "waiting_pr",
+      "display_name": "Waiting PR",
+      "description": "PR checks passed or were intentionally skipped; wait until the PR is merged before cleanup/done."
     },
     {
       "id": "group-2d85c880-20f2-429f-8f8a-aa99554544ae",
@@ -265,9 +274,9 @@
       "id": "group-fbfec7af-e466-4f53-9352-cb23efd416c5",
       "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
       "source_node_id": "node-796ba26f-05bd-4ebf-99a9-b39cabf09d51",
-      "transition_id": "blocked",
-      "display_name": "Blocked",
-      "description": "CI monitoring is blocked by GitHub access, missing check data, or unsafe repository state."
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "ci_monitor cannot safely continue until the user or external system resolves the blocker; remain in the same stage."
     },
     {
       "id": "group-aabeeadc-dc6d-44be-bac3-85994483ec8a",
@@ -278,12 +287,44 @@
       "description": "PR creation/update hit a recoverable branch, rebase, conflict, or metadata issue; user approval required before recovery work."
     },
     {
-      "id": "group-82060b25-1237-42ba-a1f6-f608cc248c9e",
+      "id": "group-f9d6c92e-850f-4730-ada8-025483a92b59",
       "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
-      "source_node_id": "node-796ba26f-05bd-4ebf-99a9-b39cabf09d51",
-      "transition_id": "retry_later",
-      "display_name": "Retry Later",
-      "description": "CI or GitHub is temporarily unavailable, still starting, or missing an expected run; user approval required before retrying monitoring."
+      "source_node_id": "node-1a60efe4-9427-43bc-aa41-a60470f895b8",
+      "transition_id": "pr_merged",
+      "display_name": "Pr Merged",
+      "description": "PR is confirmed merged; cleanup can finish the task."
+    },
+    {
+      "id": "group-a28669ca-a4cf-4a42-bcd0-2da073933b7b",
+      "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
+      "source_node_id": "node-1a60efe4-9427-43bc-aa41-a60470f895b8",
+      "transition_id": "needs_changes",
+      "display_name": "Needs Changes",
+      "description": "PR review, conflicts, or post-CI regressions need task-scoped fixes."
+    },
+    {
+      "id": "group-26e23205-f984-4f91-aa4e-ed32d3b0fc74",
+      "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
+      "source_node_id": "node-1a60efe4-9427-43bc-aa41-a60470f895b8",
+      "transition_id": "needs_user_action",
+      "display_name": "Needs User Action",
+      "description": "PR is still waiting on a human or external process; remain in Waiting PR."
+    },
+    {
+      "id": "group-edd91e42-2206-4c58-8514-a75f76318792",
+      "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
+      "source_node_id": "node-1a60efe4-9427-43bc-aa41-a60470f895b8",
+      "transition_id": "close_without_merge",
+      "display_name": "Close Without Merge",
+      "description": "User explicitly closed/canceled the PR without merge; cleanup can finish."
+    },
+    {
+      "id": "group-9f9a6407-39cc-45c6-91f5-02da7979d109",
+      "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
+      "source_node_id": "node-5769cf7c-2c95-4c1e-b98e-bd4dec7be4f5",
+      "transition_id": "wont_do",
+      "display_name": "Wont Do",
+      "description": "Latest user comment explicitly cancels this task or declares it not planned; finish without treating it as a recoverable blocker."
     }
   ],
   "edges": [
@@ -298,7 +339,7 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Run Puber test coverage planning for this Kent task.\n\nRead .kent/project-contract.md first, then use .kent/commands/test-coverage.md phases 1-3. Treat the task body as the target package/path. Create an explicit .todo/test-coverage-<name> workspace; do not infer or create .todo/.current. Analyze source/test gaps and produce plan.md. Do not add tests yet.\n\nComplete with implement when the plan is ready for user approval and provide workspace_path plus plan_path. Complete with blocked if the target path is ambiguous or unavailable and provide blocker_reason."
+      "prompt_template": "Run Puber test coverage planning for this Kent task.\n\nRead .kent/project-contract.md first, then use .kent/commands/test-coverage.md phases 1-3. Treat the task body as the target package/path. Create an explicit .todo/test-coverage-<name> workspace; do not infer or create .todo/.current. Analyze source/test gaps and produce plan.md. Do not add tests yet.\n\nComplete with implement when the plan is ready and has no unresolved product/API/UX ambiguity and provide workspace_path plus plan_path. Complete with needs_user_action if the target path is ambiguous or unavailable and provide blocker_reason."
     },
     {
       "id": "edge-635e236b-8fb7-455b-997f-e92776e39bd1",
@@ -306,20 +347,20 @@
       "transition_group_id": "group-fca23692-1705-4e7b-b9e0-66cf7edab7e4",
       "key": "approve_implement",
       "target_node_id": "node-eb273699-01a9-4407-823b-5772eb14389b",
-      "requires_approval": true,
+      "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Implement the approved Puber test coverage plan.\n\nRead .kent/project-contract.md first. Use .kent/commands/test-coverage.md phases 4-5 with workspace {{.Params.workspace_path}} and plan {{.Params.plan_path}}. Add one next unchecked test step at a time, verify narrowly, and update plan.md.\n\nIf more unchecked steps remain, complete with continue_implementation and provide workspace_path plus plan_path again. If all steps are complete, complete with review and provide workspace_path, plan_path, changed_files, and verification_summary. Complete with blocked on unresolved blockers and provide blocker_reason.",
+      "prompt_template": "Implement the Puber test coverage plan.\n\nRead .kent/project-contract.md first. Use .kent/commands/test-coverage.md phases 4-5 with workspace {{.Params.workspace_path}} and plan {{.Params.plan_path}}. Add one next unchecked test step at a time, verify narrowly, and update plan.md.\n\nIf more unchecked steps remain, complete with continue_implementation and provide workspace_path plus plan_path again. If all steps are complete, complete with review and provide workspace_path, plan_path, changed_files, and verification_summary. Complete with needs_user_action on unresolved blockers and provide blocker_reason.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/test-coverage-* workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "plan_path",
-          "description": "Path to the test coverage plan.md being executed."
+          "description": "Path to the plan.md used by this workflow transition."
         }
       ]
     },
@@ -334,15 +375,15 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Continue the approved Puber test coverage plan from {{.Params.plan_path}} in workspace {{.Params.workspace_path}}. Execute the next unchecked step, verify narrowly, update plan.md, and complete with continue_implementation, review, or blocked as appropriate.",
+      "prompt_template": "Continue the approved Puber test coverage plan from {{.Params.plan_path}} in workspace {{.Params.workspace_path}}. Execute the next unchecked step, verify narrowly, update plan.md, and complete with continue_implementation, review, or needs_user_action as appropriate.\n\nFor any needs_user_action transition, provide blocker_reason with the exact next user or external action needed.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/test-coverage-* workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "plan_path",
-          "description": "Path to the test coverage plan.md being executed."
+          "description": "Path to the plan.md used by this workflow transition."
         }
       ]
     },
@@ -357,15 +398,15 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Review the Puber test coverage changes read-only.\n\nRead .kent/project-contract.md first. Check regression-test quality, locale-independent assertions, explicit expected values, AGENTS.md rules, and {{.Params.verification_summary}}. Do not edit files in this node.\n\nComplete with done if accepted, needs_changes if fixes are required and provide workspace_path, review_report, and changed_files, or blocked if review cannot complete and provide blocker_reason.",
+      "prompt_template": "Review the Puber test coverage changes read-only.\n\nRead .kent/project-contract.md first. Check regression-test quality, locale-independent assertions, explicit expected values, AGENTS.md rules, and {{.Params.verification_summary}}. Do not edit files in this node.\n\nComplete with compliance if accepted, needs_changes if fixes are required and provide workspace_path, review_report, and changed_files, or needs_user_action if review cannot complete and provide blocker_reason.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the explicit .todo/test-coverage-* workspace."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "plan_path",
-          "description": "Path to the test coverage plan.md being executed."
+          "description": "Path to the plan.md used by this workflow transition."
         },
         {
           "key": "changed_files",
@@ -383,16 +424,16 @@
       "transition_group_id": "group-eec90e67-d819-4183-a043-c9ea33d27da1",
       "key": "fix",
       "target_node_id": "node-d9f0e401-7a7b-4993-99a1-a18d3d075fee",
-      "requires_approval": true,
+      "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Fix the Puber test coverage review findings. Apply only changes requested in {{.Params.review_report}}, verify narrowly, and complete with review or blocked.",
+      "prompt_template": "Fix the Puber test coverage review findings. Apply only changes requested in {{.Params.review_report}}, verify narrowly, and complete with review or needs_user_action.\n\nFor any needs_user_action transition, provide blocker_reason with the exact next user or external action needed.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Workspace containing the test coverage implementation."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "review_report",
@@ -415,11 +456,11 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Re-review the fixed Puber test coverage changes. Complete with done, needs_changes, or blocked.",
+      "prompt_template": "Re-review the fixed Puber test coverage changes. Complete with compliance, needs_changes, or needs_user_action.\n\nFor any needs_user_action transition, provide blocker_reason with the exact next user or external action needed.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Workspace containing the test coverage implementation."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "review_report",
@@ -435,17 +476,18 @@
       "id": "edge-5da16ad1-ae52-4ffd-bac3-5e71e5c82e98",
       "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
       "transition_group_id": "group-39e19d14-f096-439b-a5d9-9744a3679407",
-      "key": "plan_blocked",
-      "target_node_id": "node-b62d081c-5f62-4dd8-8b41-fb7d0fde82c9",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "plan_needs_user_action",
+      "target_node_id": "node-5769cf7c-2c95-4c1e-b98e-bd4dec7be4f5",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why planning cannot continue, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -453,17 +495,18 @@
       "id": "edge-dcfea51d-83b5-4485-9dc4-9f564ed809cb",
       "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
       "transition_group_id": "group-dfd99cbf-98ce-438a-8017-667180578a53",
-      "key": "implementation_blocked",
-      "target_node_id": "node-b62d081c-5f62-4dd8-8b41-fb7d0fde82c9",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "implement_needs_user_action",
+      "target_node_id": "node-eb273699-01a9-4407-823b-5772eb14389b",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why implementation cannot continue, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -471,17 +514,18 @@
       "id": "edge-8e0274ef-e94f-4bf8-865e-b1c6db8fdac4",
       "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
       "transition_group_id": "group-78094524-99fe-4931-8ea4-7cc2fcc34bae",
-      "key": "review_blocked",
-      "target_node_id": "node-b62d081c-5f62-4dd8-8b41-fb7d0fde82c9",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "review_needs_user_action",
+      "target_node_id": "node-65fd665a-57a9-462d-b336-b7e039071db9",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why review cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -489,17 +533,18 @@
       "id": "edge-cdb45ce3-cc17-463d-84a4-a42440a6c782",
       "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
       "transition_group_id": "group-6d3aff4d-bf81-4214-9baf-1107228c2232",
-      "key": "fix_blocked",
-      "target_node_id": "node-b62d081c-5f62-4dd8-8b41-fb7d0fde82c9",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "fix_needs_user_action",
+      "target_node_id": "node-d9f0e401-7a7b-4993-99a1-a18d3d075fee",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why fixing cannot continue, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -507,18 +552,18 @@
       "id": "edge-00e65d30-b271-4dc4-98e4-993a536bdfdd",
       "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
       "transition_group_id": "group-b6c17969-a249-4fc0-87fe-1e89b990f5eb",
-      "key": "review_done",
+      "key": "review_compliance",
       "target_node_id": "node-45ab8ea5-535c-423f-838f-e7be753779d7",
       "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Run mandatory Puber Compliance Review before cleanup.\n\nRead .kent/commands/compliance-review.md, .kent/project-contract.md, and AGENTS.md first. Reviewed scope: completed test coverage work in workspace {{.Params.workspace_path}}. Changed files: {{.Params.changed_files}}. Review only compliance with task requirements, test rules, specs, AGENTS.md, and workflow contract. Do not edit files.\n\nComplete with done and provide compliance_report when no compliance violations are found. Complete with needs_changes and provide workspace_path plus compliance_report when fixes are required. Complete with blocked and provide blocker_reason if required sources are missing or contradictory.",
+      "prompt_template": "Run mandatory Puber Compliance Review before cleanup.\n\nRead .kent/commands/compliance-review.md, .kent/project-contract.md, and AGENTS.md first. Reviewed scope: completed test coverage work in workspace {{.Params.workspace_path}}. Changed files: {{.Params.changed_files}}. Review only compliance with task requirements, test rules, specs, AGENTS.md, and workflow contract. Do not edit files.\n\nComplete with ship_pr and provide compliance_report when no compliance violations are found. Complete with needs_changes and provide workspace_path plus compliance_report when fixes are required. Complete with needs_user_action and provide blocker_reason if required sources are missing or contradictory.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Workspace containing the test coverage implementation."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "changed_files",
@@ -548,18 +593,18 @@
       "id": "edge-a952f52d-ea2d-45e9-b8e0-6318c204a733",
       "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
       "transition_group_id": "group-e767d574-2b68-40bd-a3d0-9a0d97914407",
-      "key": "compliance_done",
+      "key": "compliance_ship_pr",
       "target_node_id": "node-64b0c5de-26d8-478b-9629-f424e68454b6",
       "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Create or update the Puber pull request for this completed task.\n\nRead .kent/project-contract.md, .kent/commands/ship-pr.md, and AGENTS.md first. Compliance result: {{.Params.compliance_report}}.\n\nIf this task produced repository changes, commit only task-related files, push the current task branch to origin, and create or update a GitHub PR. Do not merge the PR. Do not push directly to master/main. If there are no repository changes and the task is report-only or smoke-only, complete with done and provide pr_report explaining why PR is not applicable.\n\nComplete with monitor_ci when a PR exists and provide pr_url, branch_name, and workspace_path. Complete with needs_changes when PR creation/update is blocked by recoverable repository, branch, or PR state such as merge conflicts, non-fast-forward push, branch needing rebase, or missing PR metadata that can be fixed in the task worktree; provide workspace_path and blocker_reason. Complete with done only for PR-not-applicable/no-diff cases and provide pr_report. Complete with blocked only when continuing would be unsafe without changing task scope, credentials, or project policy; provide blocker_reason.",
+      "prompt_template": "Create or update the Puber pull request for this completed task.\n\nRead .kent/project-contract.md, .kent/commands/ship-pr.md, and AGENTS.md first. Compliance result: {{.Params.compliance_report}}.\n\nIf this task produced repository changes, commit only task-related files, push the current task branch to origin, and create or update a GitHub PR. Do not merge the PR. Do not push directly to master/main. If there are no repository changes and the task is report-only or smoke-only, complete with no_pr and provide pr_report explaining why PR is not applicable.\n\nComplete with monitor_ci when a PR exists and provide pr_url, branch_name, and workspace_path. Complete with needs_changes when PR creation/update is needs_user_action by recoverable repository, branch, or PR state such as merge conflicts, non-fast-forward push, branch needing rebase, or missing PR metadata that can be fixed in the task worktree; provide workspace_path and blocker_reason. Complete with no_pr only for PR-not-applicable/no-diff cases and provide pr_report. Complete with needs_user_action only when continuing would be unsafe without changing task scope, credentials, or project policy; provide blocker_reason.",
       "parameters": [
         {
           "key": "compliance_report",
-          "description": "Compliance review report, including rule sources checked and any findings."
+          "description": "Compliance review report or summary."
         }
       ]
     },
@@ -569,20 +614,20 @@
       "transition_group_id": "group-ef0a8461-7237-41ac-9909-8041c59cd59c",
       "key": "compliance_fix",
       "target_node_id": "node-d9f0e401-7a7b-4993-99a1-a18d3d075fee",
-      "requires_approval": true,
+      "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Fix Puber test coverage compliance violations only.\n\nRead .kent/project-contract.md and .kent/commands/compliance-review.md first. Apply only the minimum changes required by compliance findings in {{.Params.compliance_report}} for workspace {{.Params.workspace_path}}. Verify narrowly, then complete with review and provide workspace_path, review_report, and changed_files. Complete with blocked and provide blocker_reason if unsafe or missing input.",
+      "prompt_template": "Fix Puber test coverage compliance violations only.\n\nRead .kent/project-contract.md and .kent/commands/compliance-review.md first. Apply only the minimum changes required by compliance findings in {{.Params.compliance_report}} for workspace {{.Params.workspace_path}}. Verify narrowly, then complete with review and provide workspace_path, review_report, and changed_files. Complete with needs_user_action and provide blocker_reason if unsafe or missing input.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Workspace containing the test coverage implementation."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "compliance_report",
-          "description": "Compliance review report, including rule sources checked and any findings."
+          "description": "Compliance review report or summary."
         }
       ]
     },
@@ -590,17 +635,18 @@
       "id": "edge-5d69ab09-e926-4cd7-9596-feb6dc146604",
       "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
       "transition_group_id": "group-d920c2d3-5daf-4026-b6b1-594ff38b227e",
-      "key": "compliance_blocked",
-      "target_node_id": "node-b62d081c-5f62-4dd8-8b41-fb7d0fde82c9",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "compliance_needs_user_action",
+      "target_node_id": "node-45ab8ea5-535c-423f-838f-e7be753779d7",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why compliance review cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -615,19 +661,19 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Monitor Puber PR checks.\n\nRead .kent/project-contract.md and AGENTS.md first. Inspect PR {{.Params.pr_url}} on branch {{.Params.branch_name}}. Use GitHub CLI when available. Do not merge the PR. Do not push new commits from this node.\n\nComplete with done if CI/checks pass, are absent, or are intentionally skipped with a clear reason; provide ci_report and pr_url. Complete with needs_changes if CI failed due to task changes and provide workspace_path plus ci_report. Complete with retry_later when checks cannot be inspected because GitHub/CI is still starting, rate-limited, temporarily unavailable, or an expected run has not appeared yet; provide pr_url, branch_name, workspace_path, and ci_report. Complete with blocked only if checks cannot be inspected and retrying would be unsafe or misleading; provide blocker_reason.",
+      "prompt_template": "Monitor Puber PR checks.\n\nRead .kent/project-contract.md and AGENTS.md first. Inspect PR {{.Params.pr_url}} on branch {{.Params.branch_name}}. Use GitHub CLI when available. Do not merge the PR. Do not push new commits from this node.\n\nComplete with waiting_pr if CI/checks pass, are absent, or are intentionally skipped with a clear reason; provide ci_report and pr_url. Complete with needs_changes if CI failed due to task changes and provide workspace_path plus ci_report. Complete with needs_user_action for temporary external waits; provide blocker_reason. Complete with needs_user_action only if checks cannot be inspected and retrying would be unsafe or misleading; provide blocker_reason.",
       "parameters": [
         {
           "key": "pr_url",
-          "description": "URL of the pull request."
+          "description": "URL of the created, updated, or monitored pull request."
         },
         {
           "key": "branch_name",
-          "description": "Name of the pushed task branch."
+          "description": "Name of the task or release branch associated with the pull request."
         },
         {
           "key": "workspace_path",
-          "description": "Path to the worktree or checkout used for PR creation."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         }
       ]
     },
@@ -646,7 +692,7 @@
       "parameters": [
         {
           "key": "pr_report",
-          "description": "Why no pull request was created or updated."
+          "description": "PR creation, review, conflict, or post-CI regression report."
         }
       ]
     },
@@ -654,17 +700,18 @@
       "id": "edge-960c9804-6f83-4d16-be21-411ee8328fd2",
       "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
       "transition_group_id": "group-2a80ced0-fbfa-446f-8352-1151f789dcbf",
-      "key": "pr_blocked",
-      "target_node_id": "node-b62d081c-5f62-4dd8-8b41-fb7d0fde82c9",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "ship_pr_needs_user_action",
+      "target_node_id": "node-64b0c5de-26d8-478b-9629-f424e68454b6",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why PR creation/update cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -672,22 +719,30 @@
       "id": "edge-21f98ec4-4a45-407f-9e56-0eca603f5582",
       "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
       "transition_group_id": "group-110d29fb-0617-4277-a4a6-55407f7e66e3",
-      "key": "ci_done",
-      "target_node_id": "node-8fb65548-deaf-4e1c-8953-41879bac1fa3",
+      "key": "ci_waiting_pr",
+      "target_node_id": "node-1a60efe4-9427-43bc-aa41-a60470f895b8",
       "requires_approval": false,
       "context_mode": "new_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Run conservative Puber task cleanup after PR/CI.\n\nRead .kent/project-contract.md first, then use .kent/commands/cleanup-task.md. PR: {{.Params.pr_url}}. CI report: {{.Params.ci_report}}. Do not delete any worktree containing unpushed or uncommitted user changes. Complete with done and provide cleanup_report.",
+      "prompt_template": "Hold this Puber task until its pull request is actually merged.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, PR {{.Params.pr_url}}, branch {{.Params.branch_name}}, workspace {{.Params.workspace_path}}, and CI report {{.Params.ci_report}}.\n\nUse `gh pr view --json state,mergedAt,mergeCommit,headRefName,baseRefName,url` when available. Do not merge the PR. Do not push commits from this node. Do not clean up while the PR is still open.\n\nComplete with pr_merged only when GitHub reports state=MERGED; provide pr_url, branch_name, and merge_report. Complete with needs_changes when PR review comments, merge conflicts, or post-CI regressions can be fixed within the task scope; provide workspace_path and pr_report. Complete with needs_user_action when the PR is still open, waiting for human review/approval/merge, or needs_user_action by an external process; add a task comment with the current PR status and exact human action, then provide pr_url, branch_name, workspace_path, and waiting_reason. Complete with close_without_merge only if the latest user comment explicitly says to close/cancel/skip this PR; provide pr_url, branch_name, and cleanup_reason.",
       "parameters": [
+        {
+          "key": "pr_url",
+          "description": "URL of the created, updated, or monitored pull request."
+        },
+        {
+          "key": "branch_name",
+          "description": "Name of the task or release branch associated with the pull request."
+        },
+        {
+          "key": "workspace_path",
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
+        },
         {
           "key": "ci_report",
           "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
-        },
-        {
-          "key": "pr_url",
-          "description": "URL of the created or updated pull request."
         }
       ]
     },
@@ -697,16 +752,16 @@
       "transition_group_id": "group-2d85c880-20f2-429f-8f8a-aa99554544ae",
       "key": "ci_fix",
       "target_node_id": "node-d9f0e401-7a7b-4993-99a1-a18d3d075fee",
-      "requires_approval": true,
+      "requires_approval": false,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Fix Puber test coverage CI failures only.\n\nRead .kent/project-contract.md first. Apply only the minimum changes required by CI report {{.Params.ci_report}} in workspace {{.Params.workspace_path}}. Verify narrowly, then complete with review and provide workspace_path, review_report, and changed_files. Complete with blocked and provide blocker_reason if unsafe or missing input.",
+      "prompt_template": "Fix Puber test coverage CI failures only.\n\nRead .kent/project-contract.md first. Apply only the minimum changes required by CI report {{.Params.ci_report}} in workspace {{.Params.workspace_path}}. Verify narrowly, then complete with review and provide workspace_path, review_report, and changed_files. Complete with needs_user_action and provide blocker_reason if unsafe or missing input.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Workspace containing the test coverage implementation."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "ci_report",
@@ -718,17 +773,18 @@
       "id": "edge-8bf0d7e7-5b9f-4929-a47c-71b5006e9312",
       "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
       "transition_group_id": "group-fbfec7af-e466-4f53-9352-cb23efd416c5",
-      "key": "ci_blocked",
-      "target_node_id": "node-b62d081c-5f62-4dd8-8b41-fb7d0fde82c9",
-      "requires_approval": false,
-      "context_mode": "new_session",
+      "key": "ci_monitor_needs_user_action",
+      "target_node_id": "node-796ba26f-05bd-4ebf-99a9-b39cabf09d51",
+      "requires_approval": true,
+      "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
+      "prompt_template": "Resume this Puber workflow stage after a user-visible blocker was resolved or explicit permission was granted.\n\nRead AGENTS.md, .kent/project-contract.md, the latest task comments, and the previous blocker reason: {{.Params.blocker_reason}}.\n\nDo not restart from backlog, do not discard existing .todo/worktree/PR context, and do not broaden scope. Continue only within the current stage. If the blocker is still present, add or update a task comment with the exact next action, then complete with needs_user_action and provide blocker_reason again. Never use a terminal state for a recoverable blocker. If the task was explicitly canceled, use a close/no-PR path only when that transition exists and the latest user comment clearly asks for it.",
       "parameters": [
         {
           "key": "blocker_reason",
-          "description": "Why CI monitoring cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
@@ -743,46 +799,141 @@
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Fix recoverable Puber PR creation/update issues only.\n\nRead .kent/project-contract.md, .kent/commands/ship-pr.md, and AGENTS.md first. Previous PR blocker: {{.Params.blocker_reason}}. Work in {{.Params.workspace_path}}. Apply only the minimum changes needed to make the task branch/PR shippable, such as rebasing, resolving merge conflicts, fixing branch metadata, or repairing the PR-ready commit set. Do not expand product scope. Verify narrowly, then continue through the workflow's normal review/compliance path. Complete with blocked only if the recovery is unsafe or requires user credentials/policy changes.",
+      "prompt_template": "Fix recoverable Puber PR creation/update issues only.\n\nRead .kent/project-contract.md, .kent/commands/ship-pr.md, and AGENTS.md first. Previous PR blocker: {{.Params.blocker_reason}}. Work in {{.Params.workspace_path}}. Apply only the minimum changes needed to make the task branch/PR shippable, such as rebasing, resolving merge conflicts, fixing branch metadata, or repairing the PR-ready commit set. Do not expand product scope. Verify narrowly, then continue through the workflow's normal review/compliance path. Complete with needs_user_action only if the recovery is unsafe or requires user credentials/policy changes.\n\nFor any needs_user_action transition, provide blocker_reason with the exact next user or external action needed.",
       "parameters": [
         {
           "key": "workspace_path",
-          "description": "Path to the worktree or checkout used for PR creation."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
           "key": "blocker_reason",
-          "description": "Why PR creation/update cannot complete, in the task language when practical."
+          "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
         }
       ]
     },
     {
-      "id": "edge-a183ffc5-f22d-46e2-bb71-84e217252667",
+      "id": "edge-c6c59c17-3133-4058-a3fb-0b30050700a7",
       "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
-      "transition_group_id": "group-82060b25-1237-42ba-a1f6-f608cc248c9e",
-      "key": "ci_retry",
-      "target_node_id": "node-796ba26f-05bd-4ebf-99a9-b39cabf09d51",
+      "transition_group_id": "group-f9d6c92e-850f-4730-ada8-025483a92b59",
+      "key": "cleanup_after_merge",
+      "target_node_id": "node-8fb65548-deaf-4e1c-8953-41879bac1fa3",
+      "requires_approval": false,
+      "context_mode": "new_session",
+      "context_source": {
+        "kind": "immediate_source"
+      },
+      "prompt_template": "Run conservative Puber task cleanup after the pull request was confirmed merged.\n\nRead AGENTS.md, .kent/project-contract.md, .kent/commands/cleanup-task.md, PR {{.Params.pr_url}}, branch {{.Params.branch_name}}, and merge report {{.Params.merge_report}}. Verify the PR is merged with GitHub state, not only git ancestry, because squash merges are allowed. Do not delete any worktree containing unpushed commits, uncommitted user changes, or unclear ownership. Complete with done and provide cleanup_report.",
+      "parameters": [
+        {
+          "key": "pr_url",
+          "description": "URL of the created, updated, or monitored pull request."
+        },
+        {
+          "key": "branch_name",
+          "description": "Name of the task or release branch associated with the pull request."
+        },
+        {
+          "key": "merge_report",
+          "description": "GitHub PR state, mergedAt, mergeCommit, and cleanup or release notes."
+        }
+      ]
+    },
+    {
+      "id": "edge-b88db529-d819-4ead-abc4-14f9a34748b1",
+      "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
+      "transition_group_id": "group-a28669ca-a4cf-4a42-bcd0-2da073933b7b",
+      "key": "pr_feedback",
+      "target_node_id": "node-d9f0e401-7a7b-4993-99a1-a18d3d075fee",
+      "requires_approval": false,
+      "context_mode": "compact_and_continue_session",
+      "context_source": {
+        "kind": "immediate_source"
+      },
+      "prompt_template": "Fix Puber PR feedback only.\n\nRead AGENTS.md, .kent/project-contract.md, latest task comments, workspace {{.Params.workspace_path}}, and PR feedback report {{.Params.pr_report}}. Apply only task-scoped changes needed for PR review comments, merge conflicts, or post-CI regressions. Do not force-push unless the latest user comment explicitly permits force-push for this exact PR/branch. Verify narrowly, then return through the workflow's normal review/verify/compliance path with an updated report. If user input is required, complete with needs_user_action and provide blocker_reason.",
+      "parameters": [
+        {
+          "key": "workspace_path",
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
+        },
+        {
+          "key": "pr_report",
+          "description": "PR creation, review, conflict, or post-CI regression report."
+        }
+      ]
+    },
+    {
+      "id": "edge-ccb8cb2d-e357-41f7-9d12-86ae7f9789a5",
+      "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
+      "transition_group_id": "group-26e23205-f984-4f91-aa4e-ed32d3b0fc74",
+      "key": "waiting_pr_needs_user_action",
+      "target_node_id": "node-1a60efe4-9427-43bc-aa41-a60470f895b8",
       "requires_approval": true,
       "context_mode": "compact_and_continue_session",
       "context_source": {
         "kind": "immediate_source"
       },
-      "prompt_template": "Retry Puber PR check monitoring after an approved temporary CI/GitHub wait.\n\nRead .kent/project-contract.md and AGENTS.md first. Previous CI status: {{.Params.ci_report}}. Inspect PR {{.Params.pr_url}} on branch {{.Params.branch_name}} again. Do not merge the PR. Do not push new commits from this node.\n\nComplete with done if CI/checks pass, are absent, or are intentionally skipped with a clear reason; provide ci_report and pr_url. Complete with needs_changes if CI failed due to task changes and provide workspace_path plus ci_report. Complete with retry_later if CI/GitHub is still temporarily unavailable and provide pr_url, branch_name, workspace_path, and ci_report. Complete with blocked only if retrying is no longer useful or safe; provide blocker_reason.",
+      "prompt_template": "Re-check the Puber pull request after the user resolved the external wait or approved another check.\n\nRead AGENTS.md, .kent/project-contract.md, latest task comments, PR {{.Params.pr_url}}, branch {{.Params.branch_name}}, workspace {{.Params.workspace_path}}, and previous waiting reason {{.Params.waiting_reason}}. Do not merge, push, or clean up unless the PR is confirmed merged.\n\nComplete with pr_merged only when GitHub reports state=MERGED. Complete with needs_changes for task-scoped PR review/conflict/regression fixes. Complete with needs_user_action again if the PR is still waiting externally. Complete with close_without_merge only on explicit latest user instruction.",
       "parameters": [
         {
           "key": "pr_url",
-          "description": "URL of the created or updated pull request."
+          "description": "URL of the created, updated, or monitored pull request."
         },
         {
           "key": "branch_name",
-          "description": "Name of the pushed task branch."
+          "description": "Name of the task or release branch associated with the pull request."
         },
         {
           "key": "workspace_path",
-          "description": "Workspace containing the test coverage implementation."
+          "description": "Path to the task workspace or worktree relevant to this workflow transition."
         },
         {
-          "key": "ci_report",
-          "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+          "key": "waiting_reason",
+          "description": "Why the PR cannot advance yet and the exact user or external action needed."
+        }
+      ]
+    },
+    {
+      "id": "edge-187229f4-219d-41c0-8c9f-7faf8b0779ce",
+      "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
+      "transition_group_id": "group-edd91e42-2206-4c58-8514-a75f76318792",
+      "key": "cancel_cleanup",
+      "target_node_id": "node-8fb65548-deaf-4e1c-8953-41879bac1fa3",
+      "requires_approval": true,
+      "context_mode": "new_session",
+      "context_source": {
+        "kind": "immediate_source"
+      },
+      "prompt_template": "Run conservative Puber task cleanup after the user explicitly closed/canceled the PR without merge.\n\nRead AGENTS.md, .kent/project-contract.md, .kent/commands/cleanup-task.md, PR {{.Params.pr_url}}, branch {{.Params.branch_name}}, and cleanup reason {{.Params.cleanup_reason}}. Do not delete any worktree containing unpushed commits, uncommitted user changes, or unclear ownership. Complete with done and provide cleanup_report.",
+      "parameters": [
+        {
+          "key": "pr_url",
+          "description": "URL of the created, updated, or monitored pull request."
+        },
+        {
+          "key": "branch_name",
+          "description": "Name of the task or release branch associated with the pull request."
+        },
+        {
+          "key": "cleanup_reason",
+          "description": "Explicit user instruction or reason for cleanup without merge."
+        }
+      ]
+    },
+    {
+      "id": "edge-a5ae347d-844e-4a4b-b08d-5c15a5b2715e",
+      "workflow_id": "workflow-139803ac-9f20-4f0a-9db3-6dfaf474566a",
+      "transition_group_id": "group-9f9a6407-39cc-45c6-91f5-02da7979d109",
+      "key": "plan_wont_do",
+      "target_node_id": "node-b62d081c-5f62-4dd8-8b41-fb7d0fde82c9",
+      "requires_approval": true,
+      "context_mode": "new_session",
+      "context_source": {
+        "kind": "immediate_source"
+      },
+      "parameters": [
+        {
+          "key": "closure_reason",
+          "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
         }
       ]
     }
@@ -797,15 +948,19 @@
         "possible_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/test-coverage-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "plan_path",
-            "description": "Path to the test coverage plan.md being executed."
+            "description": "Path to the plan.md used by this workflow transition."
           },
           {
             "name": "blocker_reason",
-            "description": "Why planning cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          },
+          {
+            "name": "closure_reason",
+            "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
           }
         ]
       },
@@ -814,11 +969,11 @@
         "possible_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/test-coverage-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "plan_path",
-            "description": "Path to the test coverage plan.md being executed."
+            "description": "Path to the plan.md used by this workflow transition."
           },
           {
             "name": "changed_files",
@@ -830,7 +985,7 @@
           },
           {
             "name": "blocker_reason",
-            "description": "Why implementation cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -839,7 +994,7 @@
         "possible_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Workspace containing the test coverage implementation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "review_report",
@@ -851,7 +1006,7 @@
           },
           {
             "name": "blocker_reason",
-            "description": "Why review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -860,7 +1015,7 @@
         "possible_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Workspace containing the test coverage implementation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "review_report",
@@ -872,7 +1027,7 @@
           },
           {
             "name": "blocker_reason",
-            "description": "Why fixing cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -893,15 +1048,15 @@
         "possible_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           },
           {
             "name": "workspace_path",
-            "description": "Workspace containing the test coverage implementation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -910,23 +1065,23 @@
         "possible_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "pr_report",
-            "description": "Why no pull request was created or updated."
+            "description": "PR creation, review, conflict, or post-CI regression report."
           },
           {
             "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -934,24 +1089,57 @@
         "node_id": "node-796ba26f-05bd-4ebf-99a9-b39cabf09d51",
         "possible_provision_fields": [
           {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
             "name": "ci_report",
             "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
           },
           {
-            "name": "pr_url",
-            "description": "URL of the created or updated pull request."
-          },
-          {
-            "name": "workspace_path",
-            "description": "Workspace containing the test coverage implementation."
-          },
-          {
             "name": "blocker_reason",
-            "description": "Why CI monitoring cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          }
+        ]
+      },
+      {
+        "node_id": "node-1a60efe4-9427-43bc-aa41-a60470f895b8",
+        "possible_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "merge_report",
+            "description": "GitHub PR state, mergedAt, mergeCommit, and cleanup or release notes."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "pr_report",
+            "description": "PR creation, review, conflict, or post-CI regression report."
+          },
+          {
+            "name": "waiting_reason",
+            "description": "Why the PR cannot advance yet and the exact user or external action needed."
+          },
+          {
+            "name": "cleanup_reason",
+            "description": "Explicit user instruction or reason for cleanup without merge."
           }
         ]
       },
@@ -968,11 +1156,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/test-coverage-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "plan_path",
-            "description": "Path to the test coverage plan.md being executed."
+            "description": "Path to the plan.md used by this workflow transition."
           }
         ]
       },
@@ -981,11 +1169,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/test-coverage-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "plan_path",
-            "description": "Path to the test coverage plan.md being executed."
+            "description": "Path to the plan.md used by this workflow transition."
           }
         ]
       },
@@ -994,11 +1182,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/test-coverage-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "plan_path",
-            "description": "Path to the test coverage plan.md being executed."
+            "description": "Path to the plan.md used by this workflow transition."
           },
           {
             "name": "changed_files",
@@ -1015,7 +1203,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Workspace containing the test coverage implementation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "review_report",
@@ -1032,7 +1220,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Workspace containing the test coverage implementation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "review_report",
@@ -1049,7 +1237,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why planning cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1058,7 +1246,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why implementation cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1067,7 +1255,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1076,7 +1264,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why fixing cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1085,7 +1273,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Workspace containing the test coverage implementation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "changed_files",
@@ -1107,7 +1295,7 @@
         "required_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -1116,11 +1304,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Workspace containing the test coverage implementation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -1129,7 +1317,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1138,15 +1326,15 @@
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           }
         ]
       },
@@ -1155,7 +1343,7 @@
         "required_provision_fields": [
           {
             "name": "pr_report",
-            "description": "Why no pull request was created or updated."
+            "description": "PR creation, review, conflict, or post-CI regression report."
           }
         ]
       },
@@ -1164,7 +1352,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1172,12 +1360,20 @@
         "transition_group_id": "group-110d29fb-0617-4277-a4a6-55407f7e66e3",
         "required_provision_fields": [
           {
-            "name": "ci_report",
-            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
-            "name": "pr_url",
-            "description": "URL of the created or updated pull request."
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "ci_report",
+            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
           }
         ]
       },
@@ -1186,7 +1382,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Workspace containing the test coverage implementation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "ci_report",
@@ -1199,7 +1395,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why CI monitoring cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1208,32 +1404,88 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
       {
-        "transition_group_id": "group-82060b25-1237-42ba-a1f6-f608cc248c9e",
+        "transition_group_id": "group-f9d6c92e-850f-4730-ada8-025483a92b59",
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the created or updated pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "merge_report",
+            "description": "GitHub PR state, mergedAt, mergeCommit, and cleanup or release notes."
+          }
+        ]
+      },
+      {
+        "transition_group_id": "group-a28669ca-a4cf-4a42-bcd0-2da073933b7b",
+        "required_provision_fields": [
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "pr_report",
+            "description": "PR creation, review, conflict, or post-CI regression report."
+          }
+        ]
+      },
+      {
+        "transition_group_id": "group-26e23205-f984-4f91-aa4e-ed32d3b0fc74",
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Workspace containing the test coverage implementation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
-            "name": "ci_report",
-            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+            "name": "waiting_reason",
+            "description": "Why the PR cannot advance yet and the exact user or external action needed."
+          }
+        ]
+      },
+      {
+        "transition_group_id": "group-edd91e42-2206-4c58-8514-a75f76318792",
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "cleanup_reason",
+            "description": "Explicit user instruction or reason for cleanup without merge."
+          }
+        ]
+      },
+      {
+        "transition_group_id": "group-9f9a6407-39cc-45c6-91f5-02da7979d109",
+        "required_provision_fields": [
+          {
+            "name": "closure_reason",
+            "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
           }
         ]
       }
@@ -1259,11 +1511,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/test-coverage-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "plan_path",
-            "description": "Path to the test coverage plan.md being executed."
+            "description": "Path to the plan.md used by this workflow transition."
           }
         ]
       },
@@ -1284,11 +1536,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/test-coverage-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "plan_path",
-            "description": "Path to the test coverage plan.md being executed."
+            "description": "Path to the plan.md used by this workflow transition."
           }
         ]
       },
@@ -1319,11 +1571,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Path to the explicit .todo/test-coverage-* workspace."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "plan_path",
-            "description": "Path to the test coverage plan.md being executed."
+            "description": "Path to the plan.md used by this workflow transition."
           },
           {
             "name": "changed_files",
@@ -1357,7 +1609,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Workspace containing the test coverage implementation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "review_report",
@@ -1391,7 +1643,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Workspace containing the test coverage implementation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "review_report",
@@ -1415,7 +1667,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why planning cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1431,7 +1683,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why implementation cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1447,7 +1699,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1463,7 +1715,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why fixing cannot continue, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1484,7 +1736,7 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Workspace containing the test coverage implementation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "changed_files",
@@ -1520,7 +1772,7 @@
         "required_provision_fields": [
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -1541,11 +1793,11 @@
         "required_provision_fields": [
           {
             "name": "workspace_path",
-            "description": "Workspace containing the test coverage implementation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "compliance_report",
-            "description": "Compliance review report, including rule sources checked and any findings."
+            "description": "Compliance review report or summary."
           }
         ]
       },
@@ -1561,7 +1813,7 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why compliance review cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
@@ -1587,15 +1839,15 @@
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           }
         ]
       },
@@ -1611,7 +1863,7 @@
         "required_provision_fields": [
           {
             "name": "pr_report",
-            "description": "Why no pull request was created or updated."
+            "description": "PR creation, review, conflict, or post-CI regression report."
           }
         ]
       },
@@ -1627,103 +1879,12 @@
         "required_provision_fields": [
           {
             "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
           }
         ]
       },
       {
         "edge_id": "edge-21f98ec4-4a45-407f-9e56-0eca603f5582",
-        "input_bindings": [
-          {
-            "name": "ci_report",
-            "source": "transition_output",
-            "field": "ci_report"
-          },
-          {
-            "name": "pr_url",
-            "source": "transition_output",
-            "field": "pr_url"
-          }
-        ],
-        "required_provision_fields": [
-          {
-            "name": "ci_report",
-            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
-          },
-          {
-            "name": "pr_url",
-            "description": "URL of the created or updated pull request."
-          }
-        ]
-      },
-      {
-        "edge_id": "edge-1b5028f6-19cb-4e58-9994-f7432899bab6",
-        "input_bindings": [
-          {
-            "name": "workspace_path",
-            "source": "transition_output",
-            "field": "workspace_path"
-          },
-          {
-            "name": "ci_report",
-            "source": "transition_output",
-            "field": "ci_report"
-          }
-        ],
-        "required_provision_fields": [
-          {
-            "name": "workspace_path",
-            "description": "Workspace containing the test coverage implementation."
-          },
-          {
-            "name": "ci_report",
-            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
-          }
-        ]
-      },
-      {
-        "edge_id": "edge-8bf0d7e7-5b9f-4929-a47c-71b5006e9312",
-        "input_bindings": [
-          {
-            "name": "blocker_reason",
-            "source": "transition_output",
-            "field": "blocker_reason"
-          }
-        ],
-        "required_provision_fields": [
-          {
-            "name": "blocker_reason",
-            "description": "Why CI monitoring cannot complete, in the task language when practical."
-          }
-        ]
-      },
-      {
-        "edge_id": "edge-a3f77960-2d03-4750-b33d-d2fb6162a6a0",
-        "input_bindings": [
-          {
-            "name": "workspace_path",
-            "source": "transition_output",
-            "field": "workspace_path"
-          },
-          {
-            "name": "blocker_reason",
-            "source": "transition_output",
-            "field": "blocker_reason"
-          }
-        ],
-        "required_provision_fields": [
-          {
-            "name": "workspace_path",
-            "description": "Path to the worktree or checkout used for PR creation."
-          },
-          {
-            "name": "blocker_reason",
-            "description": "Why PR creation/update cannot complete, in the task language when practical."
-          }
-        ]
-      },
-      {
-        "edge_id": "edge-a183ffc5-f22d-46e2-bb71-84e217252667",
         "input_bindings": [
           {
             "name": "pr_url",
@@ -1749,19 +1910,237 @@
         "required_provision_fields": [
           {
             "name": "pr_url",
-            "description": "URL of the created or updated pull request."
+            "description": "URL of the created, updated, or monitored pull request."
           },
           {
             "name": "branch_name",
-            "description": "Name of the pushed task branch."
+            "description": "Name of the task or release branch associated with the pull request."
           },
           {
             "name": "workspace_path",
-            "description": "Workspace containing the test coverage implementation."
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
           },
           {
             "name": "ci_report",
             "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-1b5028f6-19cb-4e58-9994-f7432899bab6",
+        "input_bindings": [
+          {
+            "name": "workspace_path",
+            "source": "transition_output",
+            "field": "workspace_path"
+          },
+          {
+            "name": "ci_report",
+            "source": "transition_output",
+            "field": "ci_report"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "ci_report",
+            "description": "CI/check status report, including failures, skipped checks, or accepted absent checks."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-8bf0d7e7-5b9f-4929-a47c-71b5006e9312",
+        "input_bindings": [
+          {
+            "name": "blocker_reason",
+            "source": "transition_output",
+            "field": "blocker_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "blocker_reason",
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-a3f77960-2d03-4750-b33d-d2fb6162a6a0",
+        "input_bindings": [
+          {
+            "name": "workspace_path",
+            "source": "transition_output",
+            "field": "workspace_path"
+          },
+          {
+            "name": "blocker_reason",
+            "source": "transition_output",
+            "field": "blocker_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "blocker_reason",
+            "description": "Short human-readable blocker explanation in the task language when practical; include the missing access/input/check and the exact next user action needed."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-c6c59c17-3133-4058-a3fb-0b30050700a7",
+        "input_bindings": [
+          {
+            "name": "pr_url",
+            "source": "transition_output",
+            "field": "pr_url"
+          },
+          {
+            "name": "branch_name",
+            "source": "transition_output",
+            "field": "branch_name"
+          },
+          {
+            "name": "merge_report",
+            "source": "transition_output",
+            "field": "merge_report"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "merge_report",
+            "description": "GitHub PR state, mergedAt, mergeCommit, and cleanup or release notes."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-b88db529-d819-4ead-abc4-14f9a34748b1",
+        "input_bindings": [
+          {
+            "name": "workspace_path",
+            "source": "transition_output",
+            "field": "workspace_path"
+          },
+          {
+            "name": "pr_report",
+            "source": "transition_output",
+            "field": "pr_report"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "pr_report",
+            "description": "PR creation, review, conflict, or post-CI regression report."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-ccb8cb2d-e357-41f7-9d12-86ae7f9789a5",
+        "input_bindings": [
+          {
+            "name": "pr_url",
+            "source": "transition_output",
+            "field": "pr_url"
+          },
+          {
+            "name": "branch_name",
+            "source": "transition_output",
+            "field": "branch_name"
+          },
+          {
+            "name": "workspace_path",
+            "source": "transition_output",
+            "field": "workspace_path"
+          },
+          {
+            "name": "waiting_reason",
+            "source": "transition_output",
+            "field": "waiting_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "workspace_path",
+            "description": "Path to the task workspace or worktree relevant to this workflow transition."
+          },
+          {
+            "name": "waiting_reason",
+            "description": "Why the PR cannot advance yet and the exact user or external action needed."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-187229f4-219d-41c0-8c9f-7faf8b0779ce",
+        "input_bindings": [
+          {
+            "name": "pr_url",
+            "source": "transition_output",
+            "field": "pr_url"
+          },
+          {
+            "name": "branch_name",
+            "source": "transition_output",
+            "field": "branch_name"
+          },
+          {
+            "name": "cleanup_reason",
+            "source": "transition_output",
+            "field": "cleanup_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "pr_url",
+            "description": "URL of the created, updated, or monitored pull request."
+          },
+          {
+            "name": "branch_name",
+            "description": "Name of the task or release branch associated with the pull request."
+          },
+          {
+            "name": "cleanup_reason",
+            "description": "Explicit user instruction or reason for cleanup without merge."
+          }
+        ]
+      },
+      {
+        "edge_id": "edge-a5ae347d-844e-4a4b-b08d-5c15a5b2715e",
+        "input_bindings": [
+          {
+            "name": "closure_reason",
+            "source": "transition_output",
+            "field": "closure_reason"
+          }
+        ],
+        "required_provision_fields": [
+          {
+            "name": "closure_reason",
+            "description": "Explicit latest user instruction explaining why this task should be closed as not planned or canceled."
           }
         ]
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,8 +264,8 @@ The agent recognizes intent from natural language, but feature target selection 
 ### Shared Device Coordination
 
 Before touching an emulator/device, acquire a shared lock so parallel Kent sessions do not install over each other or
-fight for focus. Physical devices, including a real TV, are forbidden unless the task/user explicitly names or allows that
-physical device. Never rely on adb's default target selection.
+fight for focus. Physical devices, including a real TV, are forbidden unless the task/user explicitly provides permission
+and an explicit serial for that physical device. Never rely on adb's default target selection.
 
 ```bash
 EMULATORS=($(.kent/adapters/mobile/emulator-resource-lock.sh adb-emulators))


### PR DESCRIPTION
## Summary
- replace terminal/retry blockers with approval-gated needs_user_action self-loops and explicit wont_do cancellations
- add waiting_pr semantics so PR workflows only reach done after merged PR + cleanup
- tighten physical-device rules to require explicit permission plus explicit serial
- update workflow snapshots, project contract, AGENTS, and command contracts away from old done/blocked transitions

## Verification
- kent workflow validate --mode execution for all 9 Puber workflows
- no live Puber transition groups named blocked/retry_later/not_ready
- snapshots parse with jq
- compliance_reviewer follow-up: No blocking findings
