### PR TITLE
Prepare Puber 1.5.0 release

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
     alias(libs.plugins.androidx.baselineprofile)
 }
 
-val currentVersion = "1.4.0"
+val currentVersion = "1.5.0"
 
 /**
  * Reads CLIENT_SECRET from local.properties or system environment variable

--- a/app/src/main/java/com/kino/puber/core/paginator/PagingVM.kt
+++ b/app/src/main/java/com/kino/puber/core/paginator/PagingVM.kt
@@ -22,10 +22,11 @@ abstract class PagingVM<T, VS>(
     protected val paginator: Paginator.Store<T>,
     router: AppRouter,
     override val errorHandler: ErrorHandler,
+    pagingCoroutineContext: CoroutineContext = Dispatchers.Default,
 ) : PuberVM<VS>(router) {
 
     private val pagingJob = SupervisorJob()
-    private val pagingScope = CoroutineScope(Dispatchers.Default + pagingJob)
+    private val pagingScope = CoroutineScope(pagingCoroutineContext + pagingJob)
     protected var isFullDataNext = false
     protected var isFullDataPrev = false
     protected open val errorHandlerGeneral by lazy { errorHandler.handler(::setGeneralError) }

--- a/app/src/main/java/com/kino/puber/ui/feature/contentlist/vm/SectionVM.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/contentlist/vm/SectionVM.kt
@@ -16,6 +16,8 @@ import com.kino.puber.domain.interactor.bookmarks.SavedItemInteractor
 import com.kino.puber.domain.interactor.contentlist.ContentListInteractor
 import com.kino.puber.ui.feature.contentlist.model.SectionConfig
 import com.kino.puber.ui.feature.contentlist.model.SectionState
+import kotlinx.coroutines.Dispatchers
+import kotlin.coroutines.CoroutineContext
 
 internal class SectionVM(
     paginator: Paginator.Store<Item>,
@@ -26,7 +28,8 @@ internal class SectionVM(
     router: AppRouter,
     errorHandler: ErrorHandler,
     private val contentListRefreshCoordinator: ContentListRefreshCoordinator,
-) : PagingVM<Item, SectionState>(paginator, router, errorHandler) {
+    pagingCoroutineContext: CoroutineContext = Dispatchers.Default,
+) : PagingVM<Item, SectionState>(paginator, router, errorHandler, pagingCoroutineContext) {
 
     // Collect state without back dispatcher — for use outside LazyColumn items
     @Composable

--- a/app/src/test/kotlin/com/kino/puber/ui/feature/contentlist/vm/SectionVMTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/ui/feature/contentlist/vm/SectionVMTest.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
+import kotlin.coroutines.CoroutineContext
 
 class SectionVMTest {
 
@@ -39,7 +40,8 @@ class SectionVMTest {
 
     @Test
     fun coordinatorRefresh_restartsPagingWithoutClearingSharedCache() = runTest {
-        val paginator = paginator(testScheduler)
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val paginator = paginator(dispatcher)
         val interactor = mockk<ContentListInteractor>(relaxed = true)
         val coordinator = ContentListRefreshCoordinator()
         val sideEffects = mutableListOf<Paginator.SideEffect>()
@@ -47,7 +49,7 @@ class SectionVMTest {
             paginator.sideEffects.collect(sideEffects::add)
         }
         coEvery { interactor.loadPage(any(), page = 1) } returns emptyPage()
-        val vm = createVM(paginator, config("popular"), interactor, coordinator)
+        val vm = createVM(paginator, config("popular"), interactor, coordinator, dispatcher)
         vm.testOnStart()
         testScheduler.advanceUntilIdle()
         sideEffects.clear()
@@ -74,8 +76,9 @@ class SectionVMTest {
 
     @Test
     fun directSavedChange_invalidatesCacheOnceAndRestartsSiblingSections() = runTest {
-        val firstPaginator = paginator(testScheduler)
-        val siblingPaginator = paginator(testScheduler)
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val firstPaginator = paginator(dispatcher)
+        val siblingPaginator = paginator(dispatcher)
         val interactor = mockk<ContentListInteractor>(relaxed = true)
         val savedItemInteractor = mockk<SavedItemInteractor>(relaxed = true)
         val coordinator = ContentListRefreshCoordinator()
@@ -85,8 +88,22 @@ class SectionVMTest {
         coEvery {
             savedItemInteractor.setSaved(itemId = 42, isSeriesLike = false, saved = false)
         } returns Result.success(false)
-        val first = createVM(firstPaginator, firstConfig, interactor, coordinator, savedItemInteractor)
-        val sibling = createVM(siblingPaginator, siblingConfig, interactor, coordinator, savedItemInteractor)
+        val first = createVM(
+            paginator = firstPaginator,
+            config = firstConfig,
+            interactor = interactor,
+            coordinator = coordinator,
+            pagingCoroutineContext = dispatcher,
+            savedItemInteractor = savedItemInteractor,
+        )
+        val sibling = createVM(
+            paginator = siblingPaginator,
+            config = siblingConfig,
+            interactor = interactor,
+            coordinator = coordinator,
+            pagingCoroutineContext = dispatcher,
+            savedItemInteractor = savedItemInteractor,
+        )
         first.testOnStart()
         sibling.testOnStart()
         testScheduler.advanceUntilIdle()
@@ -95,8 +112,8 @@ class SectionVMTest {
         testScheduler.advanceUntilIdle()
 
         verify(exactly = 1) { interactor.invalidateFirstPageCache() }
-        coVerify(timeout = 1_000, exactly = 2) { interactor.loadPage(firstConfig, page = 1) }
-        coVerify(timeout = 1_000, exactly = 2) { interactor.loadPage(siblingConfig, page = 1) }
+        coVerify(exactly = 2) { interactor.loadPage(firstConfig, page = 1) }
+        coVerify(exactly = 2) { interactor.loadPage(siblingConfig, page = 1) }
         first.testCancelScope()
         sibling.testCancelScope()
         firstPaginator.close()
@@ -108,6 +125,7 @@ class SectionVMTest {
         config: SectionConfig,
         interactor: ContentListInteractor,
         coordinator: ContentListRefreshCoordinator,
+        pagingCoroutineContext: CoroutineContext,
         savedItemInteractor: SavedItemInteractor = mockk(relaxed = true),
     ) = SectionVM(
         paginator = paginator,
@@ -118,11 +136,12 @@ class SectionVMTest {
         router = mockk<AppRouter>(relaxed = true),
         errorHandler = mockk<ErrorHandler> { every { proceed(any()) } returns { } },
         contentListRefreshCoordinator = coordinator,
+        pagingCoroutineContext = pagingCoroutineContext,
     )
 
-    private fun paginator(testScheduler: TestCoroutineScheduler) = Paginator.Store<Item>(
+    private fun paginator(coroutineContext: CoroutineContext) = Paginator.Store<Item>(
         comparator = { old, new -> old.id == new.id },
-        coroutineContext = StandardTestDispatcher(testScheduler),
+        coroutineContext = coroutineContext,
     )
 
     private fun config(id: String) = SectionConfig(id = id, title = id)


### PR DESCRIPTION
## Summary

- Prepare the next minor Puber release: `1.5.0`.
- Bump `currentVersion` in `app/build.gradle.kts` from `1.4.0` to `1.5.0`.
- Make `SectionVMTest` page loading fully virtual-time controlled after the first PR CI run exposed a remaining
  `Dispatchers.Default` timing dependency.
- Release branch: `release/1.5.0`; intended post-merge tag: `v1.5.0`.

## Planned release notes

The GitHub Release notes will be published in Russian:

### Что нового

- Добавлено автоматическое обновление приложения через GitHub Releases: Puber проверяет наличие новой версии,
  предлагает скачать APK, проверяет контрольную сумму и открывает системный установщик. Автоматическую проверку можно
  отключить в настройках.
- В плеере появилась кнопка «Просмотрено» для ручного изменения статуса текущего фильма или эпизода.
- После возврата из плеера или карточки контента автоматически обновляются прогресс просмотра, статус «Просмотрено»,
  закладки и список «Смотреть позже» на главном экране, в избранном, поиске, подборках и списках.

### Исправления и надёжность

- Исправлен запуск авторизации после очистки данных приложения: теперь корректно открывается вход по коду устройства.
- Улучшена надёжность сохранения прогресса и статуса просмотра, возврата назад, обновления кэша и вложенной навигации.
- Исправлена редкая ситуация, при которой одна из секций могла не обновиться после изменения закладки.

## Compliance Review

- PASS.
- Final compliance, standards, and quality reviews passed.
- `PagingVM` keeps `Dispatchers.Default` as its production default; the injected context is used only to make Section
  paging tests deterministic.
- Koin construction remains unchanged because the new `SectionVM` argument has a production default.
- The branch is based on `origin/master` at `ee8bd87`.
- Tag publication remains blocked until this PR is merged into `master`.

## Verification

- `./tools/agentw :app:compileDevDebugKotlin :app:compileProdReleaseKotlin :app:testProdDebugUnitTest --rerun-tasks --no-parallel` — passed.
- Prod unit tests: **323**, failures: **0**, errors: **0**, skipped: **0**.
- Prod `SectionVMTest` stress verification: **30/30** consecutive reruns passed.
- `git diff --check` — passed.
- Project-wide Detekt remains non-green at the existing **127 weighted issues**; finding-level comparison against the
  exact `origin/master` implementation reports **0 new findings**.
- Initial PR CI: Build passed; Unit Tests exposed the pre-fix Section paging timing dependency.
- Post-fix GitHub Actions on `36e64f4`: **Build passed**, **Unit Tests passed**, and **Detekt was skipped by the
  repository workflow**.
- Production signing was not locally proven because release signing files and environment secrets are not available in
  this worktree. The tag-triggered GitHub workflow validates those secrets before building and publishing the signed APK.

## Release publication

- Do not create or push `v1.5.0` until this PR is merged into `master`.
- After the tag workflow publishes the APK and checksum, replace the generated GitHub Release body with the Russian
  notes above.
