### PR TITLE
PUB-31 Complete viewing history

### DIFF
--- a/app/src/androidTest/kotlin/com/kino/puber/core/ui/navigation/component/TabFlowLifecycleTest.kt
+++ b/app/src/androidTest/kotlin/com/kino/puber/core/ui/navigation/component/TabFlowLifecycleTest.kt
@@ -1,0 +1,372 @@
+package com.kino.puber.core.ui.navigation.component
+
+import android.app.Activity
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.ViewModel
+import com.kino.puber.core.di.DIScope
+import com.kino.puber.core.di.LocalPuberKoinScope
+import com.kino.puber.core.di.puberViewModel
+import com.kino.puber.core.ui.navigation.AppLauncher
+import com.kino.puber.core.ui.navigation.AppRouter
+import com.kino.puber.core.ui.navigation.FullscreenPuberScreen
+import com.kino.puber.core.ui.navigation.PuberScreen
+import com.kino.puber.core.ui.navigation.PuberTab
+import com.kino.puber.core.ui.navigation.RootPuberScreen
+import com.kino.puber.core.ui.navigation.Screens
+import com.kino.puber.core.ui.navigation.TabRouter
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.Navigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import com.kino.puber.ui.ScreensImpl
+import com.kino.puber.ui.feature.main.model.TabType
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.koin.core.module.dsl.viewModelOf
+import org.koin.core.qualifier.named
+import org.koin.core.scope.Scope
+import org.koin.core.scope.ScopeID
+import org.koin.dsl.module
+
+private const val HISTORY_TAG = "probe_history"
+private const val CHILD_BUTTON_TAG = "probe_child"
+private const val PLAYER_BUTTON_TAG = "probe_player"
+private const val DETAILS_BUTTON_TAG = "probe_details"
+private const val DESTINATION_TAG = "probe_destination"
+private const val BACK_BUTTON_TAG = "probe_back"
+private const val OTHER_TAB_TAG = "probe_other_tab"
+
+internal class TabFlowLifecycleTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private lateinit var coroutineScope: CoroutineScope
+    private lateinit var tabRouter: TabRouter
+    private lateinit var tabAppRouterHolder: TabAppRouterHolder
+
+    @Before
+    fun setUp() {
+        ProbeHistoryVM.reset()
+        ProbeNavigatorRegistry.reset()
+        coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        tabRouter = TabRouter(coroutineScope)
+        tabAppRouterHolder = TabAppRouterHolder(ScreensImpl)
+        ProbeMainHost.bind(tabRouter, tabAppRouterHolder)
+    }
+
+    @After
+    fun tearDown() {
+        composeRule.runOnIdle { tabAppRouterHolder.dispose() }
+        ProbeMainHost.clear()
+        coroutineScope.cancel()
+    }
+
+    @Test
+    fun refreshThenPlayerAndDetailsBackUsesTheRefreshedHistoryLifecycle() {
+        composeRule.setContent {
+            FlowComponent(
+                scopeName = "TabFlowLifecycleTest",
+                screen = ProbeMainHostScreen,
+                moduleFactory = { scopeId, _ ->
+                    module {
+                        scope(named(scopeId)) {
+                            scoped<AppLauncher> { ProbeAppLauncher }
+                            scoped<Screens> { ScreensImpl }
+                        }
+                    }
+                },
+            )
+        }
+        val initialTab = PuberTab(
+            screen = ProbeHistoryScreen(contentGeneration = 0),
+            tag = TabType.History,
+        )
+        val refreshedTab = PuberTab(
+            screen = ProbeHistoryScreen(contentGeneration = 1),
+            tag = TabType.History,
+            instanceKey = "refresh_1",
+        )
+        val refreshedAgainTab = PuberTab(
+            screen = ProbeHistoryScreen(contentGeneration = 2),
+            tag = TabType.History,
+            instanceKey = "refresh_2",
+        )
+        val otherTab = PuberTab(
+            screen = ProbeOtherScreen,
+            tag = TabType.Home,
+        )
+
+        composeRule.runOnIdle { tabRouter.openTab(initialTab) }
+        composeRule.onNodeWithTag(HISTORY_TAG).assertTextContains("content=0")
+
+        composeRule.onNodeWithTag(CHILD_BUTTON_TAG).performClick()
+        composeRule.onNodeWithTag(DESTINATION_TAG).assertTextContains("Child")
+        composeRule.runOnIdle { tabRouter.openTab(otherTab) }
+        composeRule.onNodeWithTag(OTHER_TAB_TAG).assertTextContains("Other")
+        composeRule.runOnIdle { tabRouter.openTab(initialTab) }
+        composeRule.onNodeWithTag(DESTINATION_TAG).assertTextContains("Child")
+        composeRule.onNodeWithTag(BACK_BUTTON_TAG).performClick()
+        composeRule.onNodeWithTag(HISTORY_TAG).assertTextContains("content=0")
+
+        composeRule.runOnIdle { tabRouter.openTab(refreshedTab) }
+        composeRule.onNodeWithTag(HISTORY_TAG).assertTextContains("content=1")
+        composeRule.waitUntil { ProbeHistoryVM.clearedGenerations() == setOf(1) }
+        composeRule.runOnIdle { tabRouter.openTab(refreshedAgainTab) }
+        composeRule.onNodeWithTag(HISTORY_TAG).assertTextContains("content=2")
+        composeRule.waitUntil { ProbeHistoryVM.clearedGenerations() == setOf(1, 2) }
+        composeRule.runOnIdle {
+            assertSame(
+                ProbeNavigatorRegistry.historyNavigator(0),
+                ProbeNavigatorRegistry.historyNavigator(1),
+            )
+            assertSame(
+                ProbeNavigatorRegistry.historyNavigator(1),
+                ProbeNavigatorRegistry.historyNavigator(2),
+            )
+        }
+
+        openDestinationAndReturn(PLAYER_BUTTON_TAG, "Player")
+        openDestinationAndReturn(DETAILS_BUTTON_TAG, "Details")
+
+        composeRule.waitUntil {
+            ProbeHistoryVM.createdCount() - ProbeHistoryVM.clearedGenerations().size == 1
+        }
+        composeRule.runOnIdle {
+            assertEquals(
+                1,
+                ProbeHistoryVM.createdCount() - ProbeHistoryVM.clearedGenerations().size,
+            )
+        }
+    }
+
+    private fun openDestinationAndReturn(
+        actionTag: String,
+        destination: String,
+    ) {
+        composeRule.onNodeWithTag(actionTag).performClick()
+        composeRule
+            .onNodeWithTag(DESTINATION_TAG)
+            .assertTextContains(destination)
+        composeRule.onNodeWithTag(BACK_BUTTON_TAG).performClick()
+        composeRule
+            .onNodeWithTag(HISTORY_TAG)
+            .assertTextContains("content=2")
+    }
+}
+
+private data object ProbeAppLauncher : AppLauncher {
+    override fun restart() = Unit
+
+    override fun finish() = Unit
+
+    override fun bind(activity: Activity) = Unit
+
+    override fun unbind() = Unit
+}
+
+private object ProbeMainHost {
+    var tabRouter: TabRouter? = null
+    var tabAppRouterHolder: TabAppRouterHolder? = null
+
+    fun bind(
+        tabRouter: TabRouter,
+        tabAppRouterHolder: TabAppRouterHolder,
+    ) {
+        this.tabRouter = tabRouter
+        this.tabAppRouterHolder = tabAppRouterHolder
+    }
+
+    fun clear() {
+        tabRouter = null
+        tabAppRouterHolder = null
+    }
+}
+
+@Parcelize
+private data object ProbeMainHostScreen : PuberScreen {
+    @Composable
+    override fun Content() {
+        TabComponent(
+            tabRouter = requireNotNull(ProbeMainHost.tabRouter),
+            tabAppRouterHolder = requireNotNull(ProbeMainHost.tabAppRouterHolder),
+        ) {
+            PuberCurrentTab()
+        }
+    }
+}
+
+@Parcelize
+private data class ProbeHistoryScreen(
+    private val contentGeneration: Int,
+) : PuberScreen {
+
+    @IgnoredOnParcel
+    override val key = "ProbeHistoryScreen"
+
+    @Suppress("unused")
+    private fun buildModule(scopeId: ScopeID, parentScope: Scope) = module {
+        scope(named(scopeId)) {
+            viewModelOf(::ProbeHistoryVM)
+        }
+    }
+
+    @Composable
+    override fun Content() = DIScope(
+        scopeName = key,
+        moduleFactory = ::buildModule,
+    ) {
+        val vm = puberViewModel<ProbeHistoryVM>()
+        val navigator = LocalNavigator.currentOrThrow
+        SideEffect {
+            ProbeNavigatorRegistry.recordHistory(contentGeneration, navigator)
+        }
+        Column {
+            Text(
+                text = "content=$contentGeneration vm=${vm.generation}",
+                modifier = Modifier.testTag(HISTORY_TAG),
+            )
+            Button(
+                modifier = Modifier.testTag(CHILD_BUTTON_TAG),
+                onClick = vm::openChild,
+            ) {
+                Text("Open Child")
+            }
+            Button(
+                modifier = Modifier.testTag(PLAYER_BUTTON_TAG),
+                onClick = vm::openPlayer,
+            ) {
+                Text("Open Player")
+            }
+            Button(
+                modifier = Modifier.testTag(DETAILS_BUTTON_TAG),
+                onClick = vm::openDetails,
+            ) {
+                Text("Open Details")
+            }
+        }
+    }
+}
+
+@Parcelize
+private data object ProbeOtherScreen : PuberScreen {
+    @Composable
+    override fun Content() {
+        Text(
+            text = "Other",
+            modifier = Modifier.testTag(OTHER_TAB_TAG),
+        )
+    }
+}
+
+private class ProbeHistoryVM(
+    private val router: AppRouter,
+) : ViewModel() {
+    val generation: Int = generations.incrementAndGet()
+
+    fun openChild() {
+        router.navigateTo(ProbeChildScreen)
+    }
+
+    fun openPlayer() {
+        router.navigateTo(ProbePlayerScreen)
+    }
+
+    fun openDetails() {
+        router.navigateTo(ProbeDetailsScreen)
+    }
+
+    override fun onCleared() {
+        cleared += generation
+    }
+
+    companion object {
+        private val generations = AtomicInteger()
+        private val cleared = ConcurrentHashMap.newKeySet<Int>()
+
+        fun reset() {
+            generations.set(0)
+            cleared.clear()
+        }
+
+        fun createdCount(): Int = generations.get()
+
+        fun clearedGenerations(): Set<Int> = cleared.toSet()
+    }
+}
+
+@Parcelize
+private data object ProbeChildScreen : PuberScreen {
+    @Composable
+    override fun Content() {
+        ProbeDestination("Child")
+    }
+}
+
+private object ProbeNavigatorRegistry {
+    private val historyNavigators = ConcurrentHashMap<Int, Navigator>()
+
+    fun reset() {
+        historyNavigators.clear()
+    }
+
+    fun recordHistory(generation: Int, navigator: Navigator) {
+        historyNavigators[generation] = navigator
+    }
+
+    fun historyNavigator(generation: Int): Navigator? = historyNavigators[generation]
+}
+
+@Parcelize
+private data object ProbePlayerScreen : FullscreenPuberScreen {
+    @Composable
+    override fun Content() {
+        ProbeDestination("Player")
+    }
+}
+
+@Parcelize
+private data object ProbeDetailsScreen : RootPuberScreen {
+    @Composable
+    override fun Content() {
+        ProbeDestination("Details")
+    }
+}
+
+@Composable
+private fun ProbeDestination(destination: String) {
+    val router = requireNotNull(LocalPuberKoinScope.current).get<AppRouter>()
+    Column {
+        Text(
+            text = destination,
+            modifier = Modifier.testTag(DESTINATION_TAG),
+        )
+        Button(
+            modifier = Modifier.testTag(BACK_BUTTON_TAG),
+            onClick = router::back,
+        ) {
+            Text("Back")
+        }
+    }
+}

--- a/app/src/androidTest/kotlin/com/kino/puber/core/ui/uikit/component/moviesList/VideoGridInitialFocusTest.kt
+++ b/app/src/androidTest/kotlin/com/kino/puber/core/ui/uikit/component/moviesList/VideoGridInitialFocusTest.kt
@@ -1,0 +1,69 @@
+package com.kino.puber.core.ui.uikit.component.moviesList
+
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.kino.puber.core.ui.uikit.theme.PuberTheme
+import org.junit.Rule
+import org.junit.Test
+
+internal class VideoGridInitialFocusTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun initialFocusedItemIdFocusesExactEpisodeAcrossSeasons() {
+        val target = episode(id = 804, seasonNumber = 8, episodeNumber = 4)
+        composeRule.setContent {
+            PuberTheme {
+                VideoGrid(
+                    state = VideoGridUIState(
+                        list = (1..8).flatMap { seasonNumber ->
+                            listOf(
+                                VideoGridItemUIState.Title("Season $seasonNumber"),
+                                VideoGridItemUIState.Items(
+                                    listOf(
+                                        episode(
+                                            id = seasonNumber * 100 + 1,
+                                            seasonNumber = seasonNumber,
+                                            episodeNumber = 1,
+                                        ),
+                                        if (seasonNumber == 8) {
+                                            target
+                                        } else {
+                                            episode(
+                                                id = seasonNumber * 100 + 2,
+                                                seasonNumber = seasonNumber,
+                                                episodeNumber = 2,
+                                            )
+                                        },
+                                    ),
+                                ),
+                            )
+                        },
+                    ),
+                    initialFocusedItemId = target.id,
+                )
+            }
+        }
+
+        composeRule.onNodeWithText(target.title).assertIsFocused()
+    }
+
+    private fun episode(
+        id: Int,
+        seasonNumber: Int,
+        episodeNumber: Int,
+    ): VideoItemUIState {
+        return VideoItemUIState(
+            id = id,
+            title = "S${seasonNumber}E$episodeNumber",
+            imageUrl = "",
+            bigImageUrl = "",
+            showTitle = true,
+            seasonNumber = seasonNumber,
+            episodeNumber = episodeNumber,
+        )
+    }
+}

--- a/app/src/androidTest/kotlin/com/kino/puber/ui/feature/details/component/DetailsScreenContentTest.kt
+++ b/app/src/androidTest/kotlin/com/kino/puber/ui/feature/details/component/DetailsScreenContentTest.kt
@@ -1,0 +1,207 @@
+package com.kino.puber.ui.feature.details.component
+
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.adamglin.PhosphorIcons
+import com.adamglin.phosphoricons.Duotone
+import com.adamglin.phosphoricons.duotone.Play
+import com.kino.puber.R
+import com.kino.puber.core.ui.uikit.component.details.VideoDetailsUIState
+import com.kino.puber.core.ui.uikit.component.moviesList.VideoGridItemUIState
+import com.kino.puber.core.ui.uikit.component.moviesList.VideoGridUIState
+import com.kino.puber.core.ui.uikit.component.moviesList.VideoItemUIState
+import com.kino.puber.core.ui.uikit.theme.PuberTheme
+import com.kino.puber.ui.feature.details.model.DetailsAction
+import com.kino.puber.ui.feature.details.model.DetailsButtonUIState
+import com.kino.puber.ui.feature.details.model.DetailsInfoUIState
+import com.kino.puber.ui.feature.details.model.DetailsScreenState
+import org.junit.Rule
+import org.junit.Test
+
+private const val PRIMARY_ACTION = "Primary details action"
+private const val DEFAULT_EPISODE = "S1E1"
+private const val TARGET_EPISODE = "S8E4 target"
+
+internal class DetailsScreenContentTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun visibleEpisodePanelFocusesExactTargetInLaterSeason() {
+        val episodes = episodes()
+        composeRule.setContent {
+            PuberTheme {
+                DetailsScreenContent(
+                    state = content(
+                        episodes = episodes,
+                        seasonsPanelVisible = true,
+                        initialEpisodeFocusId = TARGET_EPISODE_ID,
+                    ),
+                    onAction = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Season 8").assertIsDisplayed()
+        composeRule.onNodeWithText(TARGET_EPISODE).assertIsDisplayed()
+        composeRule.waitUntil {
+            composeRule
+                .onNodeWithText(TARGET_EPISODE)
+                .fetchSemanticsNode()
+                .config
+                .getOrNull(SemanticsProperties.Focused) == true
+        }
+        composeRule.onNodeWithText(TARGET_EPISODE).assertIsFocused()
+    }
+
+    @Test
+    fun ordinaryDetailsWithoutEpisodeTargetKeepsPrimaryActionFocused() {
+        composeRule.setContent {
+            PuberTheme {
+                DetailsScreenContent(
+                    state = content(
+                        episodes = episodes(),
+                        seasonsPanelVisible = false,
+                        initialEpisodeFocusId = null,
+                    ),
+                    onAction = {},
+                )
+            }
+        }
+
+        composeRule.waitUntil {
+            composeRule
+                .onNodeWithText(PRIMARY_ACTION)
+                .fetchSemanticsNode()
+                .config
+                .getOrNull(SemanticsProperties.Focused) == true
+        }
+        composeRule.onNodeWithText(PRIMARY_ACTION).assertIsFocused()
+        composeRule.onNodeWithText(TARGET_EPISODE).assertDoesNotExist()
+    }
+
+    @Test
+    fun visibleEpisodePanelWithoutTargetFocusesDefaultEpisode() {
+        composeRule.setContent {
+            PuberTheme {
+                DetailsScreenContent(
+                    state = content(
+                        episodes = episodes(),
+                        seasonsPanelVisible = true,
+                        initialEpisodeFocusId = null,
+                    ),
+                    onAction = {},
+                )
+            }
+        }
+
+        composeRule.waitUntil {
+            composeRule
+                .onNodeWithText(DEFAULT_EPISODE)
+                .fetchSemanticsNode()
+                .config
+                .getOrNull(SemanticsProperties.Focused) == true
+        }
+        composeRule.onNodeWithText(DEFAULT_EPISODE).assertIsFocused()
+    }
+
+    private fun content(
+        episodes: VideoGridUIState,
+        seasonsPanelVisible: Boolean,
+        initialEpisodeFocusId: Int?,
+    ): DetailsScreenState.Content {
+        return DetailsScreenState.Content(
+            details = VideoDetailsUIState(
+                id = 42,
+                title = "Synthetic details",
+                description = "",
+                imageUrl = "",
+                trailerUrl = "",
+                ratings = emptyList(),
+                year = "",
+                genres = "",
+                duration = "",
+                country = "",
+            ),
+            info = DetailsInfoUIState(
+                description = "",
+                ratings = emptyList(),
+                primaryRows = emptyList(),
+                secondaryRows = emptyList(),
+                castMembers = emptyList(),
+            ),
+            buttons = listOf(
+                DetailsButtonUIState.TextButton(
+                    textRes = R.string.video_details_button_watch_movie,
+                    icon = PhosphorIcons.Duotone.Play,
+                    action = DetailsAction.PlayClicked,
+                    textOverride = PRIMARY_ACTION,
+                ),
+            ),
+            isInWatchlist = false,
+            isWatched = false,
+            seasonsPanelVisible = seasonsPanelVisible,
+            episodes = episodes,
+            initialEpisodeFocusId = initialEpisodeFocusId,
+        )
+    }
+
+    private fun episodes(): VideoGridUIState {
+        return VideoGridUIState(
+            list = (1..8).flatMap { seasonNumber ->
+                listOf(
+                    VideoGridItemUIState.Title("Season $seasonNumber"),
+                    VideoGridItemUIState.Items(
+                        listOf(
+                            episode(
+                                id = seasonNumber * 100 + 1,
+                                seasonNumber = seasonNumber,
+                                episodeNumber = 1,
+                            ),
+                            if (seasonNumber == 8) {
+                                episode(
+                                    id = TARGET_EPISODE_ID,
+                                    seasonNumber = seasonNumber,
+                                    episodeNumber = 4,
+                                    title = TARGET_EPISODE,
+                                )
+                            } else {
+                                episode(
+                                    id = seasonNumber * 100 + 2,
+                                    seasonNumber = seasonNumber,
+                                    episodeNumber = 2,
+                                )
+                            },
+                        ),
+                    ),
+                )
+            },
+        )
+    }
+
+    private fun episode(
+        id: Int,
+        seasonNumber: Int,
+        episodeNumber: Int,
+        title: String = "S${seasonNumber}E$episodeNumber",
+    ): VideoItemUIState {
+        return VideoItemUIState(
+            id = id,
+            title = title,
+            imageUrl = "",
+            bigImageUrl = "",
+            showTitle = true,
+            seasonNumber = seasonNumber,
+            episodeNumber = episodeNumber,
+        )
+    }
+
+    private companion object {
+        const val TARGET_EPISODE_ID = 804
+    }
+}

--- a/app/src/androidTest/kotlin/com/kino/puber/ui/feature/history/component/HistoryScreenContentTest.kt
+++ b/app/src/androidTest/kotlin/com/kino/puber/ui/feature/history/component/HistoryScreenContentTest.kt
@@ -1,0 +1,786 @@
+package com.kino.puber.ui.feature.history.component
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.SemanticsPropertiesAndroid
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotFocused
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onParent
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performSemanticsAction
+import com.kino.puber.core.ui.uikit.component.modifier.LocalAutoFocusOnLaunchEnabled
+import com.kino.puber.core.ui.uikit.component.modifier.LocalContentFocusActive
+import com.kino.puber.core.ui.uikit.component.moviesList.WATCHED_INDICATOR_TEST_TAG
+import com.kino.puber.core.ui.uikit.component.moviesList.VideoItemUIState
+import com.kino.puber.core.ui.uikit.model.CommonAction
+import com.kino.puber.core.ui.uikit.model.UIAction
+import com.kino.puber.core.ui.uikit.theme.PuberTheme
+import com.kino.puber.domain.interactor.history.HistoryRowKey
+import com.kino.puber.domain.interactor.history.HistorySemanticKey
+import com.kino.puber.ui.feature.history.model.HistoryAction
+import com.kino.puber.ui.feature.history.model.HistoryItemUIState
+import com.kino.puber.ui.feature.history.model.HistoryPlaybackTarget
+import com.kino.puber.ui.feature.history.model.HistoryPresentation
+import com.kino.puber.ui.feature.history.model.HistoryViewState
+import com.kino.puber.ui.feature.player.model.PlayerStartMode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+private const val DISCLOSURE = "Удаление влияет на историю просмотров вашего аккаунта."
+private const val CONTINUE = "Продолжить просмотр"
+private const val START_OVER = "Смотреть сначала"
+private const val DETAILS = "Подробнее"
+private const val DELETE_EXACT_MEDIA = "Удалить эту запись"
+private const val CLOSE = "Закрыть"
+private const val EMPTY_TITLE = "История просмотров пуста"
+private const val REDUNDANT_CONTENT_TITLE = "История"
+
+internal class HistoryScreenContentTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun finalItemDeletionFocusesRefreshAction() {
+        val historyItem = historyItem()
+        val rowKey = historyItem.rowKey
+        val state = mutableStateOf<HistoryViewState>(
+            HistoryViewState.Content(
+                items = listOf(historyItem),
+                focusKey = rowKey,
+            ),
+        )
+
+        composeRule.setContent {
+            PuberTheme {
+                CompositionLocalProvider(LocalAutoFocusOnLaunchEnabled provides false) {
+                    HistoryScreenContent(
+                        state = state.value,
+                        presentation = HistoryPresentation.TopTabs,
+                        onAction = {},
+                    )
+                }
+            }
+        }
+
+        composeRule
+            .historyCardNode()
+            .performSemanticsAction(SemanticsActions.RequestFocus)
+            .assertIsFocused()
+
+        composeRule.runOnIdle {
+            state.value = HistoryViewState.Empty
+        }
+
+        composeRule
+            .onNodeWithTag(HISTORY_REFRESH_TEST_TAG)
+            .assertIsFocused()
+    }
+
+    @Test
+    fun contextMenuShowsDisclosureAndOmitsBroaderDeletionActions() {
+        setHistoryContent(openMenuState())
+
+        composeRule.onNodeWithText(DISCLOSURE).assertExists()
+        composeRule.onNodeWithText(CONTINUE).assertExists()
+        composeRule.onNodeWithText(DETAILS).assertExists()
+        composeRule.onNodeWithText(DELETE_EXACT_MEDIA).assertExists()
+        composeRule.onNodeWithText(CLOSE).assertExists()
+        composeRule.onNodeWithText("Удалить фильм").assertDoesNotExist()
+        composeRule.onNodeWithText("Удалить сезон").assertDoesNotExist()
+        composeRule.onNodeWithText("Очистить историю").assertDoesNotExist()
+    }
+
+    @Test
+    fun contextMenuMapsSupportedActionsAndClose() {
+        val actions = mutableListOf<UIAction>()
+        setHistoryContent(openMenuState()) { actions += it }
+
+        composeRule.onNodeWithText(CONTINUE).performClick()
+        composeRule.onNodeWithText(DETAILS).performClick()
+        composeRule.onNodeWithText(DELETE_EXACT_MEDIA).performClick()
+        composeRule.onNodeWithText(CLOSE).performClick()
+
+        composeRule.runOnIdle {
+            assertTrue(
+                actions.filterIsInstance<HistoryAction.Play>().single().startMode ==
+                    PlayerStartMode.ResumeIfAvailable,
+            )
+            assertTrue(actions.any { it is HistoryAction.OpenDetails })
+            assertTrue(actions.any { it is HistoryAction.DeleteExactMedia })
+            assertTrue(actions.any { it is HistoryAction.DismissContextMenu })
+        }
+    }
+
+    @Test
+    fun fallbackDetailsContextMenuOmitsPlaybackActions() {
+        val fallback = historyItem(playbackTarget = HistoryPlaybackTarget.Details)
+        setHistoryContent(openMenuState(item = fallback))
+
+        composeRule.onNodeWithText(CONTINUE).assertDoesNotExist()
+        composeRule.onNodeWithText(START_OVER).assertDoesNotExist()
+        composeRule.onNodeWithText(DETAILS).assertExists()
+        composeRule.onNodeWithText(DELETE_EXACT_MEDIA).assertExists()
+    }
+
+    @Test
+    fun completedRowStartOverActionCarriesExplicitPlayerMode() {
+        val completed = historyItem(isWatched = true)
+        val actions = mutableListOf<UIAction>()
+        setHistoryContent(openMenuState(item = completed)) { actions += it }
+
+        composeRule.onNodeWithText(START_OVER).performClick()
+
+        composeRule.runOnIdle {
+            val play = actions.filterIsInstance<HistoryAction.Play>().single()
+            assertTrue(
+                play ==
+                    HistoryAction.Play(completed, PlayerStartMode.StartFromBeginning),
+            )
+            assertTrue(actions.any { it is HistoryAction.DismissContextMenu })
+        }
+    }
+
+    @Test
+    fun contextMenuDisablesDeleteWhileMutationIsPending() {
+        setHistoryContent(openMenuState(isDeletionPending = true))
+
+        composeRule
+            .onNodeWithText(DELETE_EXACT_MEDIA, useUnmergedTree = true)
+            .onParent()
+            .assertIsNotEnabled()
+    }
+
+    @Test
+    fun deletingCardRejectsSelectAndContextMenuInput() {
+        val item = historyItem()
+        val actions = mutableListOf<UIAction>()
+        setHistoryContent(
+            state = HistoryViewState.Content(
+                items = listOf(item),
+                deletingKeys = setOf(item.rowKey),
+                focusKey = item.rowKey,
+                isDeleteExactMediaAvailable = false,
+            ),
+            onAction = { actions += it },
+        )
+        val card = composeRule.historyCardNode()
+
+        card.performSemanticsAction(SemanticsActions.RequestFocus)
+        card.performClick()
+        card.performKeyInput {
+            keyDown(Key.Menu)
+            keyUp(Key.Menu)
+        }
+
+        composeRule.runOnIdle {
+            assertTrue(actions.none { it is CommonAction.ItemSelected<*> })
+            assertTrue(actions.none { it is HistoryAction.OpenContextMenu })
+        }
+    }
+
+    @Test
+    fun contextMenuKeepsDeleteVisiblyUnavailableDuringRefresh() {
+        setHistoryContent(openMenuState(isRefreshPending = true))
+
+        composeRule
+            .onNodeWithText(DELETE_EXACT_MEDIA, useUnmergedTree = true)
+            .onParent()
+            .assertIsNotEnabled()
+    }
+
+    @Test
+    fun contextMenuKeepsDeleteVisiblyUnavailableDuringPagination() {
+        setHistoryContent(openMenuState(isNextPagePending = true))
+
+        composeRule
+            .onNodeWithText(DELETE_EXACT_MEDIA, useUnmergedTree = true)
+            .onParent()
+            .assertIsNotEnabled()
+    }
+
+    @Test
+    fun completedHistoryItemShowsWatchedIndicatorWhenSharedCardPreferenceIsOff() {
+        val item = historyItem(
+            isWatched = true,
+            showWatchedIndicator = false,
+        )
+        setHistoryContent(
+            HistoryViewState.Content(
+                items = listOf(item),
+                focusKey = item.rowKey,
+            ),
+        )
+
+        composeRule
+            .onNodeWithTag(WATCHED_INDICATOR_TEST_TAG, useUnmergedTree = true)
+            .assertExists()
+    }
+
+    @Test
+    fun topTabsNonEmptyHistoryDoesNotRenderContentTitle() {
+        setHistoryContent(
+            state = HistoryViewState.Content(
+                items = listOf(historyItem()),
+                isRefreshing = true,
+                hasMorePages = true,
+            ),
+            presentation = HistoryPresentation.TopTabs,
+        )
+
+        composeRule.onNodeWithText(REDUNDANT_CONTENT_TITLE).assertDoesNotExist()
+    }
+
+    @Test
+    fun sideDrawerNonEmptyHistoryRetainsContentTitle() {
+        setHistoryContent(
+            state = HistoryViewState.Content(
+                items = listOf(historyItem()),
+                isRefreshing = true,
+                hasMorePages = true,
+            ),
+            presentation = HistoryPresentation.SideDrawer,
+        )
+
+        composeRule.onNodeWithText(REDUNDANT_CONTENT_TITLE).assertExists()
+    }
+
+    @Test
+    fun retainedTopTabsHistoryDoesNotReclaimFocusWhileTabRowOwnsFocus() {
+        val item = historyItem()
+        setHistoryContent(
+            state = HistoryViewState.Content(
+                items = listOf(item),
+                focusKey = item.rowKey,
+            ),
+            contentFocusActive = false,
+        )
+
+        composeRule.historyCardNode().assertIsNotFocused()
+    }
+
+    @Test
+    fun rightAtGridEdgeKeepsFocusOnHistoryCard() {
+        val items = listOf(
+            historyItem(itemId = 41),
+            historyItem(itemId = 42),
+            historyItem(itemId = 43),
+        )
+        assertRightKeepsFocusOnFinalCard(items)
+    }
+
+    @Test
+    fun rightAtOneCardTrailingRowKeepsFocusOnFinalHistoryCard() {
+        val items = (41..44).map { itemId -> historyItem(itemId = itemId) }
+
+        assertRightKeepsFocusOnFinalCard(items)
+    }
+
+    @Test
+    fun rightAtTwoCardTrailingRowKeepsFocusOnFinalHistoryCard() {
+        val items = (41..45).map { itemId -> historyItem(itemId = itemId) }
+
+        assertRightKeepsFocusOnFinalCard(items)
+    }
+
+    @Test
+    fun refreshIndicatorKeepsGridPositionStable() {
+        val item = historyItem()
+        val state = mutableStateOf<HistoryViewState>(
+            HistoryViewState.Content(
+                items = listOf(item),
+                isRefreshing = false,
+            ),
+        )
+        setHistoryContent(state = state, onAction = {})
+        val idleTop = composeRule.historyCardNode().fetchSemanticsNode().boundsInRoot.top
+
+        composeRule.runOnIdle {
+            state.value = (state.value as HistoryViewState.Content).copy(
+                isRefreshing = true,
+            )
+        }
+
+        composeRule.onNodeWithTag(HISTORY_REFRESH_INDICATOR_TEST_TAG).assertExists()
+        val refreshingTop = composeRule.historyCardNode().fetchSemanticsNode().boundsInRoot.top
+        assertEquals(idleTop, refreshingTop)
+
+        composeRule.runOnIdle {
+            state.value = (state.value as HistoryViewState.Content).copy(
+                isRefreshing = false,
+            )
+        }
+
+        composeRule.onNodeWithTag(HISTORY_REFRESH_INDICATOR_TEST_TAG).assertDoesNotExist()
+        assertEquals(
+            idleTop,
+            composeRule.historyCardNode().fetchSemanticsNode().boundsInRoot.top,
+        )
+    }
+
+    @Test
+    fun nextPageLoadingUsesThreeCardSkeletonRow() {
+        setHistoryContent(
+            HistoryViewState.Content(
+                items = listOf(historyItem()),
+                isLoadingMore = true,
+                hasMorePages = true,
+            ),
+        )
+
+        composeRule.onNodeWithTag(HISTORY_NEXT_PAGE_SKELETON_TEST_TAG).assertExists()
+        repeat(3) { index ->
+            composeRule
+                .onNodeWithTag(HISTORY_NEXT_PAGE_SKELETON_CARD_TEST_TAG_PREFIX + index)
+                .assertExists()
+        }
+    }
+
+    @Test
+    fun exhaustedPaginationExposesFinalPageMarker() {
+        setHistoryContent(
+            HistoryViewState.Content(
+                items = listOf(historyItem()),
+                hasMorePages = false,
+                isLoadingMore = false,
+                nextPageErrorMessage = null,
+            ),
+        )
+
+        composeRule.onNodeWithTag(HISTORY_FINAL_PAGE_TEST_TAG).assertExists()
+    }
+
+    @Test
+    fun finalPageMarkerIsAbsentWhileMorePagesMayExist() {
+        setHistoryContent(
+            HistoryViewState.Content(
+                items = listOf(historyItem()),
+                hasMorePages = true,
+            ),
+        )
+
+        composeRule.onNodeWithTag(HISTORY_FINAL_PAGE_TEST_TAG).assertDoesNotExist()
+    }
+
+    @Test
+    fun finalPageMarkerIsAbsentWhilePaginationIsLoading() {
+        setHistoryContent(
+            HistoryViewState.Content(
+                items = listOf(historyItem()),
+                hasMorePages = false,
+                isLoadingMore = true,
+            ),
+        )
+
+        composeRule.onNodeWithTag(HISTORY_FINAL_PAGE_TEST_TAG).assertDoesNotExist()
+    }
+
+    @Test
+    fun finalPageMarkerIsAbsentWhileHistoryIsRefreshing() {
+        setHistoryContent(
+            HistoryViewState.Content(
+                items = listOf(historyItem()),
+                hasMorePages = false,
+                isRefreshing = true,
+            ),
+        )
+
+        composeRule.onNodeWithTag(HISTORY_FINAL_PAGE_TEST_TAG).assertDoesNotExist()
+    }
+
+    @Test
+    fun finalPageMarkerIsAbsentOnPaginationError() {
+        setHistoryContent(
+            HistoryViewState.Content(
+                items = listOf(historyItem()),
+                hasMorePages = false,
+                nextPageErrorMessage = "Synthetic page failure",
+            ),
+        )
+
+        composeRule.onNodeWithTag(HISTORY_FINAL_PAGE_TEST_TAG).assertDoesNotExist()
+    }
+
+    @Test
+    fun finalPageMarkerIsAbsentAfterRetainedContentReconciliationFailure() {
+        setHistoryContent(
+            HistoryViewState.Content(
+                items = listOf(historyItem()),
+                hasMorePages = false,
+                reloadErrorMessage = "Synthetic reconciliation failure",
+            ),
+        )
+
+        composeRule.onNodeWithTag(HISTORY_FINAL_PAGE_TEST_TAG).assertDoesNotExist()
+    }
+
+    @Test
+    fun historyCardTestTagIsExportedAsAnAccessibilityResourceId() {
+        setHistoryContent(
+            HistoryViewState.Content(
+                items = listOf(historyItem()),
+                hasMorePages = true,
+            ),
+        )
+
+        val resourceIdExport = SemanticsMatcher.expectValue(
+            SemanticsPropertiesAndroid.TestTagsAsResourceId,
+            true,
+        )
+        composeRule
+            .historyCardNode()
+            .assert(hasAnyAncestor(resourceIdExport))
+    }
+
+    @Test
+    fun exportedHistoryCardTagsDoNotContainRawMediaIdentifiers() {
+        val movie = historyItem(
+            itemId = 123456789,
+            deletionMediaId = 234567891,
+            playbackTarget = HistoryPlaybackTarget.Movie(videoNumber = 345678912),
+        )
+        val episode = historyItem(
+            itemId = 456789123,
+            deletionMediaId = 567891234,
+            playbackTarget = HistoryPlaybackTarget.Episode(
+                seasonNumber = 678912345,
+                episodeNumber = 789123456,
+            ),
+        )
+        val deletionOnly = historyItem(
+            itemId = 891234567,
+            deletionMediaId = 912345678,
+            playbackTarget = HistoryPlaybackTarget.Details,
+        )
+        setHistoryContent(
+            HistoryViewState.Content(
+                items = listOf(movie, episode, deletionOnly),
+                hasMorePages = true,
+            ),
+        )
+
+        val tags = composeRule
+            .onAllNodes(historyCardTagMatcher, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .map { node -> node.config[SemanticsProperties.TestTag] }
+        val rawIdentifiers = listOf(
+            movie.itemId,
+            movie.deletionMediaId,
+            movie.videoNumber,
+            episode.itemId,
+            episode.deletionMediaId,
+            episode.seasonNumber,
+            episode.episodeNumber,
+            deletionOnly.itemId,
+            deletionOnly.deletionMediaId,
+        ).filterNotNull()
+
+        assertEquals(3, tags.toSet().size)
+        tags.forEach { tag ->
+            assertTrue(tag.matches(Regex("""history_card_[a-p]{32}""")))
+            assertFalse(rawIdentifiers.any { identifier -> identifier.toString() in tag })
+        }
+    }
+
+    @Test
+    fun exportedHistoryCardTagRemainsStableAcrossRetainedStateUpdates() {
+        val item = historyItem()
+        val state = mutableStateOf<HistoryViewState>(
+            HistoryViewState.Content(
+                items = listOf(item),
+                hasMorePages = true,
+            ),
+        )
+        setHistoryContent(state = state, onAction = {})
+        val initialTag = composeRule.historyCardTestTag()
+
+        composeRule.runOnIdle {
+            state.value = (state.value as HistoryViewState.Content).copy(
+                isLoadingMore = true,
+            )
+        }
+
+        assertEquals(initialTag, composeRule.historyCardTestTag())
+    }
+
+    @Test
+    fun emptyRetainedContentDuringReconciliationDoesNotPublishEmptyCopy() {
+        setHistoryContent(
+            HistoryViewState.Content(
+                items = emptyList(),
+                isRefreshing = true,
+                isDeleteExactMediaAvailable = false,
+            ),
+        )
+
+        composeRule.onNodeWithText(EMPTY_TITLE).assertDoesNotExist()
+    }
+
+    @Test
+    fun emptyRetainedContentAfterReconciliationFailureShowsRetryableError() {
+        val actions = mutableListOf<UIAction>()
+        setHistoryContent(
+            state = HistoryViewState.Content(
+                items = emptyList(),
+                reloadErrorMessage = "Synthetic reconciliation failure",
+                isDeleteExactMediaAvailable = false,
+            ),
+            onAction = { actions += it },
+        )
+
+        composeRule.onNodeWithText(EMPTY_TITLE).assertDoesNotExist()
+        composeRule.onNodeWithText("Synthetic reconciliation failure").assertExists()
+        composeRule.onNodeWithText("Повторить").performClick()
+        composeRule.runOnIdle {
+            assertTrue(actions.single() == HistoryAction.RetryReconciliation)
+        }
+    }
+
+    @Test
+    fun duplicateOnlyPageCompletionRequestsContinuationWithoutLosingCardFocus() {
+        val item = historyItem()
+        val state = mutableStateOf<HistoryViewState>(
+            HistoryViewState.Content(
+                items = listOf(item),
+                focusKey = item.rowKey,
+                hasMorePages = true,
+                isLoadingMore = true,
+            ),
+        )
+        val actions = mutableListOf<UIAction>()
+        setHistoryContent(state = state, onAction = { actions += it })
+        composeRule
+            .historyCardNode()
+            .performSemanticsAction(SemanticsActions.RequestFocus)
+            .assertIsFocused()
+        composeRule.runOnIdle {
+            state.value = (state.value as HistoryViewState.Content).copy(
+                isLoadingMore = false,
+                pageAttemptRevision = 1L,
+            )
+        }
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            actions.count { it == CommonAction.LoadMore } == 1
+        }
+
+        composeRule.runOnIdle {
+            state.value = (state.value as HistoryViewState.Content).copy(
+                isLoadingMore = true,
+            )
+        }
+        composeRule.runOnIdle {
+            state.value = (state.value as HistoryViewState.Content).copy(
+                isLoadingMore = false,
+                pageAttemptRevision = 2L,
+            )
+        }
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            actions.count { it == CommonAction.LoadMore } == 2
+        }
+        composeRule
+            .historyCardNode()
+            .assertIsFocused()
+    }
+
+    @Test
+    fun nextPageFailureWaitsForExplicitRetryAndKeepsCardFocus() {
+        val item = historyItem()
+        val state = mutableStateOf<HistoryViewState>(
+            HistoryViewState.Content(
+                items = listOf(item),
+                focusKey = item.rowKey,
+                hasMorePages = true,
+                isLoadingMore = true,
+            ),
+        )
+        val actions = mutableListOf<UIAction>()
+        setHistoryContent(state = state, onAction = { actions += it })
+        composeRule
+            .historyCardNode()
+            .performSemanticsAction(SemanticsActions.RequestFocus)
+            .assertIsFocused()
+
+        composeRule.runOnIdle {
+            state.value = (state.value as HistoryViewState.Content).copy(
+                isLoadingMore = false,
+                pageAttemptRevision = 1L,
+                nextPageErrorMessage = "Synthetic page failure",
+            )
+        }
+
+        composeRule.waitForIdle()
+        composeRule.runOnIdle {
+            assertTrue(actions.none { it == CommonAction.LoadMore })
+        }
+        composeRule
+            .historyCardNode()
+            .assertIsFocused()
+        composeRule.onNodeWithText("Повторить").performClick()
+        composeRule.runOnIdle {
+            assertTrue(actions.count { it == CommonAction.ReloadNextPage } == 1)
+            assertTrue(actions.none { it == CommonAction.LoadMore })
+        }
+    }
+
+    private fun setHistoryContent(
+        state: HistoryViewState,
+        presentation: HistoryPresentation = HistoryPresentation.TopTabs,
+        contentFocusActive: Boolean = true,
+        onAction: (UIAction) -> Unit = {},
+    ) {
+        composeRule.setContent {
+            PuberTheme {
+                CompositionLocalProvider(
+                    LocalAutoFocusOnLaunchEnabled provides false,
+                    LocalContentFocusActive provides contentFocusActive,
+                ) {
+                    HistoryScreenContent(
+                        state = state,
+                        presentation = presentation,
+                        onAction = onAction,
+                    )
+                }
+            }
+        }
+    }
+
+    private fun setHistoryContent(
+        state: MutableState<HistoryViewState>,
+        presentation: HistoryPresentation = HistoryPresentation.TopTabs,
+        contentFocusActive: Boolean = true,
+        onAction: (UIAction) -> Unit,
+    ) {
+        composeRule.setContent {
+            PuberTheme {
+                CompositionLocalProvider(
+                    LocalAutoFocusOnLaunchEnabled provides false,
+                    LocalContentFocusActive provides contentFocusActive,
+                ) {
+                    HistoryScreenContent(
+                        state = state.value,
+                        presentation = presentation,
+                        onAction = onAction,
+                    )
+                }
+            }
+        }
+    }
+
+    private fun assertRightKeepsFocusOnFinalCard(items: List<HistoryItemUIState>) {
+        setHistoryContent(HistoryViewState.Content(items = items))
+        val finalCard = composeRule.historyCardNode(index = items.lastIndex)
+
+        finalCard
+            .performSemanticsAction(SemanticsActions.RequestFocus)
+            .assertIsFocused()
+            .performKeyInput {
+                keyDown(Key.DirectionRight)
+                keyUp(Key.DirectionRight)
+            }
+            .assertIsFocused()
+    }
+
+    private fun openMenuState(
+        item: HistoryItemUIState = historyItem(),
+        isDeletionPending: Boolean = false,
+        isRefreshPending: Boolean = false,
+        isNextPagePending: Boolean = false,
+    ): HistoryViewState.Content {
+        return HistoryViewState.Content(
+            items = listOf(item),
+            isRefreshing = isRefreshPending,
+            isLoadingMore = isNextPagePending,
+            isDeleteExactMediaAvailable =
+                !isDeletionPending && !isRefreshPending && !isNextPagePending,
+            openMenuKey = item.rowKey,
+            deletingKeys = if (isDeletionPending) setOf(item.rowKey) else emptySet(),
+            focusKey = item.rowKey,
+        )
+    }
+
+    private fun historyItem(
+        itemId: Int = 42,
+        deletionMediaId: Int = 700,
+        isWatched: Boolean = false,
+        showWatchedIndicator: Boolean = true,
+        playbackTarget: HistoryPlaybackTarget = HistoryPlaybackTarget.Movie(videoNumber = 1),
+    ): HistoryItemUIState {
+        val semanticKey = when (playbackTarget) {
+            is HistoryPlaybackTarget.Movie -> HistorySemanticKey.Movie(
+                itemId = itemId,
+                videoNumber = playbackTarget.videoNumber,
+            )
+            is HistoryPlaybackTarget.Episode -> HistorySemanticKey.Episode(
+                itemId = itemId,
+                seasonNumber = playbackTarget.seasonNumber,
+                episodeNumber = playbackTarget.episodeNumber,
+            )
+            HistoryPlaybackTarget.Details -> null
+        }
+        val rowKey = semanticKey?.let(HistoryRowKey::Media)
+            ?: HistoryRowKey.DeletionMedia(deletionMediaId)
+        return HistoryItemUIState(
+            itemId = itemId,
+            deletionMediaId = deletionMediaId,
+            rowKey = rowKey,
+            semanticKey = semanticKey,
+            videoNumber = (semanticKey as? HistorySemanticKey.Movie)?.videoNumber,
+            seasonNumber = (semanticKey as? HistorySemanticKey.Episode)?.seasonNumber,
+            episodeNumber = (semanticKey as? HistorySemanticKey.Episode)?.episodeNumber,
+            progressPercent = 0.5f,
+            isWatched = isWatched,
+            lastViewedAt = "2099-07-23T12:00:00Z",
+            playbackTarget = playbackTarget,
+            card = VideoItemUIState(
+                id = itemId,
+                title = "Synthetic history movie",
+                imageUrl = "",
+                bigImageUrl = "",
+                wideImageUrl = "",
+                showTitle = true,
+                progressPercent = 0.5f,
+                isWatched = isWatched,
+                showWatchedIndicator = showWatchedIndicator,
+            ),
+        )
+    }
+
+    private fun androidx.compose.ui.test.junit4.ComposeTestRule.historyCardNode(
+        index: Int = 0,
+    ):
+        SemanticsNodeInteraction {
+        return onAllNodes(historyCardTagMatcher, useUnmergedTree = true)[index]
+    }
+
+    private fun androidx.compose.ui.test.junit4.ComposeTestRule.historyCardTestTag(): String {
+        return historyCardNode()
+            .fetchSemanticsNode()
+            .config[SemanticsProperties.TestTag]
+    }
+
+    private companion object {
+        val historyCardTagMatcher = SemanticsMatcher("has opaque History card test tag") { node ->
+            node.config
+                .getOrNull(SemanticsProperties.TestTag)
+                ?.startsWith(HISTORY_CARD_TEST_TAG_PREFIX) == true
+        }
+    }
+}

--- a/app/src/androidTest/kotlin/com/kino/puber/ui/feature/main/toptabs/TopTabMainContentHistoryFocusTest.kt
+++ b/app/src/androidTest/kotlin/com/kino/puber/ui/feature/main/toptabs/TopTabMainContentHistoryFocusTest.kt
@@ -1,0 +1,312 @@
+package com.kino.puber.ui.feature.main.toptabs
+
+import android.app.Activity
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotFocused
+import androidx.compose.ui.test.hasAnyDescendant
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isFocused
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.performKeyInput
+import com.adamglin.PhosphorIcons
+import com.adamglin.phosphoricons.Duotone
+import com.adamglin.phosphoricons.duotone.ClockCounterClockwise
+import com.adamglin.phosphoricons.duotone.FilmSlate
+import com.adamglin.phosphoricons.duotone.House
+import com.kino.puber.core.ui.navigation.AppLauncher
+import com.kino.puber.core.ui.navigation.PuberScreen
+import com.kino.puber.core.ui.navigation.PuberTab
+import com.kino.puber.core.ui.navigation.Screens
+import com.kino.puber.core.ui.navigation.TabRouter
+import com.kino.puber.core.ui.navigation.component.FlowComponent
+import com.kino.puber.core.ui.navigation.component.TabAppRouterHolder
+import com.kino.puber.core.ui.uikit.component.moviesList.VideoItemUIState
+import com.kino.puber.core.ui.uikit.model.UIAction
+import com.kino.puber.core.ui.uikit.theme.PuberTheme
+import com.kino.puber.domain.interactor.history.HistoryRowKey
+import com.kino.puber.domain.interactor.history.HistorySemanticKey
+import com.kino.puber.ui.ScreensImpl
+import com.kino.puber.ui.feature.history.component.HISTORY_CARD_TEST_TAG_PREFIX
+import com.kino.puber.ui.feature.history.component.HistoryScreenContent
+import com.kino.puber.ui.feature.history.model.HistoryItemUIState
+import com.kino.puber.ui.feature.history.model.HistoryPlaybackTarget
+import com.kino.puber.ui.feature.history.model.HistoryPresentation
+import com.kino.puber.ui.feature.history.model.HistoryViewState
+import com.kino.puber.ui.feature.main.model.MainTab
+import com.kino.puber.ui.feature.main.model.MainViewState
+import com.kino.puber.ui.feature.main.model.TabType
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.parcelize.Parcelize
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.koin.core.qualifier.named
+import org.koin.dsl.module
+
+private const val HOME_TAB = "Главная"
+private const val MOVIES_TAB = "Фильмы"
+private const val HISTORY_TAB = "История"
+private const val SETTINGS = "Settings"
+
+internal class TopTabMainContentHistoryFocusTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private lateinit var coroutineScope: CoroutineScope
+    private lateinit var tabRouter: TabRouter
+    private lateinit var tabAppRouterHolder: TabAppRouterHolder
+
+    @Before
+    fun setUp() {
+        coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        tabRouter = TabRouter(coroutineScope)
+        tabAppRouterHolder = TabAppRouterHolder(ScreensImpl)
+        TopTabHistoryProbeHost.bind(tabRouter, tabAppRouterHolder)
+    }
+
+    @After
+    fun tearDown() {
+        composeRule.runOnIdle { tabAppRouterHolder.dispose() }
+        TopTabHistoryProbeHost.clear()
+        coroutineScope.cancel()
+    }
+
+    @Test
+    fun retainedHistoryFocusStaysWithinTheActiveTopTabsRegion() {
+        composeRule.setContent {
+            PuberTheme {
+                FlowComponent(
+                    scopeName = "TopTabMainContentHistoryFocusTest",
+                    screen = TopTabHistoryProbeHostScreen,
+                    moduleFactory = { scopeId, _ ->
+                        module {
+                            scope(named(scopeId)) {
+                                scoped<AppLauncher> { NoOpAppLauncher }
+                                scoped<Screens> { ScreensImpl }
+                            }
+                        }
+                    },
+                )
+            }
+        }
+        composeRule.runOnIdle {
+            tabRouter.openTab(
+                PuberTab(
+                    screen = RetainedHistoryProbeScreen,
+                    tag = TabType.History,
+                ),
+            )
+        }
+
+        val historyCard = composeRule.onNode(historyCardMatcher, useUnmergedTree = true)
+        historyCard.assertExists()
+        composeRule.waitUntil {
+            historyCard.fetchSemanticsNode().config
+                .getOrNull(SemanticsProperties.Focused) == false
+        }
+        composeRule.waitForFocusedControlWithText(HISTORY_TAB)
+        composeRule
+            .focusedControlWithText(HISTORY_TAB)
+            .assertIsFocused()
+            .performDirection(Key.DirectionLeft)
+        composeRule.focusedControlWithText(MOVIES_TAB).assertIsFocused()
+        historyCard.assertIsNotFocused()
+
+        composeRule
+            .focusedControlWithText(MOVIES_TAB)
+            .performDirection(Key.DirectionRight)
+        composeRule.focusedControlWithText(HISTORY_TAB).assertIsFocused()
+        historyCard.assertIsNotFocused()
+
+        composeRule
+            .focusedControlWithText(HISTORY_TAB)
+            .performDirection(Key.DirectionRight)
+        composeRule.focusedSettingsControl().assertIsFocused()
+        historyCard.assertIsNotFocused()
+
+        composeRule
+            .focusedSettingsControl()
+            .performDirection(Key.DirectionLeft)
+        composeRule
+            .focusedControlWithText(HISTORY_TAB)
+            .assertIsFocused()
+            .performDirection(Key.DirectionDown)
+        composeRule.waitUntil {
+            historyCard.fetchSemanticsNode().config
+                .getOrNull(SemanticsProperties.Focused) == true
+        }
+        historyCard.assertIsFocused()
+    }
+
+    private fun androidx.compose.ui.test.junit4.ComposeTestRule.focusedControlWithText(
+        text: String,
+    ) = onNode(
+        matcher = isFocused() and hasAnyDescendant(hasText(text)),
+        useUnmergedTree = true,
+    )
+
+    private fun androidx.compose.ui.test.junit4.ComposeTestRule.waitForFocusedControlWithText(
+        text: String,
+    ) {
+        waitUntil {
+            onAllNodes(
+                matcher = isFocused() and hasAnyDescendant(hasText(text)),
+                useUnmergedTree = true,
+            )
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+    }
+
+    private fun androidx.compose.ui.test.junit4.ComposeTestRule.focusedSettingsControl() = onNode(
+        matcher = isFocused() and hasAnyDescendant(hasContentDescription(SETTINGS)),
+        useUnmergedTree = true,
+    )
+
+    private fun androidx.compose.ui.test.SemanticsNodeInteraction.performDirection(
+        key: Key,
+    ) = performKeyInput {
+        keyDown(key)
+        keyUp(key)
+    }
+
+    private companion object {
+        val historyCardMatcher = SemanticsMatcher("has opaque History card test tag") { node ->
+            node.config
+                .getOrNull(SemanticsProperties.TestTag)
+                ?.startsWith(HISTORY_CARD_TEST_TAG_PREFIX) == true
+        }
+    }
+}
+
+private object TopTabHistoryProbeHost {
+    var tabRouter: TabRouter? = null
+    var tabAppRouterHolder: TabAppRouterHolder? = null
+
+    fun bind(
+        tabRouter: TabRouter,
+        tabAppRouterHolder: TabAppRouterHolder,
+    ) {
+        this.tabRouter = tabRouter
+        this.tabAppRouterHolder = tabAppRouterHolder
+    }
+
+    fun clear() {
+        tabRouter = null
+        tabAppRouterHolder = null
+    }
+}
+
+@Parcelize
+private data object TopTabHistoryProbeHostScreen : PuberScreen {
+    @Composable
+    override fun Content() {
+        TopTabMainContent(
+            state = historyMainState(),
+            onAction = {},
+            tabRouter = requireNotNull(TopTabHistoryProbeHost.tabRouter),
+            tabAppRouterHolder = requireNotNull(TopTabHistoryProbeHost.tabAppRouterHolder),
+            onSearchClick = {},
+            onSettingsClick = {},
+        )
+    }
+}
+
+@Parcelize
+private data object RetainedHistoryProbeScreen : PuberScreen {
+    @Composable
+    override fun Content() {
+        val item = historyItem()
+        HistoryScreenContent(
+            state = HistoryViewState.Content(
+                items = listOf(item),
+                focusKey = item.rowKey,
+            ),
+            presentation = HistoryPresentation.TopTabs,
+            onAction = noOpAction,
+        )
+    }
+}
+
+private data object NoOpAppLauncher : AppLauncher {
+    override fun restart() = Unit
+
+    override fun finish() = Unit
+
+    override fun bind(activity: Activity) = Unit
+
+    override fun unbind() = Unit
+}
+
+private val noOpAction: (UIAction) -> Unit = {}
+
+private fun historyMainState(): MainViewState {
+    return MainViewState(
+        tabs = listOf(
+            mainTab(TabType.Home, HOME_TAB, PhosphorIcons.Duotone.House),
+            mainTab(TabType.Movies, MOVIES_TAB, PhosphorIcons.Duotone.FilmSlate),
+            mainTab(
+                type = TabType.History,
+                label = HISTORY_TAB,
+                icon = PhosphorIcons.Duotone.ClockCounterClockwise,
+                isSelected = true,
+            ),
+        ),
+        selectedTab = TabType.History,
+    )
+}
+
+private fun mainTab(
+    type: TabType,
+    label: String,
+    icon: ImageVector,
+    isSelected: Boolean = false,
+): MainTab {
+    return MainTab(
+        type = type,
+        label = label,
+        icon = icon,
+        isSelected = isSelected,
+    )
+}
+
+private fun historyItem(): HistoryItemUIState {
+    val semanticKey = HistorySemanticKey.Movie(
+        itemId = 42,
+        videoNumber = 1,
+    )
+    return HistoryItemUIState(
+        itemId = semanticKey.itemId,
+        deletionMediaId = 700,
+        rowKey = HistoryRowKey.Media(semanticKey),
+        semanticKey = semanticKey,
+        videoNumber = semanticKey.videoNumber,
+        seasonNumber = null,
+        episodeNumber = null,
+        progressPercent = 0.5f,
+        isWatched = false,
+        lastViewedAt = "2099-07-23T12:00:00Z",
+        playbackTarget = HistoryPlaybackTarget.Movie(videoNumber = semanticKey.videoNumber),
+        card = VideoItemUIState(
+            id = semanticKey.itemId,
+            title = "Synthetic retained History movie",
+            imageUrl = "",
+            bigImageUrl = "",
+            wideImageUrl = "",
+            showTitle = true,
+            progressPercent = 0.5f,
+        ),
+    )
+}

--- a/app/src/main/java/com/kino/puber/core/di/ScopeModuleManager.kt
+++ b/app/src/main/java/com/kino/puber/core/di/ScopeModuleManager.kt
@@ -3,7 +3,6 @@ package com.kino.puber.core.di
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.RememberObserver
 import androidx.compose.runtime.remember
-import com.kino.puber.core.logger.log
 import org.koin.compose.getKoin
 import org.koin.core.Koin
 import org.koin.core.annotation.KoinInternalApi
@@ -24,47 +23,35 @@ internal class ScopeModuleManager(
     private var module: Module? = null
 
     fun initialize() {
-        log("initialize scope='$scopeName'", tag = TAG)
         scope = koin.createScope(scopeName, named(scopeName)).apply {
             linkTo(parentScope)
         }
         module = moduleFactory(scope!!.id, parentScope).also {
-            log("loadModules scope='$scopeName' isLoaded=${it.isLoaded}", tag = TAG)
             koin.loadModules(listOf(it))
         }
     }
 
-    override fun onRemembered() {
-        log("onRemembered scope='$scopeName'", tag = TAG)
-    }
+    override fun onRemembered() = Unit
 
     override fun onAbandoned() {
-        log("onAbandoned scope='$scopeName'", tag = TAG)
         clearScope()
     }
 
     override fun onForgotten() {
-        log("onForgotten scope='$scopeName'", tag = TAG)
         clearScope()
     }
 
     private fun clearScope() {
-        log("clearScope scope='$scopeName' closed=${scope?.closed}", tag = TAG)
         scope?.close()
         scope = null
 
         module?.let {
-            log("unloadModules scope='$scopeName'", tag = TAG)
             koin.unloadModules(listOf(it))
         }
         module = null
     }
 
     fun getScope(): Scope? = scope
-
-    companion object {
-        private const val TAG = "ScopeModuleManager"
-    }
 }
 
 @OptIn(KoinInternalApi::class)

--- a/app/src/main/java/com/kino/puber/core/error/DefaultErrorHandler.kt
+++ b/app/src/main/java/com/kino/puber/core/error/DefaultErrorHandler.kt
@@ -1,6 +1,11 @@
 package com.kino.puber.core.error
 
-internal class DefaultErrorHandler() : ErrorHandler {
+import com.kino.puber.R
+import com.kino.puber.core.system.ResourceProvider
+
+internal class DefaultErrorHandler(
+    private val resources: ResourceProvider,
+) : ErrorHandler {
     override fun proceed(action: ((ErrorEntity) -> Unit)?): (Throwable) -> Unit {
         return { e -> proceedInvoke(e, action) }
     }
@@ -13,8 +18,8 @@ internal class DefaultErrorHandler() : ErrorHandler {
 
     override fun map(e: Throwable): ErrorEntity {
         return ErrorEntity(
-            message = e.message.orEmpty(), code = "Unknown"
+            message = resources.getString(R.string.error_generic),
+            code = "Unknown",
         )
     }
-
 }

--- a/app/src/main/java/com/kino/puber/core/logger/Logger.kt
+++ b/app/src/main/java/com/kino/puber/core/logger/Logger.kt
@@ -2,9 +2,10 @@ package com.kino.puber.core.logger
 
 import timber.log.Timber
 
+private val sensitiveLogPolicy = SensitiveRequestLogPolicy()
 
 fun Any.log(message: String, tag: String = this.getTag()) {
-    Timber.tag("Puber: $tag").d(message)
+    Timber.tag("Puber: $tag").d(sensitiveLogPolicy.sanitizeText(message))
 }
 
 fun Any.log(
@@ -12,7 +13,10 @@ fun Any.log(
     message: String = "Something went wrong",
     tag: String = this.getTag()
 ) {
-    Timber.tag("Puber: $tag").w(throwable, message)
+    Timber.tag("Puber: $tag").w(
+        sensitiveLogPolicy.sanitizeThrowable(throwable),
+        sensitiveLogPolicy.sanitizeText(message),
+    )
 }
 
 private fun Any.getTag(): String {

--- a/app/src/main/java/com/kino/puber/core/logger/SensitiveRequestLogPolicy.kt
+++ b/app/src/main/java/com/kino/puber/core/logger/SensitiveRequestLogPolicy.kt
@@ -1,0 +1,272 @@
+package com.kino.puber.core.logger
+
+import java.net.URI
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
+internal const val REDACTED_LOG_VALUE = "<redacted>"
+internal const val REDACTED_LOG_BODY = "<redacted sensitive body>"
+
+internal enum class SensitiveRequestKind(
+    val redactAllQueryValues: Boolean,
+    val redactEntireBody: Boolean,
+) {
+    Standard(
+        redactAllQueryValues = false,
+        redactEntireBody = false,
+    ),
+    History(
+        redactAllQueryValues = true,
+        redactEntireBody = true,
+    ),
+    ItemDetails(
+        redactAllQueryValues = true,
+        redactEntireBody = true,
+    ),
+    PlaybackProgress(
+        redactAllQueryValues = true,
+        redactEntireBody = true,
+    ),
+    Authentication(
+        redactAllQueryValues = true,
+        redactEntireBody = true,
+    ),
+    AccountOrDevice(
+        redactAllQueryValues = true,
+        redactEntireBody = true,
+    ),
+}
+
+internal class SensitiveRequestLogPolicy {
+
+    fun classify(url: String): SensitiveRequestKind {
+        val path = extractPath(url).trimEnd('/').lowercase()
+        val segments = path.split('/').filter(String::isNotBlank)
+        return when {
+            "history" in segments -> SensitiveRequestKind.History
+            segments.isItemDetailsPath() -> SensitiveRequestKind.ItemDetails
+            "watching" in segments -> SensitiveRequestKind.PlaybackProgress
+            "oauth2" in segments -> SensitiveRequestKind.Authentication
+            "user" in segments ||
+                "device" in segments ||
+                "devices" in segments -> SensitiveRequestKind.AccountOrDevice
+            else -> SensitiveRequestKind.Standard
+        }
+    }
+
+    fun sanitizeUrl(url: String): String {
+        val credentialSafeUrl = USER_INFO_REGEX.replace(url) { match ->
+            "${match.groupValues[1]}$REDACTED_LOG_VALUE@"
+        }
+        val fragmentStart = credentialSafeUrl.indexOf('#')
+        val urlWithoutFragment = if (fragmentStart >= 0) {
+            credentialSafeUrl.substring(0, fragmentStart)
+        } else {
+            credentialSafeUrl
+        }
+        val fragment = fragmentStart
+            .takeIf { it >= 0 }
+            ?.let { credentialSafeUrl.substring(it + 1) }
+        val queryStart = urlWithoutFragment.indexOf('?')
+        val kind = classify(credentialSafeUrl)
+        val sanitizedBase = if (queryStart >= 0) {
+            val query = urlWithoutFragment.substring(queryStart + 1)
+            buildString {
+                append(urlWithoutFragment.substring(0, queryStart + 1))
+                append(sanitizeParameterSection(query, kind.redactAllQueryValues))
+            }
+        } else {
+            urlWithoutFragment
+        }
+        val sanitizedUrl = if (fragment != null) {
+            "$sanitizedBase#${sanitizeParameterSection(fragment, kind.redactAllQueryValues)}"
+        } else {
+            sanitizedBase
+        }
+        return redactCredentialFields(sanitizePathIdentity(sanitizedUrl, kind))
+    }
+
+    fun sanitizeHeader(name: String, value: String): String {
+        return when (name.lowercase()) {
+            in SENSITIVE_HEADER_NAMES -> REDACTED_LOG_VALUE
+            in DIRECT_URL_HEADER_NAMES -> sanitizeUrl(value)
+            "link" -> sanitizeLinkHeader(value)
+            else -> redactCredentialFields(value)
+        }
+    }
+
+    fun sanitizeRequestBody(url: String, body: String): String {
+        return sanitizeBody(url, body)
+    }
+
+    fun sanitizeResponseBody(url: String, body: String): String {
+        return sanitizeBody(url, body)
+    }
+
+    fun sanitizeText(value: String): String {
+        val sanitizedUrls = URL_REGEX.replace(value) { match ->
+            sanitizeUrl(match.value)
+        }
+        val sanitizedPaths = ITEM_DETAILS_TEXT_ID_REGEX.replace(sanitizedUrls) { match ->
+            match.groupValues[1] + REDACTED_LOG_VALUE
+        }
+        return redactCredentialFields(sanitizedPaths)
+    }
+
+    fun sanitizeThrowable(throwable: Throwable): Throwable {
+        return SanitizedLogThrowable(
+            sourceType = throwable::class.qualifiedName ?: throwable.javaClass.name,
+            sourceMessage = throwable.message?.let(::sanitizeText),
+            sourceStackTrace = throwable.stackTrace,
+            sourceCause = throwable.cause?.let(::sanitizeThrowable),
+            sourceSuppressed = throwable.suppressed.map(::sanitizeThrowable),
+        )
+    }
+
+    private fun sanitizeBody(url: String, body: String): String {
+        return if (classify(url).redactEntireBody) {
+            REDACTED_LOG_BODY
+        } else {
+            redactCredentialFields(body)
+        }
+    }
+
+    private fun sanitizeQueryParameter(
+        parameter: String,
+        redactAllValues: Boolean,
+    ): String {
+        if (parameter.isEmpty()) return parameter
+        val separatorIndex = parameter.indexOf('=')
+        val rawName = if (separatorIndex >= 0) {
+            parameter.substring(0, separatorIndex)
+        } else {
+            parameter
+        }
+        val decodedName = runCatching {
+            URLDecoder.decode(rawName, StandardCharsets.UTF_8.name())
+        }.getOrDefault(rawName)
+        val shouldRedact = redactAllValues || decodedName.lowercase() in SENSITIVE_PARAMETER_NAMES
+        return if (shouldRedact) {
+            "$rawName=$REDACTED_LOG_VALUE"
+        } else {
+            parameter
+        }
+    }
+
+    private fun sanitizeParameterSection(
+        section: String,
+        redactAllValues: Boolean,
+    ): String {
+        return section
+            .split('&')
+            .joinToString("&") { parameter ->
+                sanitizeQueryParameter(
+                    parameter = parameter,
+                    redactAllValues = redactAllValues,
+                )
+            }
+    }
+
+    private fun sanitizeLinkHeader(value: String): String {
+        val sanitizedTargets = LINK_TARGET_REGEX.replace(value) { match ->
+            "<${sanitizeUrl(match.groupValues[1])}>"
+        }
+        return redactCredentialFields(sanitizedTargets)
+    }
+
+    private fun sanitizePathIdentity(
+        url: String,
+        kind: SensitiveRequestKind,
+    ): String {
+        return if (kind == SensitiveRequestKind.ItemDetails) {
+            ITEM_DETAILS_ID_REGEX.replace(url) { match ->
+                match.groupValues[1] + REDACTED_LOG_VALUE
+            }
+        } else {
+            url
+        }
+    }
+
+    private fun redactCredentialFields(value: String): String {
+        val jsonRedacted = JSON_CREDENTIAL_REGEX.replace(value) { match ->
+            match.groupValues[1] + REDACTED_LOG_VALUE + match.groupValues[3]
+        }
+        val formRedacted = FORM_CREDENTIAL_REGEX.replace(jsonRedacted) { match ->
+            match.groupValues[1] + REDACTED_LOG_VALUE
+        }
+        return BEARER_TOKEN_REGEX.replace(formRedacted) {
+            "Bearer $REDACTED_LOG_VALUE"
+        }
+    }
+
+    private fun extractPath(url: String): String {
+        return runCatching { URI(url).path.orEmpty() }
+            .getOrElse { url.substringBefore('?').substringBefore('#') }
+    }
+
+    private fun List<String>.isItemDetailsPath(): Boolean {
+        val itemsIndex = indexOfLast { it == "items" }
+        return itemsIndex >= 0 &&
+            itemsIndex == lastIndex - 1 &&
+            last().toIntOrNull() != null
+    }
+
+    private companion object {
+        val SENSITIVE_HEADER_NAMES = setOf(
+            "authorization",
+            "proxy-authorization",
+            "cookie",
+            "set-cookie",
+            "user-agent",
+            "x-api-key",
+        )
+        val DIRECT_URL_HEADER_NAMES = setOf(
+            "content-location",
+            "location",
+            "referer",
+            "referrer",
+        )
+        val SENSITIVE_PARAMETER_NAMES = setOf(
+            "access_token",
+            "refresh_token",
+            "client_secret",
+            "device_token",
+            "code",
+        )
+        val USER_INFO_REGEX = Regex(
+            """(?i)(((?:[a-z][a-z0-9+.-]*:)?//))[^/@\s?#]+@""",
+        )
+        val LINK_TARGET_REGEX = Regex("""<([^>]*)>""")
+        val ITEM_DETAILS_ID_REGEX = Regex("""(?i)(/items/)\d+(?=/?(?:[?#]|$))""")
+        val ITEM_DETAILS_TEXT_ID_REGEX = Regex(
+            """(?i)(/items/)\d+(?=/?(?:[?#\s,\]}):]|$))""",
+        )
+        val URL_REGEX = Regex("""(?i)\bhttps?://[^\s\[\]()<>"',;]+""")
+        val JSON_CREDENTIAL_REGEX = Regex(
+            """(?i)("(?:access_token|refresh_token|client_secret|device_token|code)"\s*:\s*")([^"]*)(")""",
+        )
+        val FORM_CREDENTIAL_REGEX = Regex(
+            pattern = """(?i)((?:^|[?&#\s])""" +
+                """(?:access_token|refresh_token|client_secret|device_token|code)=)""" +
+                """(?!<redacted>)([^&#\s,;>"']+)""",
+        )
+        val BEARER_TOKEN_REGEX = Regex("""(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+""")
+    }
+}
+
+private class SanitizedLogThrowable(
+    sourceType: String,
+    sourceMessage: String?,
+    sourceStackTrace: Array<StackTraceElement>,
+    sourceCause: Throwable?,
+    sourceSuppressed: List<Throwable>,
+) : Throwable(
+    message = listOfNotNull(sourceType, sourceMessage?.takeIf(String::isNotBlank))
+        .joinToString(": "),
+    cause = sourceCause,
+) {
+    init {
+        stackTrace = sourceStackTrace
+        sourceSuppressed.forEach(::addSuppressed)
+    }
+}

--- a/app/src/main/java/com/kino/puber/core/ui/PuberVM.kt
+++ b/app/src/main/java/com/kino/puber/core/ui/PuberVM.kt
@@ -9,7 +9,6 @@ import androidx.lifecycle.viewModelScope
 import com.kino.puber.core.coroutine.DefaultExceptionHandler
 import com.kino.puber.core.error.ErrorEntity
 import com.kino.puber.core.error.ErrorHandler
-import com.kino.puber.core.logger.log
 import com.kino.puber.core.ui.navigation.AppRouter
 import com.kino.puber.core.ui.navigation.BackButtonDispatcher
 import com.kino.puber.core.ui.uikit.model.CommonAction
@@ -50,6 +49,10 @@ abstract class PuberVM<ViewState>(protected val router: AppRouter) : ViewModel()
     internal val testStateValue: ViewState
         get() = mutableViewState.value
 
+    @VisibleForTesting
+    internal val testMessageValue: SnackbarMessage?
+        get() = snackBarMessageFlow.value
+
     protected inline fun <reified T : ViewState> updateViewState(
         crossinline updates: T.() -> ViewState,
     ) {
@@ -75,7 +78,6 @@ abstract class PuberVM<ViewState>(protected val router: AppRouter) : ViewModel()
 
     private fun exceptionHandler(): CoroutineExceptionHandler = DefaultExceptionHandler {
         errorHandler?.proceedInvoke(it, ::dispatchError)
-        log(it)
     }
 
     protected open fun dispatchError(error: ErrorEntity) {

--- a/app/src/main/java/com/kino/puber/core/ui/model/VideoItemUIMapper.kt
+++ b/app/src/main/java/com/kino/puber/core/ui/model/VideoItemUIMapper.kt
@@ -5,7 +5,6 @@ import com.kino.puber.core.system.ResourceProvider
 import com.kino.puber.core.ui.uikit.component.RatingUIState
 import com.kino.puber.core.ui.uikit.component.details.VideoDetailsUIState
 import com.kino.puber.core.ui.uikit.component.moviesList.VideoItemUIState
-import com.kino.puber.data.api.models.History
 import com.kino.puber.data.api.models.Item
 import com.kino.puber.data.api.models.isSeriesLike
 import com.kino.puber.data.repository.PlayerPreferencesRepository
@@ -42,13 +41,6 @@ class VideoItemUIMapper(
                 item.bookmarks.orEmpty().isNotEmpty()
             },
         )
-    }
-
-    fun mapHistoryItem(history: History): VideoItemUIState {
-        val progress = history.video?.watching?.let { w ->
-            if (w.duration > 0) w.time.toFloat() / w.duration.toFloat() else null
-        }
-        return mapShortItem(history.item).copy(progressPercent = progress)
     }
 
     fun mapDetailedItem(item: Item): VideoDetailsUIState {

--- a/app/src/main/java/com/kino/puber/core/ui/navigation/AppRouter.kt
+++ b/app/src/main/java/com/kino/puber/core/ui/navigation/AppRouter.kt
@@ -5,8 +5,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
 import java.util.ArrayDeque
+import java.util.concurrent.atomic.AtomicLong
 
 typealias OnResult<T> = (T?) -> (Unit)
 
@@ -15,12 +17,22 @@ class AppRouter(
     val coroutineScope: CoroutineScope,
     //val scopeName: String, // for debug info
 ) {
-    private val sharedFlow = MutableSharedFlow<Command>(extraBufferCapacity = 0, replay = 1)
+    private data class SessionCommand(
+        val sessionId: Long,
+        val command: Command,
+    )
+
+    private val sharedFlow = MutableSharedFlow<SessionCommand>(extraBufferCapacity = 0, replay = 1)
     private val onceListeners = HashMap<Int, ArrayDeque<OnResult<Any>>>()
     private val backDispatchersStack = ArrayDeque<BackButtonDispatcher>()
+    private val sessionId = AtomicLong()
 
     fun events(): Flow<Command> {
-        return sharedFlow.asSharedFlow()
+        return sharedFlow
+            .asSharedFlow()
+            .mapNotNull { event ->
+                event.command.takeIf { event.sessionId == sessionId.get() }
+            }
     }
 
     fun navigateTo(screen: PuberScreen) {
@@ -92,6 +104,13 @@ class AppRouter(
         sharedFlow.resetReplayCache()
     }
 
+    internal fun resetSession() {
+        sessionId.incrementAndGet()
+        clearPendingCommands()
+        onceListeners.clear()
+        backDispatchersStack.clear()
+    }
+
     private fun dispatchResult(resultCode: Int, result: Any?) {
         val resultListeners = onceListeners[resultCode] ?: return
         val resultListener = resultListeners.pollLast() ?: return
@@ -102,8 +121,16 @@ class AppRouter(
     }
 
     private fun runCommand(command: Command) {
+        val commandSessionId = sessionId.get()
         coroutineScope.launch(Dispatchers.Main.immediate) {
-            sharedFlow.emit(command)
+            if (commandSessionId == sessionId.get()) {
+                sharedFlow.emit(
+                    SessionCommand(
+                        sessionId = commandSessionId,
+                        command = command,
+                    )
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/kino/puber/core/ui/navigation/PuberTab.kt
+++ b/app/src/main/java/com/kino/puber/core/ui/navigation/PuberTab.kt
@@ -22,14 +22,19 @@ data class PuberTab(
 ) : PuberScreen, Tab {
 
     @IgnoredOnParcel
-    override val key: ScreenKey = buildString {
-        append("Tab:")
-        append(screen.key)
+    internal val navigationSlotKey: ScreenKey = "Tab:${screen.key}"
+
+    @IgnoredOnParcel
+    internal val contentInstanceKey: ScreenKey = buildString {
+        append(navigationSlotKey)
         if (instanceKey.isNotBlank()) {
             append(":")
             append(instanceKey)
         }
     }
+
+    @IgnoredOnParcel
+    override val key: ScreenKey = navigationSlotKey
 
     override val options: TabOptions
         @Composable
@@ -44,11 +49,18 @@ data class PuberTab(
             Navigator(screen)
             return
         }
-        val tabRouter = remember(key) { holder.getOrCreate(key) }
+        val tabSession = remember(key) {
+            holder.getOrCreate(
+                key = key,
+                initialContentInstanceKey = contentInstanceKey,
+            )
+        }
         TabFlowComponent(
             scopeName = key,
+            navigationSlotKey = navigationSlotKey,
+            contentInstanceKey = contentInstanceKey,
             screen = screen,
-            tabRouter = tabRouter,
+            tabSession = tabSession,
         )
     }
 }

--- a/app/src/main/java/com/kino/puber/core/ui/navigation/Screens.kt
+++ b/app/src/main/java/com/kino/puber/core/ui/navigation/Screens.kt
@@ -1,6 +1,9 @@
 package com.kino.puber.core.ui.navigation
 
 import com.kino.puber.ui.feature.main.model.TabType
+import com.kino.puber.ui.feature.details.model.DetailsEpisodeTarget
+import com.kino.puber.ui.feature.history.model.HistoryPresentation
+import com.kino.puber.ui.feature.player.model.PlayerStartMode
 
 interface Screens {
     fun auth(): PuberScreen
@@ -10,6 +13,8 @@ interface Screens {
     fun search(): PuberScreen
 
     fun home(): PuberScreen
+
+    fun history(presentation: HistoryPresentation): PuberScreen
 
     fun collections(): PuberScreen
 
@@ -25,5 +30,13 @@ interface Screens {
 
     fun details(itemId: Int): PuberScreen
 
-    fun player(itemId: Int, seasonNumber: Int? = null, episodeNumber: Int? = null): PuberScreen
+    fun details(itemId: Int, initialEpisode: DetailsEpisodeTarget): PuberScreen
+
+    fun player(
+        itemId: Int,
+        seasonNumber: Int? = null,
+        episodeNumber: Int? = null,
+        videoNumber: Int? = null,
+        startMode: PlayerStartMode = PlayerStartMode.ResumeIfAvailable,
+    ): PuberScreen
 }

--- a/app/src/main/java/com/kino/puber/core/ui/navigation/component/FlowComponent.kt
+++ b/app/src/main/java/com/kino/puber/core/ui/navigation/component/FlowComponent.kt
@@ -24,6 +24,8 @@ import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.Navigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.kino.puber.core.di.DIScope
+import com.kino.puber.core.di.LocalPuberKoinScope
+import com.kino.puber.core.di.LocalPuberScopePrefix
 import com.kino.puber.core.logger.log
 import com.kino.puber.core.ui.navigation.AppLauncher
 import com.kino.puber.core.ui.navigation.AppRouter
@@ -37,11 +39,10 @@ import com.kino.puber.core.ui.navigation.puberPush
 import com.kino.puber.core.ui.navigation.puberReplace
 import com.kino.puber.core.ui.navigation.puberReplaceAll
 import com.kino.puber.core.ui.uikit.component.FullScreenProgressIndicator
-import kotlinx.coroutines.yield
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.yield
+import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
-import com.kino.puber.core.di.LocalPuberKoinScope
-import com.kino.puber.core.di.LocalPuberScopePrefix
 import org.koin.core.module.Module
 import org.koin.core.qualifier.named
 import org.koin.core.scope.Scope
@@ -209,14 +210,23 @@ object LoadingScreen : PuberScreen {
 }
 
 @Composable
-fun TabFlowComponent(
+internal fun TabFlowComponent(
     scopeName: String,
+    navigationSlotKey: ScreenKey,
+    contentInstanceKey: ScreenKey,
     screen: PuberScreen,
-    tabRouter: AppRouter,
+    tabSession: TabFlowSession,
 ) {
     val composableScope = rememberCoroutineScope()
+    val tabRouter = tabSession.router
     val parentScope = LocalPuberKoinScope.current
     val rootRouter = remember(parentScope) { parentScope?.getOrNull<AppRouter>() }
+    val rootScreen = remember(contentInstanceKey, screen) {
+        TabRootScreen(
+            delegate = screen,
+            tabInstanceKey = contentInstanceKey,
+        )
+    }
     DIScope(
         scopeName = scopeName,
         moduleFactory = { scopeId, _ ->
@@ -230,9 +240,18 @@ fun TabFlowComponent(
     ) {
         val contentFocusRequester = remember { FocusRequester() }
         Navigator(
-            screen = screen,
+            screen = rootScreen,
             onBackPressed = null,
+            key = tabFlowNavigatorKey(navigationSlotKey),
         ) { navigator ->
+            LaunchedEffect(contentInstanceKey) {
+                replaceTabRootIfChanged(
+                    navigator = navigator,
+                    rootScreen = rootScreen,
+                    contentInstanceKey = contentInstanceKey,
+                    tabSession = tabSession,
+                )
+            }
             TabBackHandler(navigator, tabRouter)
             Box(
                 Modifier
@@ -255,6 +274,47 @@ fun TabFlowComponent(
             }
         }
     }
+}
+
+@Parcelize
+private data class TabRootScreen(
+    private val delegate: PuberScreen,
+    private val tabInstanceKey: ScreenKey,
+) : PuberScreen {
+
+    @IgnoredOnParcel
+    override val key: ScreenKey = tabRootScreenKey(
+        tabInstanceKey = tabInstanceKey,
+        delegateKey = delegate.key,
+    )
+
+    @Composable
+    override fun Content() {
+        delegate.Content()
+    }
+}
+
+internal fun tabRootScreenKey(
+    tabInstanceKey: ScreenKey,
+    delegateKey: ScreenKey,
+): ScreenKey = "TabRoot:$tabInstanceKey:$delegateKey"
+
+internal fun tabFlowNavigatorKey(navigationSlotKey: ScreenKey): String {
+    return "TabFlow:$navigationSlotKey"
+}
+
+internal fun replaceTabRootIfChanged(
+    navigator: Navigator,
+    rootScreen: PuberScreen,
+    contentInstanceKey: ScreenKey,
+    tabSession: TabFlowSession,
+): Boolean {
+    if (!tabSession.beginContentInstance(contentInstanceKey)) {
+        return false
+    }
+    tabSession.router.resetSession()
+    navigator.puberReplaceAll(rootScreen)
+    return true
 }
 
 @Composable

--- a/app/src/main/java/com/kino/puber/core/ui/navigation/component/TabComponent.kt
+++ b/app/src/main/java/com/kino/puber/core/ui/navigation/component/TabComponent.kt
@@ -26,23 +26,38 @@ import org.koin.compose.koinInject
 
 internal val LocalTabAppRouterHolder = staticCompositionLocalOf<TabAppRouterHolder?> { null }
 
+internal class TabFlowSession(
+    val router: AppRouter,
+    initialContentInstanceKey: ScreenKey,
+) {
+    private var contentInstanceKey: ScreenKey = initialContentInstanceKey
+
+    fun beginContentInstance(nextKey: ScreenKey): Boolean {
+        val previousKey = contentInstanceKey
+        contentInstanceKey = nextKey
+        return previousKey != nextKey
+    }
+}
+
 internal class TabAppRouterHolder(private val screens: Screens) {
-    private data class Entry(val router: AppRouter, val scope: CoroutineScope)
+    private data class Entry(val session: TabFlowSession, val scope: CoroutineScope)
 
     private val entries = mutableMapOf<ScreenKey, Entry>()
 
-    fun getOrCreate(key: ScreenKey): AppRouter {
+    fun getOrCreate(
+        key: ScreenKey,
+        initialContentInstanceKey: ScreenKey,
+    ): TabFlowSession {
         return entries.getOrPut(key) {
             val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
             Entry(
-                router = AppRouter(coroutineScope = scope, screens = screens),
+                session = TabFlowSession(
+                    router = AppRouter(coroutineScope = scope, screens = screens),
+                    initialContentInstanceKey = initialContentInstanceKey,
+                ),
                 scope = scope,
             )
-        }.router
-    }
-
-    fun dispose(key: ScreenKey) {
-        entries.remove(key)?.scope?.cancel()
+        }.session
     }
 
     fun dispose() {
@@ -77,6 +92,9 @@ internal fun TabComponent(
     CompositionLocalProvider(LocalTabAppRouterHolder provides holder) {
         TabNavigator(
             tab = LoadingTab,
+            // Voyager retains one nested Navigator per logical tab so switching tabs preserves its stack.
+            // Refreshes replace that Navigator's root instead of creating generation-specific child Navigators.
+            disposeNestedNavigators = false,
             key = scopeName,
         ) {
             val navigator = LocalTabNavigator.current

--- a/app/src/main/java/com/kino/puber/core/ui/uikit/component/TvContextMenu.kt
+++ b/app/src/main/java/com/kino/puber/core/ui/uikit/component/TvContextMenu.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
@@ -52,6 +53,7 @@ internal fun TvContextMenuDialog(
     onAction: (TvContextMenuAction) -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
+    supportingText: String? = null,
 ) {
     if (actions.isEmpty()) return
 
@@ -86,41 +88,79 @@ internal fun TvContextMenuDialog(
                 modifier = Modifier.padding(20.dp),
                 verticalArrangement = Arrangement.spacedBy(10.dp),
             ) {
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.titleLarge,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
+                ContextMenuHeader(
+                    title = title,
+                    supportingText = supportingText,
                 )
-                actions.forEachIndexed { index, action ->
-                    TvSafeButton(
-                        text = action.title,
-                        onClick = {
-                            dismiss()
-                            onAction(action)
-                        },
-                        enabled = action.enabled,
-                        primary = index == 0,
-                        modifier = if (index == initialFocusActionIndex) {
-                            Modifier.focusRequester(actionFocusRequester)
-                        } else {
-                            Modifier
-                        },
-                    )
-                }
-                TvSafeButton(
-                    text = stringResource(R.string.context_menu_close),
-                    onClick = dismiss,
-                    modifier = if (initialFocusActionIndex < 0) {
-                        Modifier.focusRequester(closeFocusRequester)
-                    } else {
-                        Modifier
+                ContextMenuActions(
+                    actions = actions,
+                    initialFocusActionIndex = initialFocusActionIndex,
+                    actionFocusRequester = actionFocusRequester,
+                    closeFocusRequester = closeFocusRequester,
+                    onAction = { action ->
+                        dismiss()
+                        onAction(action)
                     },
+                    onClose = dismiss,
                 )
             }
         }
     }
+}
+
+@Composable
+private fun ContextMenuHeader(
+    title: String,
+    supportingText: String?,
+) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleLarge,
+        color = MaterialTheme.colorScheme.onSurface,
+        maxLines = 2,
+        overflow = TextOverflow.Ellipsis,
+    )
+    if (!supportingText.isNullOrBlank()) {
+        Text(
+            text = supportingText,
+            modifier = Modifier.focusProperties { canFocus = false },
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun ContextMenuActions(
+    actions: List<TvContextMenuAction>,
+    initialFocusActionIndex: Int,
+    actionFocusRequester: FocusRequester,
+    closeFocusRequester: FocusRequester,
+    onAction: (TvContextMenuAction) -> Unit,
+    onClose: () -> Unit,
+) {
+    actions.forEachIndexed { index, action ->
+        TvSafeButton(
+            text = action.title,
+            onClick = { onAction(action) },
+            enabled = action.enabled,
+            primary = index == 0,
+            modifier = if (index == initialFocusActionIndex) {
+                Modifier.focusRequester(actionFocusRequester)
+            } else {
+                Modifier
+            },
+        )
+    }
+    TvSafeButton(
+        text = stringResource(R.string.context_menu_close),
+        onClick = onClose,
+        modifier = if (initialFocusActionIndex < 0) {
+            Modifier.focusRequester(closeFocusRequester)
+        } else {
+            Modifier
+        },
+    )
 }
 
 @Composable
@@ -276,9 +316,8 @@ internal fun Modifier.onTvContextMenuKey(
                 true
             }
 
-            event.type == KeyEventType.KeyUp && event.key.isSelectKey() -> {
+            event.type == KeyEventType.KeyUp && event.key.isSelectKey() ->
                 longSelectState.onSelectKeyUp()
-            }
 
             else -> false
         }

--- a/app/src/main/java/com/kino/puber/core/ui/uikit/component/modifier/FocusOnLaunchRequester.kt
+++ b/app/src/main/java/com/kino/puber/core/ui/uikit/component/modifier/FocusOnLaunchRequester.kt
@@ -22,6 +22,13 @@ import kotlinx.coroutines.launch
  */
 val LocalAutoFocusOnLaunchEnabled = staticCompositionLocalOf { true }
 
+/**
+ * Whether the surrounding navigation host currently owns focus for its content.
+ * TopTabs keeps this false while the tab row owns focus so retained screens
+ * cannot reclaim focus merely by becoming selected.
+ */
+val LocalContentFocusActive = staticCompositionLocalOf { true }
+
 @Composable
 fun rememberFocusRequesterOnLaunch(): FocusRequester {
     val focusRequester = remember { FocusRequester() }

--- a/app/src/main/java/com/kino/puber/core/ui/uikit/component/moviesList/VideoGridUIState.kt
+++ b/app/src/main/java/com/kino/puber/core/ui/uikit/component/moviesList/VideoGridUIState.kt
@@ -3,6 +3,7 @@ package com.kino.puber.core.ui.uikit.component.moviesList
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -17,10 +18,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -57,9 +60,23 @@ fun VideoGrid(
     onItemFocused: (VideoItemUIState) -> Unit = {},
     onItemContextMenu: ((VideoItemUIState) -> Unit)? = null,
     enableTopSideGradient: Boolean = true,
+    initialFocusedItemId: Int? = null,
 ) {
     val lazyListState = rememberLazyListState()
-    var focusedColumnIndex by rememberSaveable { mutableIntStateOf(-1) }
+    val initialColumnIndex = remember(state, initialFocusedItemId) {
+        state.list.indexOfFirst { gridItem ->
+            gridItem is VideoGridItemUIState.Items &&
+                gridItem.items.any { it.id == initialFocusedItemId }
+        }
+    }
+    var focusedColumnIndex by rememberSaveable(initialFocusedItemId) {
+        mutableIntStateOf(initialColumnIndex)
+    }
+    LaunchedEffect(initialColumnIndex) {
+        if (initialColumnIndex >= 0) {
+            lazyListState.scrollToItem(initialColumnIndex)
+        }
+    }
 
     val showTopGradient by remember { derivedStateOf { lazyListState.firstVisibleItemScrollOffset > 0 } }
 
@@ -89,6 +106,9 @@ fun VideoGrid(
                         items = columnItem,
                         columnIndex = indexC,
                         isTargetRow = indexC == focusedColumnIndex,
+                        initialFocusedItemId = initialFocusedItemId?.takeIf { itemId ->
+                            columnItem.items.any { it.id == itemId }
+                        },
                         onItemClick = onItemClick,
                         onItemContextMenu = onItemContextMenu,
                         onItemFocused = { item ->
@@ -100,25 +120,29 @@ fun VideoGrid(
             }
         }
 
-        if (enableTopSideGradient && showTopGradient) {
-            val gradientHeight = 48.dp
-            val surfaceColor = MaterialTheme.colorScheme.surface
-            val density = LocalDensity.current
-            val gradientBrush = remember(surfaceColor) {
-                Brush.verticalGradient(
-                    colors = listOf(surfaceColor, surfaceColor.copy(alpha = 0F)),
-                    endY = with(density) { gradientHeight.toPx() },
-                )
-            }
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(gradientHeight)
-                    .align(Alignment.TopCenter)
-                    .background(brush = gradientBrush)
-            )
-        }
+        VideoGridTopGradient(visible = enableTopSideGradient && showTopGradient)
     }
+}
+
+@Composable
+private fun BoxScope.VideoGridTopGradient(visible: Boolean) {
+    if (!visible) return
+    val gradientHeight = 48.dp
+    val surfaceColor = MaterialTheme.colorScheme.surface
+    val density = LocalDensity.current
+    val gradientBrush = remember(surfaceColor) {
+        Brush.verticalGradient(
+            colors = listOf(surfaceColor, surfaceColor.copy(alpha = 0F)),
+            endY = with(density) { gradientHeight.toPx() },
+        )
+    }
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(gradientHeight)
+            .align(Alignment.TopCenter)
+            .background(brush = gradientBrush),
+    )
 }
 
 @Composable
@@ -126,6 +150,7 @@ private fun VideoGridItems(
     items: VideoGridItemUIState.Items,
     columnIndex: Int,
     isTargetRow: Boolean,
+    initialFocusedItemId: Int?,
     onItemClick: (VideoItemUIState) -> Unit,
     onItemContextMenu: ((VideoItemUIState) -> Unit)?,
     onItemFocused: (VideoItemUIState) -> Unit,
@@ -136,10 +161,21 @@ private fun VideoGridItems(
             .fillMaxWidth(),
     ) {
         val listState = rememberLazyListState()
-        var focusedItemIndex by rememberSaveable { mutableIntStateOf(0) }
+        val initialItemIndex = remember(items, initialFocusedItemId) {
+            items.items.indexOfFirst { it.id == initialFocusedItemId }
+        }
+        var focusedItemIndex by rememberSaveable(columnIndex, initialFocusedItemId) {
+            mutableIntStateOf(initialItemIndex.coerceAtLeast(0))
+        }
 
         val rowFocusRequester = remember { FocusRequester() }
         val savedItemFocusRequester = remember { FocusRequester() }
+        LaunchedEffect(initialFocusedItemId, initialItemIndex) {
+            if (initialItemIndex >= 0) {
+                withFrameNanos { }
+                savedItemFocusRequester.requestFocus()
+            }
+        }
         PositionFocusedItemInLazyLayout {
             LazyRow(
                 modifier = Modifier
@@ -157,35 +193,62 @@ private fun VideoGridItems(
                     } else {
                         indexR == 0
                     }
-                    val focusModifier = remember(indexR, item.id) {
-                        Modifier.onFocusChanged { state ->
-                            if (state.isFocused) {
-                                focusedItemIndex = indexR
-                                onItemFocused(item)
-                            }
-                        }
-                    }
-                    val clickCallback = remember(item.id) {
-                        {
-                            runCatching { rowFocusRequester.saveFocusedChild() }
-                            onItemClick(item)
-                        }
-                    }
-
-                    VideoItem(
-                        modifier = Modifier
-                            .then(
-                                if (isFallbackTarget) Modifier.focusRequester(savedItemFocusRequester)
-                                else Modifier
-                            )
-                            .then(focusModifier),
-                        state = item,
-                        onClick = clickCallback,
-                        onContextMenu = onItemContextMenu?.let { callback -> { callback(item) } },
+                    VideoGridRowItem(
+                        item = item,
+                        itemIndex = indexR,
+                        isFallbackTarget = isFallbackTarget,
+                        rowFocusRequester = rowFocusRequester,
+                        savedItemFocusRequester = savedItemFocusRequester,
+                        onItemClick = onItemClick,
+                        onItemContextMenu = onItemContextMenu,
+                        onItemFocused = { focusedIndex, focusedItem ->
+                            focusedItemIndex = focusedIndex
+                            onItemFocused(focusedItem)
+                        },
                     )
                 }
             }
             FadeGradient(listState)
         }
     }
+}
+
+@Composable
+private fun VideoGridRowItem(
+    item: VideoItemUIState,
+    itemIndex: Int,
+    isFallbackTarget: Boolean,
+    rowFocusRequester: FocusRequester,
+    savedItemFocusRequester: FocusRequester,
+    onItemClick: (VideoItemUIState) -> Unit,
+    onItemContextMenu: ((VideoItemUIState) -> Unit)?,
+    onItemFocused: (Int, VideoItemUIState) -> Unit,
+) {
+    val focusModifier = remember(itemIndex, item.id) {
+        Modifier.onFocusChanged { state ->
+            if (state.isFocused) {
+                onItemFocused(itemIndex, item)
+            }
+        }
+    }
+    val clickCallback = remember(item.id) {
+        {
+            runCatching { rowFocusRequester.saveFocusedChild() }
+            onItemClick(item)
+        }
+    }
+    VideoItem(
+        modifier = Modifier
+            .then(
+                if (isFallbackTarget) {
+                    Modifier.focusRequester(savedItemFocusRequester)
+                } else {
+                    Modifier
+                },
+            )
+            .then(focusModifier),
+        state = item,
+        onClick = clickCallback,
+        onContextMenu = onItemContextMenu?.let { callback -> { callback(item) } },
+    )
 }

--- a/app/src/main/java/com/kino/puber/core/ui/uikit/component/moviesList/VideoItemUIState.kt
+++ b/app/src/main/java/com/kino/puber/core/ui/uikit/component/moviesList/VideoItemUIState.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -61,6 +62,8 @@ data class VideoItemUIState(
     val episodeNumber: Int? = null,
     val isSeasonWatched: Boolean? = null,
 )
+
+internal const val WATCHED_INDICATOR_TEST_TAG = "watched_indicator"
 
 @Composable
 fun VideoItem(
@@ -188,6 +191,7 @@ internal fun WatchedIndicatorBadge(
 
     Box(
         modifier = modifier
+            .testTag(WATCHED_INDICATOR_TEST_TAG)
             .padding(6.dp)
             .background(
                 MaterialTheme.colorScheme.scrim.copy(alpha = 0.48F),

--- a/app/src/main/java/com/kino/puber/data/api/IntroDbAppApiClient.kt
+++ b/app/src/main/java/com/kino/puber/data/api/IntroDbAppApiClient.kt
@@ -1,6 +1,5 @@
 package com.kino.puber.data.api
 
-import com.kino.puber.core.logger.log
 import com.kino.puber.data.api.models.IntroDbAppResponse
 import com.kino.puber.data.api.models.IntroDbAppSegment
 import com.kino.puber.data.api.models.SkipSegment
@@ -32,14 +31,12 @@ class IntroDbAppApiClient {
 
     suspend fun getSegments(imdbId: String, season: Int?, episode: Int?): Result<List<SkipSegment>> = runCatching {
         val formattedId = if (imdbId.startsWith("tt", ignoreCase = true)) imdbId else "tt$imdbId"
-        log("IntroDbApp: GET /segments?imdb_id=$formattedId&season=$season&episode=$episode")
         val response = httpClient.get("segments") {
             parameter("imdb_id", formattedId)
             if (season != null) parameter("season", season)
             if (episode != null) parameter("episode", episode)
         }
         if (!response.status.isSuccess()) {
-            log("IntroDbApp: failed with status=${response.status}")
             return@runCatching emptyList()
         }
         val body = response.body<IntroDbAppResponse>()

--- a/app/src/main/java/com/kino/puber/data/api/KinoPubApiClient.kt
+++ b/app/src/main/java/com/kino/puber/data/api/KinoPubApiClient.kt
@@ -6,8 +6,9 @@ import com.kino.puber.data.api.auth.DeviceCodeResponse
 import com.kino.puber.data.api.auth.DeviceFlowResult
 import com.kino.puber.data.api.auth.OAuthError
 import com.kino.puber.data.api.auth.TokenResponse
-import com.kino.puber.data.api.history.HistoryRequest
 import com.kino.puber.data.api.history.HistoryPageResponse
+import com.kino.puber.data.api.history.clearHistoryMedia
+import com.kino.puber.data.api.history.fetchHistoryPage
 import com.kino.puber.core.session.SessionEvent
 import com.kino.puber.core.session.SessionEventBus
 import com.kino.puber.data.api.config.KinoPubConfig
@@ -348,13 +349,7 @@ class KinoPubApiClient(
      */
     suspend fun getHistoryData(page: Int): Result<PaginatedResponse<History>> =
         apiCall<HistoryPageResponse> {
-            val request = HistoryRequest.page(page)
-            httpClient.get(request.resolveUrl(mainApiBaseUrl)) {
-                request.query.forEach { (name, value) -> parameter(name, value) }
-                headers {
-                    append(HttpHeaders.CacheControl, request.cacheControl)
-                }
-            }
+            httpClient.fetchHistoryPage(page, mainApiBaseUrl)
         }.map(HistoryPageResponse::toModel)
 
     /**
@@ -375,19 +370,7 @@ class KinoPubApiClient(
      * Clear history for the exact media represented by a selected history row.
      */
     suspend fun clearExactMediaHistory(mediaId: Int): Result<Unit> =
-        apiCall {
-            val request = HistoryRequest.clearExactMedia(mediaId)
-            httpClient.post(request.resolveUrl(mainApiBaseUrl)) {
-                request.query.forEach { (name, value) -> parameter(name, value) }
-                headers {
-                    append(HttpHeaders.CacheControl, request.cacheControl)
-                }
-            }.also { response ->
-                check(response.status.isSuccess()) {
-                    "History exact-media deletion failed with HTTP ${response.status.value}"
-                }
-            }
-        }
+        apiCall { httpClient.clearHistoryMedia(mediaId, mainApiBaseUrl) }
 
     /**
      * Clear season history

--- a/app/src/main/java/com/kino/puber/data/api/KinoPubApiClient.kt
+++ b/app/src/main/java/com/kino/puber/data/api/KinoPubApiClient.kt
@@ -6,6 +6,8 @@ import com.kino.puber.data.api.auth.DeviceCodeResponse
 import com.kino.puber.data.api.auth.DeviceFlowResult
 import com.kino.puber.data.api.auth.OAuthError
 import com.kino.puber.data.api.auth.TokenResponse
+import com.kino.puber.data.api.history.HistoryRequest
+import com.kino.puber.data.api.history.HistoryPageResponse
 import com.kino.puber.core.session.SessionEvent
 import com.kino.puber.core.session.SessionEventBus
 import com.kino.puber.data.api.config.KinoPubConfig
@@ -90,6 +92,7 @@ class KinoPubApiClient(
     private val connectivityManager: ConnectivityManager,
     private val cryptoPreferenceRepository: ICryptoPreferenceRepository,
     private val sessionEventBus: SessionEventBus,
+    private val mainApiBaseUrl: String = KinoPubConfig.MAIN_API_BASE_URL,
 ) {
     private val json = Json {
         ignoreUnknownKeys = true
@@ -120,7 +123,7 @@ class KinoPubApiClient(
 
                 refreshTokens {
                     val refreshToken = cryptoPreferenceRepository.getRefreshToken().orEmpty()
-                    log("Attempting to refresh token with refresh token: $refreshToken")
+                    log("Attempting to refresh access token")
 
                     try {
                         val response = client.post("${KinoPubConfig.OAUTH_BASE_URL}device") {
@@ -135,18 +138,17 @@ class KinoPubApiClient(
                             cryptoPreferenceRepository.saveRefreshToken(newTokens.refreshToken)
                             BearerTokens(newTokens.accessToken, newTokens.refreshToken)
                         } else {
-                            val errorBody = response.bodyAsText()
-                            log("Refresh token failed with ${response.status.value}: $errorBody")
+                            log("Refresh token failed with HTTP ${response.status.value}")
                             onSessionExpired()
-                            throw IllegalStateException("Failed to refresh token: $errorBody")
+                            throw IllegalStateException(REFRESH_TOKEN_FAILURE_MESSAGE)
                         }
                     } catch (e: Exception) {
-                        if (e is IllegalStateException && e.message?.startsWith("Failed to refresh token:") == true) {
+                        if (e is IllegalStateException && e.message == REFRESH_TOKEN_FAILURE_MESSAGE) {
                             throw e
                         }
-                        log("Refresh token error: ${e.message}")
+                        log("Refresh token request failed")
                         onSessionExpired()
-                        throw IllegalStateException("Failed to refresh token: ${e.message}", e)
+                        throw IllegalStateException(REFRESH_TOKEN_FAILURE_MESSAGE, e)
                     }
                 }
             }
@@ -344,11 +346,16 @@ class KinoPubApiClient(
     /**
      * Get history data with pagination
      */
-    suspend fun getHistoryData(page: Int): Result<PaginatedResponse<History>> = apiCall {
-        httpClient.get("${KinoPubConfig.MAIN_API_BASE_URL}history") {
-            parameter("page", page)
-        }
-    }
+    suspend fun getHistoryData(page: Int): Result<PaginatedResponse<History>> =
+        apiCall<HistoryPageResponse> {
+            val request = HistoryRequest.page(page)
+            httpClient.get(request.resolveUrl(mainApiBaseUrl)) {
+                request.query.forEach { (name, value) -> parameter(name, value) }
+                headers {
+                    append(HttpHeaders.CacheControl, request.cacheControl)
+                }
+            }
+        }.map(HistoryPageResponse::toModel)
 
     /**
      * Clear item history
@@ -362,11 +369,25 @@ class KinoPubApiClient(
     /**
      * Clear media history
      */
-    suspend fun clearMediaHistory(id: Int): Result<Unit> = apiCall {
-        httpClient.post("${KinoPubConfig.MAIN_API_BASE_URL}history/clear-for-media") {
-            parameter("id", id)
+    suspend fun clearMediaHistory(id: Int): Result<Unit> = clearExactMediaHistory(id)
+
+    /**
+     * Clear history for the exact media represented by a selected history row.
+     */
+    suspend fun clearExactMediaHistory(mediaId: Int): Result<Unit> =
+        apiCall {
+            val request = HistoryRequest.clearExactMedia(mediaId)
+            httpClient.post(request.resolveUrl(mainApiBaseUrl)) {
+                request.query.forEach { (name, value) -> parameter(name, value) }
+                headers {
+                    append(HttpHeaders.CacheControl, request.cacheControl)
+                }
+            }.also { response ->
+                check(response.status.isSuccess()) {
+                    "History exact-media deletion failed with HTTP ${response.status.value}"
+                }
+            }
         }
-    }
 
     /**
      * Clear season history
@@ -543,8 +564,6 @@ class KinoPubApiClient(
         title: String, hardware: String, software: String
     ): Result<Unit> = apiCall {
         httpClient.post("${KinoPubConfig.MAIN_API_BASE_URL}device/notify") {
-            val token = cryptoPreferenceRepository.getAccessToken().orEmpty()
-            log("Access token: $token")
             setBody(
                 mapOf(
                     "title" to title, "hardware" to hardware, "software" to software
@@ -1052,7 +1071,7 @@ class KinoPubApiClient(
     private suspend inline fun <reified T> handleApiResponse(response: HttpResponse): Result<T> = runCatching {
         if (!response.status.isSuccess()) {
             val errorText = response.bodyAsText()
-            throw IllegalStateException("HTTP ${response.status.value}: $errorText")
+            throw buildApiError(errorText, response.status.value)
         }
 
         val responseText = response.bodyAsText()
@@ -1060,25 +1079,30 @@ class KinoPubApiClient(
             throw buildApiError(responseText)
         }
 
-        json.decodeFromString<T>(responseText)
+        try {
+            json.decodeFromString<T>(responseText)
+        } catch (_: Exception) {
+            throw IllegalStateException("OAuth response decoding failed")
+        }
     }
 
-    private fun buildApiError(responseText: String): Exception {
+    private fun buildApiError(responseText: String, statusCode: Int? = null): Exception {
         return try {
             val error = json.decodeFromString<OAuthError>(responseText)
-            val description = error.errorDescription?.let { " - $it" }.orEmpty()
-            Exception("OAuth Error: ${error.error}$description")
-        } catch (e: Exception) {
-            Exception("API Error: $responseText", e)
+            Exception("OAuth Error: ${error.error}")
+        } catch (_: Exception) {
+            val prefix = statusCode?.let { "HTTP $it" } ?: "API"
+            Exception("$prefix error response")
         }
     }
 
     private fun shouldSendKinoPubToken(host: String): Boolean {
-        return host == Url(KinoPubConfig.MAIN_API_BASE_URL).host ||
+        return host == Url(mainApiBaseUrl).host ||
             host == Url(KinoPubConfig.OAUTH_BASE_URL).host
     }
 
     companion object {
+        private const val REFRESH_TOKEN_FAILURE_MESSAGE = "Failed to refresh token"
         private const val MAX_RETRIES = 3
         private const val CONNECT_TIMEOUT = 60_000L
         private const val READ_TIMEOUT = 120_000L

--- a/app/src/main/java/com/kino/puber/data/api/KtorPlugins.kt
+++ b/app/src/main/java/com/kino/puber/data/api/KtorPlugins.kt
@@ -2,6 +2,7 @@ package com.kino.puber.data.api
 
 import com.kino.puber.BuildConfig
 import com.kino.puber.core.logger.log
+import com.kino.puber.data.api.network.CurlLogFormatter
 import io.ktor.client.plugins.api.createClientPlugin
 import io.ktor.client.statement.bodyAsChannel
 import io.ktor.client.statement.request
@@ -21,6 +22,8 @@ private const val CLIENT_ID = "android"
 private const val CLIENT_SECRET = BuildConfig.CLIENT_SECRET
 private const val PADDING_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 private const val MAX_PADDING_LENGTH = 2048
+private const val BYTES_PER_MEBIBYTE = 1024L * 1024L
+private const val MAX_LOG_BODY_SIZE = BYTES_PER_MEBIBYTE
 
 val TrafficPaddingPlugin = createClientPlugin("TrafficPaddingPlugin") {
     onRequest { request, _ ->
@@ -53,61 +56,42 @@ val KinoPubParametersPlugin = createClientPlugin("KinoPubParametersPlugin") {
 }
 
 val CurlLogger = createClientPlugin("CurlLogger") {
-    val maxBodySize = 1024 * 1024L // 1MB
+    val formatter = CurlLogFormatter()
 
     onRequest { request, _ ->
-        val curl = StringBuilder("curl")
-
-        curl.append(" -X ").append(request.method.value)
-
-        request.headers.entries().forEach { (key, values) ->
-            values.forEach { value ->
-                curl.append(" -H \"$key: $value\"")
-            }
+        val headers = request.headers.entries().flatMap { (name, values) ->
+            values.map { value -> name to value }
         }
-
-        val body = request.body
-        if (body is TextContent) {
-            val data = body.text.replace("\n", "\\n")
-            curl.append(" --data $'").append(data).append("'")
-        } else {
-            curl.append(" --data-binary '<non-text or unknown body>'")
-        }
-
-        curl.append(" \"").append(request.url).append("\"")
-
-        log("╭--- cURL (${request.url})")
-        log(curl.toString())
-        log("╰--- (copy & paste to terminal)")
+        val textBody = (request.body as? TextContent)?.text
+        formatter.formatRequest(
+            method = request.method.value,
+            url = request.url.toString(),
+            headers = headers,
+            textBody = textBody,
+        ).forEach { line -> log(line) }
     }
 
     onResponse { response ->
-        log("<-- ${response.status} ${response.request.url}")
-        response.headers.entries().forEach { (key, values) ->
-            values.forEach { value ->
-                log("$key: $value")
-            }
+        val headers = response.headers.entries().flatMap { (name, values) ->
+            values.map { value -> name to value }
         }
-
-        if (
+        val content = if (
             shouldSkipBodyLogging(
                 host = response.request.url.host,
                 path = response.request.url.encodedPath,
                 contentType = response.headers[HttpHeaders.ContentType],
             )
         ) {
-            log("")
-            log("<body logging skipped>")
-            log("<-- END HTTP")
-            return@onResponse
+            "<body logging skipped>"
+        } else {
+            readTextLimited(response.bodyAsChannel(), MAX_LOG_BODY_SIZE)
         }
-
-        val responseBody = response.bodyAsChannel()
-        val content = readTextLimited(responseBody, maxBodySize)
-
-        log("")
-        log(content)
-        log("<-- END HTTP (${content.length}-char body)")
+        formatter.formatResponse(
+            status = response.status.toString(),
+            url = response.request.url.toString(),
+            headers = headers,
+            body = content,
+        ).forEach { line -> log(line) }
     }
 }
 
@@ -131,7 +115,6 @@ private suspend fun readTextLimited(channel: ByteReadChannel, maxSize: Long): St
         "<binary body or decode error>"
     }
 }
-
 private fun shouldSkipBodyLogging(host: String, path: String, contentType: String?): Boolean {
     val normalizedHost = host.lowercase()
     val normalizedPath = path.lowercase()

--- a/app/src/main/java/com/kino/puber/data/api/TheIntroDbApiClient.kt
+++ b/app/src/main/java/com/kino/puber/data/api/TheIntroDbApiClient.kt
@@ -1,6 +1,5 @@
 package com.kino.puber.data.api
 
-import com.kino.puber.core.logger.log
 import com.kino.puber.data.api.models.SkipSegment
 import com.kino.puber.data.api.models.SkipSegmentType
 import com.kino.puber.data.api.models.TheIntroDbMediaResponse
@@ -31,29 +30,19 @@ class TheIntroDbApiClient {
     }
 
     suspend fun getSegments(tmdbId: Int, season: Int?, episode: Int?): Result<List<SkipSegment>> = runCatching {
-        log("TheIntroDB: GET /media?tmdb_id=$tmdbId&season=$season&episode=$episode")
         val response = httpClient.get("media") {
             parameter("tmdb_id", tmdbId)
             if (season != null) parameter("season", season)
             if (episode != null) parameter("episode", episode)
         }
-        log("TheIntroDB: status=${response.status}")
         when (response.status) {
             HttpStatusCode.OK -> {
                 val body = response.body<TheIntroDbMediaResponse>()
-                val segments = mapToSegments(body)
-                log("TheIntroDB: parsed ${segments.size} segments")
-                segments
+                mapToSegments(body)
             }
             HttpStatusCode.NoContent, HttpStatusCode.NotFound -> emptyList()
-            HttpStatusCode.TooManyRequests -> {
-                log("TheIntroDB rate limited")
-                emptyList()
-            }
-            else -> {
-                log("TheIntroDB unexpected status: ${response.status}")
-                emptyList()
-            }
+            HttpStatusCode.TooManyRequests -> emptyList()
+            else -> emptyList()
         }
     }
 

--- a/app/src/main/java/com/kino/puber/data/api/TmdbApiClient.kt
+++ b/app/src/main/java/com/kino/puber/data/api/TmdbApiClient.kt
@@ -1,7 +1,6 @@
 package com.kino.puber.data.api
 
 import com.kino.puber.BuildConfig
-import com.kino.puber.core.logger.log
 import com.kino.puber.data.api.models.TmdbFindResponse
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -32,17 +31,13 @@ class TmdbApiClient {
 
     suspend fun findByImdbId(imdbId: String): Result<Int?> = runCatching {
         val formattedId = if (imdbId.startsWith("tt", ignoreCase = true)) imdbId else "tt$imdbId"
-        log("TMDB: GET /find/$formattedId, token=${BuildConfig.TMDB_READ_ACCESS_TOKEN.take(10)}...")
         val response = httpClient.get("find/$formattedId") {
             parameter("external_source", "imdb_id")
         }
         if (!response.status.isSuccess()) {
-            log("TMDB: /find failed with status=${response.status}")
             return@runCatching null
         }
         val body = response.body<TmdbFindResponse>()
-        val id = body.tvResults?.firstOrNull()?.id ?: body.movieResults?.firstOrNull()?.id
-        log("TMDB: /find result tmdbId=$id (tv=${body.tvResults?.size}, movie=${body.movieResults?.size})")
-        id
+        body.tvResults?.firstOrNull()?.id ?: body.movieResults?.firstOrNull()?.id
     }
 }

--- a/app/src/main/java/com/kino/puber/data/api/history/HistoryApiTransport.kt
+++ b/app/src/main/java/com/kino/puber/data/api/history/HistoryApiTransport.kt
@@ -1,0 +1,45 @@
+package com.kino.puber.data.api.history
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.headers
+import io.ktor.client.request.parameter
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpHeaders
+import io.ktor.http.isSuccess
+
+internal suspend fun HttpClient.fetchHistoryPage(
+    page: Int,
+    baseUrl: String,
+): HttpResponse = get(HistoryRequest.page(page), baseUrl)
+
+internal suspend fun HttpClient.clearHistoryMedia(
+    mediaId: Int,
+    baseUrl: String,
+): HttpResponse = post(HistoryRequest.clearExactMedia(mediaId), baseUrl).also { response ->
+    check(response.status.isSuccess()) {
+        "History exact-media deletion failed with HTTP ${response.status.value}"
+    }
+}
+
+private suspend fun HttpClient.get(
+    request: HistoryRequest,
+    baseUrl: String,
+): HttpResponse = get(request.resolveUrl(baseUrl)) {
+    apply(request)
+}
+
+private suspend fun HttpClient.post(
+    request: HistoryRequest,
+    baseUrl: String,
+): HttpResponse = post(request.resolveUrl(baseUrl)) {
+    apply(request)
+}
+
+private fun io.ktor.client.request.HttpRequestBuilder.apply(request: HistoryRequest) {
+    request.query.forEach { (name, value) -> parameter(name, value) }
+    headers {
+        append(HttpHeaders.CacheControl, request.cacheControl)
+    }
+}

--- a/app/src/main/java/com/kino/puber/data/api/history/HistoryPageResponse.kt
+++ b/app/src/main/java/com/kino/puber/data/api/history/HistoryPageResponse.kt
@@ -1,0 +1,94 @@
+package com.kino.puber.data.api.history
+
+import com.kino.puber.data.api.models.History
+import com.kino.puber.data.api.models.Item
+import com.kino.puber.data.api.models.ItemType
+import com.kino.puber.data.api.models.PaginatedResponse
+import com.kino.puber.data.api.models.Pagination
+import com.kino.puber.data.api.models.Posters
+import com.kino.puber.data.api.models.Video
+import com.kino.puber.data.api.models.WatchingInfo
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class HistoryPageResponse(
+    @SerialName("history")
+    val history: List<HistoryEntryResponse>,
+    val pagination: Pagination,
+) {
+    fun toModel(): PaginatedResponse<History> {
+        return PaginatedResponse(
+            items = history
+                .asSequence()
+                .filterNot(HistoryEntryResponse::deleted)
+                .map(HistoryEntryResponse::toModel)
+                .toList(),
+            pagination = pagination,
+        )
+    }
+}
+
+@Serializable
+internal data class HistoryEntryResponse(
+    val counter: Int,
+    @SerialName("first_seen")
+    val firstSeen: Long,
+    val item: HistoryItemResponse,
+    @SerialName("last_seen")
+    val lastSeen: Long,
+    val media: HistoryMediaResponse,
+    val time: Int,
+    val deleted: Boolean = false,
+) {
+    fun toModel(): History {
+        val duration = media.duration.takeIf { it > 0 }
+        val watched = duration?.let { time >= it } == true
+        return History(
+            item = item.toModel(),
+            video = Video(
+                id = media.id,
+                number = media.number.takeIf { it > 0 },
+                duration = duration,
+                watched = watched.toStatus(),
+                watching = WatchingInfo(
+                    time = time.coerceAtLeast(0),
+                    duration = duration ?: 0,
+                    status = watched.toStatus(),
+                    updatedAt = lastSeen.toString(),
+                ),
+            ),
+            season = media.seasonNumber.takeIf { it > 0 },
+            time = time,
+            updated = lastSeen.toString(),
+        )
+    }
+}
+
+@Serializable
+internal data class HistoryItemResponse(
+    val id: Int,
+    val title: String,
+    val type: ItemType,
+    val posters: Posters? = null,
+) {
+    fun toModel(): Item {
+        return Item(
+            id = id,
+            title = title,
+            type = type,
+            posters = posters,
+        )
+    }
+}
+
+@Serializable
+internal data class HistoryMediaResponse(
+    val id: Int,
+    val number: Int,
+    @SerialName("snumber")
+    val seasonNumber: Int,
+    val duration: Int,
+)
+
+private fun Boolean.toStatus(): Int = if (this) 1 else 0

--- a/app/src/main/java/com/kino/puber/data/api/history/HistoryRequest.kt
+++ b/app/src/main/java/com/kino/puber/data/api/history/HistoryRequest.kt
@@ -1,0 +1,34 @@
+package com.kino.puber.data.api.history
+
+internal class HistoryRequest private constructor(
+    val path: String,
+    val query: Map<String, String>,
+    val cacheControl: String,
+) {
+    fun resolveUrl(baseUrl: String): String {
+        require(baseUrl.isNotBlank()) { "History base URL must not be blank" }
+        return "${baseUrl.trimEnd('/')}/${path.trimStart('/')}"
+    }
+
+    companion object {
+        const val NO_STORE_CACHE_CONTROL = "no-store"
+
+        fun page(page: Int): HistoryRequest {
+            require(page > 0) { "History page must be positive" }
+            return HistoryRequest(
+                path = "history",
+                query = mapOf("page" to page.toString()),
+                cacheControl = NO_STORE_CACHE_CONTROL,
+            )
+        }
+
+        fun clearExactMedia(mediaId: Int): HistoryRequest {
+            require(mediaId > 0) { "History media ID must be positive" }
+            return HistoryRequest(
+                path = "history/clear-for-media",
+                query = mapOf("id" to mediaId.toString()),
+                cacheControl = NO_STORE_CACHE_CONTROL,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/kino/puber/data/api/models/Models.kt
+++ b/app/src/main/java/com/kino/puber/data/api/models/Models.kt
@@ -179,9 +179,16 @@ data class Tracklist(
     val url: String? = null,
 )
 
+/**
+ * A normalized server history row.
+ *
+ * [recordId] is present only when an endpoint exposes a verified record identifier. The paginated `/history` endpoint
+ * does not expose one, so its adapter leaves this null. Exact playback semantics come from the item/media coordinates,
+ * while media-level deletion identity comes from [video].
+ */
 @Serializable
 data class History(
-    val id: Int,
+    @SerialName("id") val recordId: Int? = null,
     val item: Item,
     val video: Video? = null,
     val season: Int? = null,

--- a/app/src/main/java/com/kino/puber/data/api/network/CurlLogFormatter.kt
+++ b/app/src/main/java/com/kino/puber/data/api/network/CurlLogFormatter.kt
@@ -1,0 +1,62 @@
+package com.kino.puber.data.api.network
+
+import com.kino.puber.core.logger.SensitiveRequestLogPolicy
+
+internal class CurlLogFormatter(
+    private val policy: SensitiveRequestLogPolicy = SensitiveRequestLogPolicy(),
+) {
+    fun formatRequest(
+        method: String,
+        url: String,
+        headers: List<Pair<String, String>>,
+        textBody: String?,
+    ): List<String> {
+        val safeUrl = policy.sanitizeUrl(url)
+        val curl = buildString {
+            append("curl -X ").append(shellQuote(method))
+            headers.forEach { (name, value) ->
+                val safeValue = policy.sanitizeHeader(name, value)
+                append(" -H ")
+                    .append(shellQuote("$name: $safeValue"))
+            }
+            if (textBody != null) {
+                val safeBody = policy.sanitizeRequestBody(url, textBody)
+                append(" --data-raw ")
+                    .append(shellQuote(safeBody))
+            } else {
+                append(" --data-binary ")
+                    .append(shellQuote("<non-text or unknown body>"))
+            }
+            append(" -- ")
+                .append(shellQuote(safeUrl))
+        }
+        return listOf(
+            "╭--- cURL ($safeUrl)",
+            curl,
+            "╰--- (copy & paste to terminal)",
+        )
+    }
+
+    fun formatResponse(
+        status: String,
+        url: String,
+        headers: List<Pair<String, String>>,
+        body: String,
+    ): List<String> {
+        val safeUrl = policy.sanitizeUrl(url)
+        val safeBody = policy.sanitizeResponseBody(url, body)
+        return buildList {
+            add("<-- $status $safeUrl")
+            headers.forEach { (name, value) ->
+                add("$name: ${policy.sanitizeHeader(name, value)}")
+            }
+            add("")
+            add(safeBody)
+            add("<-- END HTTP (${safeBody.length}-char body)")
+        }
+    }
+
+    private fun shellQuote(value: String): String {
+        return "'${value.replace("'", "'\"'\"'")}'"
+    }
+}

--- a/app/src/main/java/com/kino/puber/data/preferences/NavigationPreferencesRepository.kt
+++ b/app/src/main/java/com/kino/puber/data/preferences/NavigationPreferencesRepository.kt
@@ -18,12 +18,43 @@ class NavigationPreferencesRepository(context: Context) {
     }
 
     fun getVisibleTabs(mode: NavigationMode): List<TabType> {
+        if (mode == NavigationMode.TopTabs) {
+            migrateTopTabsIfNeeded()
+        }
         val key = tabsKeyForMode(mode)
         val stored = prefs.getString(key, null)
         if (stored != null) {
             return deserializeTabs(stored)
         }
         return defaultTabsForMode(mode)
+    }
+
+    private fun migrateTopTabsIfNeeded() {
+        val currentVersion = prefs.getInt(KEY_TOP_TABS_SCHEMA_VERSION, 0)
+        if (currentVersion >= TOP_TABS_SCHEMA_VERSION_HISTORY) return
+
+        val stored = prefs.getString(KEY_TOP_TABS, null)
+        val currentTabs = stored
+            ?.let(::deserializeTabs)
+            ?: resolveTabNames(TOP_TABS_DEFAULT_TAB_NAMES)
+        val normalizedTabs = normalizeTopTabsForHistory(currentTabs)
+        val editor = prefs.edit()
+        editor.putString(KEY_TOP_TABS, serializeTabs(normalizedTabs))
+        editor.putInt(KEY_TOP_TABS_SCHEMA_VERSION, TOP_TABS_SCHEMA_VERSION_HISTORY)
+        editor.apply()
+    }
+
+    private fun normalizeTopTabsForHistory(tabs: List<TabType>): List<TabType> {
+        val normalized = tabs
+            .filterNot { it == TabType.Search || it == TabType.Settings || it == TabType.History }
+            .toMutableList()
+        if (TabType.Home !in normalized) {
+            normalized.add(index = 0, element = TabType.Home)
+        }
+        val collectionsIndex = normalized.indexOf(TabType.Collections)
+        val historyIndex = if (collectionsIndex >= 0) collectionsIndex + 1 else normalized.size
+        normalized.add(index = historyIndex, element = TabType.History)
+        return normalized
     }
 
     fun setVisibleTabs(mode: NavigationMode, tabs: List<TabType>) {
@@ -33,11 +64,10 @@ class NavigationPreferencesRepository(context: Context) {
     }
 
     private fun defaultTabsForMode(mode: NavigationMode): List<TabType> {
-        val names = when (mode) {
-            NavigationMode.SideDrawer -> DRAWER_DEFAULT_TAB_NAMES
-            NavigationMode.TopTabs -> TOP_TABS_DEFAULT_TAB_NAMES
+        return when (mode) {
+            NavigationMode.SideDrawer -> TabType.entries.filter(TabType::enabled)
+            NavigationMode.TopTabs -> resolveTabNames(TOP_TABS_DEFAULT_TAB_NAMES)
         }
-        return resolveTabNames(names)
     }
 
     private fun resolveTabNames(names: List<String>): List<TabType> {
@@ -84,27 +114,16 @@ class NavigationPreferencesRepository(context: Context) {
         const val KEY_NAVIGATION_MODE = "navigation_mode"
         const val KEY_DRAWER_TABS = "drawer_tabs_visible"
         const val KEY_TOP_TABS = "toptabs_tabs_visible"
+        const val KEY_TOP_TABS_SCHEMA_VERSION = "toptabs_schema_version"
+        const val TOP_TABS_SCHEMA_VERSION_HISTORY = 1
         const val SEPARATOR = ","
-
-        val DRAWER_DEFAULT_TAB_NAMES = listOf(
-            "Search",
-            "Favourites",
-            "Movies",
-            "Series",
-            "Cartoons",
-            "For4k",
-            "Concerts",
-            "DocMovies",
-            "DocSeries",
-            "TvShows",
-            "Settings",
-        )
 
         val TOP_TABS_DEFAULT_TAB_NAMES = listOf(
             "Home",
             "Movies",
             "Series",
             "Collections",
+            "History",
         )
     }
 }

--- a/app/src/main/java/com/kino/puber/data/repository/ItemDetailsRepository.kt
+++ b/app/src/main/java/com/kino/puber/data/repository/ItemDetailsRepository.kt
@@ -15,12 +15,12 @@ class ItemDetailsRepository(private val api: KinoPubApiClient) {
     }
 
     suspend fun refresh(id: Int): Item {
-        cache.remove(id)
+        invalidate(id)
         return getItemDetails(id)
     }
 
-    fun invalidate(id: Int) {
-        cache.remove(id)
+    fun invalidate(itemId: Int) {
+        cache.remove(itemId)
     }
 
     fun clear() {

--- a/app/src/main/java/com/kino/puber/data/repository/SkipSegmentService.kt
+++ b/app/src/main/java/com/kino/puber/data/repository/SkipSegmentService.kt
@@ -1,6 +1,5 @@
 package com.kino.puber.data.repository
 
-import com.kino.puber.core.logger.log
 import com.kino.puber.data.api.IntroDbAppApiClient
 import com.kino.puber.data.api.TheIntroDbApiClient
 import com.kino.puber.data.api.TmdbApiClient
@@ -19,18 +18,11 @@ class SkipSegmentService(
             // 1. Try TheIntroDB (needs TMDB ID)
             val theIntroDbResult = tryTheIntroDB(imdbId, season, episode)
             if (theIntroDbResult.isNotEmpty()) {
-                log("SkipSegments: got ${theIntroDbResult.size} from TheIntroDB")
                 return@getOrLoad theIntroDbResult
             }
 
             // 2. Fallback: IntroDB.app (works with IMDb ID directly)
-            val introDbAppResult = introDbAppClient.getSegments(imdbId, season, episode).getOrDefault(emptyList())
-            if (introDbAppResult.isNotEmpty()) {
-                log("SkipSegments: got ${introDbAppResult.size} from IntroDB.app")
-            } else {
-                log("SkipSegments: no data from any source for imdb=$imdbId")
-            }
-            introDbAppResult
+            introDbAppClient.getSegments(imdbId, season, episode).getOrDefault(emptyList())
         }
     }
 
@@ -40,22 +32,13 @@ class SkipSegmentService(
     }
 
     private suspend fun resolveTmdbId(imdbId: String): Int? {
-        tmdbIdRepository.getTmdbId(imdbId)?.let {
-            log("SkipSegments: cached tmdbId=$it for imdb=$imdbId")
-            return it
+        val cachedTmdbId = tmdbIdRepository.getTmdbId(imdbId)
+        if (cachedTmdbId != null) {
+            return cachedTmdbId
         }
-        log("SkipSegments: resolving TMDB ID for imdb=$imdbId via API...")
-        val result = tmdbApiClient.findByImdbId(imdbId)
-        if (result.isFailure) {
-            log("SkipSegments: TMDB API error: ${result.exceptionOrNull()?.message}")
-            return null
+
+        return tmdbApiClient.findByImdbId(imdbId).getOrNull()?.also { tmdbId ->
+            tmdbIdRepository.saveTmdbId(imdbId, tmdbId)
         }
-        val tmdbId = result.getOrNull() ?: run {
-            log("SkipSegments: TMDB returned no match for imdb=$imdbId")
-            return null
-        }
-        log("SkipSegments: resolved tmdbId=$tmdbId for imdb=$imdbId")
-        tmdbIdRepository.saveTmdbId(imdbId, tmdbId)
-        return tmdbId
     }
 }

--- a/app/src/main/java/com/kino/puber/domain/interactor/history/HistoryInteractor.kt
+++ b/app/src/main/java/com/kino/puber/domain/interactor/history/HistoryInteractor.kt
@@ -1,0 +1,110 @@
+package com.kino.puber.domain.interactor.history
+
+import com.kino.puber.core.logger.log
+import com.kino.puber.data.api.KinoPubApiClient
+import com.kino.puber.data.api.models.History
+import com.kino.puber.data.api.models.ItemType
+import com.kino.puber.data.api.models.PaginatedResponse
+import com.kino.puber.data.api.models.isSeriesLike
+import com.kino.puber.data.repository.ItemDetailsRepository
+
+internal class HistoryInteractor(
+    private val api: KinoPubApiClient,
+    private val itemDetailsRepository: ItemDetailsRepository,
+) {
+    suspend fun getPage(page: Int): PaginatedResponse<History> {
+        return api.getHistoryData(page).getOrThrow()
+    }
+
+    suspend fun clearExactMediaHistory(mediaId: Int, itemId: Int) {
+        api.clearExactMediaHistory(mediaId).getOrThrow()
+        itemDetailsRepository.invalidate(itemId)
+    }
+
+    fun invalidateItemDetails(itemId: Int) {
+        itemDetailsRepository.invalidate(itemId)
+    }
+}
+
+internal class HistoryTraversal(
+    seedItems: List<History> = emptyList(),
+) {
+    private val seenRowKeys: MutableSet<HistoryRowKey> =
+        seedItems.mapNotNullTo(mutableSetOf(), History::rowKeyOrNull)
+
+    fun filterFirstOccurrences(items: List<History>): List<History> {
+        return items.filter { history ->
+            history.rowKeyOrNull()
+                ?.let(seenRowKeys::add)
+                ?: run {
+                    log("Skipping a history row without supported media identity")
+                    false
+                }
+        }
+    }
+}
+
+internal sealed interface HistorySemanticKey {
+    data class Movie(
+        val itemId: Int,
+        val videoNumber: Int,
+    ) : HistorySemanticKey
+
+    data class Episode(
+        val itemId: Int,
+        val seasonNumber: Int,
+        val episodeNumber: Int,
+    ) : HistorySemanticKey
+}
+
+internal sealed interface HistoryRowKey {
+    data class Media(
+        val semanticKey: HistorySemanticKey,
+    ) : HistoryRowKey
+
+    data class DeletionMedia(
+        val mediaId: Int,
+    ) : HistoryRowKey
+}
+
+internal fun History.semanticKeyOrNull(): HistorySemanticKey? {
+    val media = video?.takeIf { it.id > 0 }
+    if (media == null || item.id <= 0 || item.type == ItemType.UNKNOWN_VALUE) {
+        return null
+    }
+
+    return if (item.type.isSeriesLike()) {
+        val seasonNumber = season?.takeIf { it > 0 }
+        val episodeNumber = media.number?.takeIf { it > 0 }
+        if (seasonNumber != null && episodeNumber != null) {
+            HistorySemanticKey.Episode(
+                itemId = item.id,
+                seasonNumber = seasonNumber,
+                episodeNumber = episodeNumber,
+            )
+        } else {
+            null
+        }
+    } else {
+        media.number
+            ?.takeIf { it > 0 }
+            ?.let { videoNumber ->
+                HistorySemanticKey.Movie(
+                    itemId = item.id,
+                    videoNumber = videoNumber,
+                )
+            }
+    }
+}
+
+internal fun History.rowKeyOrNull(): HistoryRowKey? {
+    return semanticKeyOrNull()?.let(HistoryRowKey::Media)
+        ?: video
+            ?.id
+            ?.takeIf {
+                it > 0 &&
+                    item.id > 0 &&
+                    item.type.isSeriesLike()
+            }
+            ?.let(HistoryRowKey::DeletionMedia)
+}

--- a/app/src/main/java/com/kino/puber/domain/interactor/player/PlayerInteractor.kt
+++ b/app/src/main/java/com/kino/puber/domain/interactor/player/PlayerInteractor.kt
@@ -54,7 +54,12 @@ internal class PlayerInteractor(
         return itemDetailsRepository.getItemDetails(id)
     }
 
-    fun resolveMedia(item: Item, seasonNumber: Int?, episodeNumber: Int?): ResolvedMedia {
+    fun resolveMedia(
+        item: Item,
+        seasonNumber: Int?,
+        episodeNumber: Int?,
+        videoNumber: Int? = null,
+    ): ResolvedMedia {
         val isSeries = isSeriesType(item.type)
 
         var resolvedSeason = seasonNumber
@@ -87,7 +92,11 @@ internal class PlayerInteractor(
                 episodeNumber = resolvedEpisode,
             )
         } else {
-            val video = item.videos?.firstOrNull()
+            val video = if (videoNumber == null) {
+                item.videos?.firstOrNull()
+            } else {
+                item.videos?.firstOrNull { it.number == videoNumber }
+            }
             ResolvedMedia(
                 files = video?.files,
                 audios = video?.audios,
@@ -97,7 +106,11 @@ internal class PlayerInteractor(
                 videoNumber = video?.number,
                 episodeId = null,
                 episodeTitle = null,
-                isCurrentMediaWatched = isWatched(item.watched),
+                isCurrentMediaWatched = isWatched(
+                    video?.watched
+                        ?: video?.watching?.status
+                        ?: item.watched,
+                ),
                 isSeries = false,
                 hasNext = false,
                 hasPrevious = false,
@@ -236,8 +249,8 @@ internal class PlayerInteractor(
         itemDetailsRepository.invalidate(id)
     }
 
-    suspend fun markCurrentAsWatched(id: Int, season: Int? = null, episode: Int? = null): Item {
-        markAsWatched(id = id, season = season, videoNumber = episode)
+    suspend fun markCurrentAsWatched(id: Int, season: Int? = null, videoNumber: Int? = null): Item {
+        markAsWatched(id = id, season = season, videoNumber = videoNumber)
         return try {
             itemDetailsRepository.getItemDetails(id)
         } catch (error: CancellationException) {

--- a/app/src/main/java/com/kino/puber/domain/interactor/player/SkipSegmentInteractor.kt
+++ b/app/src/main/java/com/kino/puber/domain/interactor/player/SkipSegmentInteractor.kt
@@ -1,6 +1,5 @@
 package com.kino.puber.domain.interactor.player
 
-import com.kino.puber.core.logger.log
 import com.kino.puber.data.api.models.Item
 import com.kino.puber.data.api.models.SkipSegment
 import com.kino.puber.data.api.models.SkipSegmentType
@@ -15,13 +14,9 @@ class SkipSegmentInteractor(
     suspend fun loadSegments(item: Item, season: Int?, episode: Int?): List<SkipSegment> {
         val imdbId = item.imdb
         if (imdbId == null) {
-            log("SkipSegments: item.imdb is null for '${item.title}', skipping")
             return emptyList()
         }
-        log("SkipSegments: loading for imdb=$imdbId, s=$season, e=$episode")
-        val result = service.getSegments(imdbId, season, episode)
-        log("SkipSegments: loaded ${result.size} segments: ${result.map { "${it.type}(${it.startMs}-${it.endMs})" }}")
-        return result
+        return service.getSegments(imdbId, season, episode)
     }
 
     fun findActiveSegment(segments: List<SkipSegment>, positionMs: Long): SkipSegment? {

--- a/app/src/main/java/com/kino/puber/ui/ScreensImpl.kt
+++ b/app/src/main/java/com/kino/puber/ui/ScreensImpl.kt
@@ -14,13 +14,17 @@ import com.kino.puber.ui.feature.auth.component.AuthScreen
 import com.kino.puber.ui.feature.contentlist.ContentListScreen
 import com.kino.puber.ui.feature.details.component.DetailsScreen
 import com.kino.puber.ui.feature.details.model.DetailsScreenParams
+import com.kino.puber.ui.feature.details.model.DetailsEpisodeTarget
 import com.kino.puber.ui.feature.device.settings.flow.DeviceSettingsFlowScreen
 import com.kino.puber.ui.feature.player.component.PlayerScreen
 import com.kino.puber.ui.feature.player.model.PlayerScreenParams
+import com.kino.puber.ui.feature.player.model.PlayerStartMode
 import com.kino.puber.ui.feature.favorites.content.FavoritesScreen
 import com.kino.puber.ui.feature.main.component.MainScreen
 import com.kino.puber.ui.feature.search.SearchScreen
 import com.kino.puber.ui.feature.home.component.HomeScreen
+import com.kino.puber.ui.feature.history.component.HistoryScreen
+import com.kino.puber.ui.feature.history.model.HistoryPresentation
 import com.kino.puber.ui.feature.collections.component.CollectionsScreen
 import com.kino.puber.ui.feature.bookmarks.component.BookmarksScreen
 import com.kino.puber.ui.feature.main.model.TabType
@@ -40,6 +44,10 @@ internal object ScreensImpl : Screens {
     }
 
     override fun home(): PuberScreen = HomeScreen()
+
+    override fun history(presentation: HistoryPresentation): PuberScreen {
+        return HistoryScreen(presentation)
+    }
 
     override fun collections(): PuberScreen = CollectionsScreen()
 
@@ -65,8 +73,31 @@ internal object ScreensImpl : Screens {
         return DetailsScreen(DetailsScreenParams(itemId))
     }
 
-    override fun player(itemId: Int, seasonNumber: Int?, episodeNumber: Int?): PuberScreen {
-        return PlayerScreen(PlayerScreenParams(itemId, seasonNumber, episodeNumber))
+    override fun details(itemId: Int, initialEpisode: DetailsEpisodeTarget): PuberScreen {
+        return DetailsScreen(
+            DetailsScreenParams(
+                itemId = itemId,
+                initialEpisode = initialEpisode,
+            ),
+        )
+    }
+
+    override fun player(
+        itemId: Int,
+        seasonNumber: Int?,
+        episodeNumber: Int?,
+        videoNumber: Int?,
+        startMode: PlayerStartMode,
+    ): PuberScreen {
+        return PlayerScreen(
+            PlayerScreenParams(
+                itemId = itemId,
+                seasonNumber = seasonNumber,
+                episodeNumber = episodeNumber,
+                videoNumber = videoNumber,
+                startMode = startMode,
+            ),
+        )
     }
 
 

--- a/app/src/main/java/com/kino/puber/ui/feature/details/component/DetailsScreen.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/details/component/DetailsScreen.kt
@@ -26,7 +26,16 @@ import org.koin.dsl.module
 internal data class DetailsScreen(private val params: DetailsScreenParams) : RootPuberScreen {
 
     @IgnoredOnParcel
-    override val key: ScreenKey = "DetailsScreen_${params.itemId}"
+    override val key: ScreenKey = buildString {
+        append("DetailsScreen_")
+        append(params.itemId)
+        params.initialEpisode?.let { episode ->
+            append("_s")
+            append(episode.seasonNumber)
+            append("_e")
+            append(episode.episodeNumber)
+        }
+    }
 
     @Suppress("unused")
     private fun buildModule(scopeId: ScopeID, parentScope: Scope) = module {

--- a/app/src/main/java/com/kino/puber/ui/feature/details/component/DetailsScreenContent.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/details/component/DetailsScreenContent.kt
@@ -119,8 +119,8 @@ internal fun DetailsScreenContent(
         is DetailsScreenState.Content -> {
             val seasonsPanelFocusRequester = remember { FocusRequester() }
             var episodeContextMenuItem by remember { mutableStateOf<VideoItemUIState?>(null) }
-            LaunchedEffect(state.seasonsPanelVisible) {
-                if (state.seasonsPanelVisible) {
+            LaunchedEffect(state.seasonsPanelVisible, state.initialEpisodeFocusId) {
+                if (state.seasonsPanelVisible && state.initialEpisodeFocusId == null) {
                     delay(SEASONS_PANEL_FOCUS_DELAY_MS)
                     try {
                         seasonsPanelFocusRequester.requestFocus()
@@ -138,6 +138,7 @@ internal fun DetailsScreenContent(
                     EpisodesPanel(
                         visible = state.seasonsPanelVisible,
                         episodes = state.episodes,
+                        initialFocusedItemId = state.initialEpisodeFocusId,
                         onEpisodeSelected = { item -> onAction(DetailsAction.EpisodeSelected(item)) },
                         onEpisodeContextMenu = { episodeContextMenuItem = it },
                         onBackPressed = { onAction(DetailsAction.CloseSeasonsPanel) },

--- a/app/src/main/java/com/kino/puber/ui/feature/details/model/DetailsScreenParams.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/details/model/DetailsScreenParams.kt
@@ -6,4 +6,11 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 internal class DetailsScreenParams(
     val itemId: Int,
+    val initialEpisode: DetailsEpisodeTarget? = null,
+) : Parcelable
+
+@Parcelize
+data class DetailsEpisodeTarget(
+    val seasonNumber: Int,
+    val episodeNumber: Int,
 ) : Parcelable

--- a/app/src/main/java/com/kino/puber/ui/feature/details/model/DetailsScreenState.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/details/model/DetailsScreenState.kt
@@ -21,6 +21,7 @@ internal sealed class DetailsScreenState {
         val seasonsPanelVisible: Boolean = false,
         val episodes: VideoGridUIState? = null,
         val currentEpisode: VideoItemUIState? = null,
+        val initialEpisodeFocusId: Int? = null,
         val similarItems: List<VideoItemUIState> = emptyList(),
         val trailerUrl: String? = null,
     ) : DetailsScreenState()

--- a/app/src/main/java/com/kino/puber/ui/feature/details/model/DetailsScreenUIMapper.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/details/model/DetailsScreenUIMapper.kt
@@ -23,14 +23,38 @@ internal class DetailsScreenUIMapper(
 ) {
 
     fun map(item: Item, isInWatchlist: Boolean = item.inWatchlist ?: false): DetailsScreenState.Content {
+        return mapContent(item = item, isInWatchlist = isInWatchlist)
+    }
+
+    fun map(
+        item: Item,
+        isInWatchlist: Boolean,
+        initialEpisode: DetailsEpisodeTarget,
+    ): DetailsScreenState.Content {
+        return mapContent(
+            item = item,
+            isInWatchlist = isInWatchlist,
+            initialEpisode = initialEpisode,
+        )
+    }
+
+    private fun mapContent(
+        item: Item,
+        isInWatchlist: Boolean,
+        initialEpisode: DetailsEpisodeTarget? = null,
+    ): DetailsScreenState.Content {
+        val episodes = if (item.type.isSeriesLike()) mapEpisodes(item) else null
+        val requestedEpisode = episodes?.findEpisode(initialEpisode)
         return DetailsScreenState.Content(
             details = itemMapper.mapDetailedItem(item),
             info = buildInfo(item),
             buttons = buildButtons(item),
             isInWatchlist = isInWatchlist,
             isWatched = itemMapper.isItemWatched(item),
-            episodes = if (item.type.isSeriesLike()) mapEpisodes(item) else null,
-            currentEpisode = if (item.type.isSeriesLike()) mapCurrentEpisode(item) else null,
+            episodes = episodes,
+            currentEpisode = requestedEpisode
+                ?: if (item.type.isSeriesLike()) mapCurrentEpisode(item) else null,
+            initialEpisodeFocusId = requestedEpisode?.id,
         )
     }
 
@@ -58,6 +82,18 @@ internal class DetailsScreenUIMapper(
     private fun mapCurrentEpisode(item: Item): VideoItemUIState? {
         val (seasonNumber, episodes, episode) = findFirstUnwatchedEpisode(item) ?: return null
         return mapEpisode(seasonNumber, episodes, episode)
+    }
+
+    private fun VideoGridUIState.findEpisode(target: DetailsEpisodeTarget?): VideoItemUIState? {
+        if (target == null) return null
+        return list
+            .filterIsInstance<VideoGridItemUIState.Items>()
+            .asSequence()
+            .flatMap { it.items.asSequence() }
+            .firstOrNull { item ->
+                item.seasonNumber == target.seasonNumber &&
+                    item.episodeNumber == target.episodeNumber
+            }
     }
 
     private fun mapEpisode(

--- a/app/src/main/java/com/kino/puber/ui/feature/details/vm/DetailsVM.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/details/vm/DetailsVM.kt
@@ -68,7 +68,15 @@ internal class DetailsVM(
                 interactor.getItemDetails(params.itemId)
             }
             currentItem = item
-            updateViewState(mapper.map(item, isInWatchlist = interactor.isInWatchLaterFolder(item)))
+            val mapped = mapDetails(
+                item = item,
+                isInWatchlist = interactor.isInWatchLaterFolder(item),
+            )
+            updateViewState(
+                mapped.copy(
+                    seasonsPanelVisible = mapped.initialEpisodeFocusId != null,
+                ),
+            )
             loadSimilarItems()
         }
     }
@@ -188,7 +196,7 @@ internal class DetailsVM(
         isWatched: Boolean? = null,
     ) {
         val state = stateValue as? DetailsScreenState.Content
-        val mapped = mapper.map(item, isInWatchlist = isInWatchlist)
+        val mapped = mapDetails(item = item, isInWatchlist = isInWatchlist)
         currentItem = item
         updateViewState(
             mapped.copy(
@@ -199,6 +207,19 @@ internal class DetailsVM(
                 trailerUrl = state?.trailerUrl,
             )
         )
+    }
+
+    private fun mapDetails(
+        item: Item,
+        isInWatchlist: Boolean,
+    ): DetailsScreenState.Content {
+        return params.initialEpisode?.let { initialEpisode ->
+            mapper.map(
+                item = item,
+                isInWatchlist = isInWatchlist,
+                initialEpisode = initialEpisode,
+            )
+        } ?: mapper.map(item, isInWatchlist = isInWatchlist)
     }
 
     private fun showTrailer() {

--- a/app/src/main/java/com/kino/puber/ui/feature/history/component/HistoryCard.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/history/component/HistoryCard.kt
@@ -1,0 +1,156 @@
+package com.kino.puber.ui.feature.history.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import com.kino.puber.R
+import com.kino.puber.core.ui.uikit.component.moviesList.VideoItemHorizontal
+import com.kino.puber.core.ui.uikit.component.modifier.LocalContentFocusActive
+import com.kino.puber.domain.interactor.history.HistoryRowKey
+import com.kino.puber.domain.interactor.history.HistorySemanticKey
+import com.kino.puber.ui.feature.history.model.HistoryItemUIState
+import java.util.UUID
+
+internal const val HISTORY_CARD_TEST_TAG_PREFIX = "history_card_"
+private const val OPAQUE_TOKEN_ALPHABET = "abcdefghijklmnop"
+private const val HEX_RADIX = 16
+
+@Composable
+internal fun HistoryCard(
+    state: HistoryItemUIState,
+    requestFocus: Boolean,
+    isDeleting: Boolean,
+    onClick: () -> Unit,
+    onContextMenu: () -> Unit,
+    onFocus: () -> Unit,
+    blockRightFocusExit: Boolean = false,
+    modifier: Modifier = Modifier,
+) {
+    val focusRequester = remember(state.rowKey) { FocusRequester() }
+    val contentFocusActive = LocalContentFocusActive.current
+
+    LaunchedEffect(requestFocus, contentFocusActive) {
+        if (requestFocus && contentFocusActive) {
+            withFrameNanos { }
+            focusRequester.requestFocus()
+        }
+    }
+
+    Box(modifier = modifier) {
+        VideoItemHorizontal(
+            modifier = Modifier
+                .focusRequester(focusRequester)
+                .then(
+                    if (blockRightFocusExit) {
+                        Modifier.focusProperties {
+                            right = FocusRequester.Cancel
+                        }
+                    } else {
+                        Modifier
+                    },
+                )
+                .onFocusChanged { focusState ->
+                    if (focusState.isFocused) {
+                        onFocus()
+                    }
+                }
+                .opaqueHistoryCardTestTag(state.rowKey),
+            state = state.card.copy(
+                isWatched = state.isWatched,
+                showWatchedIndicator = state.isWatched || state.card.showWatchedIndicator,
+            ),
+            onClick = { if (!isDeleting) onClick() },
+            onContextMenu = onContextMenu.takeUnless { isDeleting },
+        )
+
+        HistoryEpisodeMetadata(state)
+        HistoryDeletingOverlay(visible = isDeleting)
+    }
+}
+
+@Composable
+private fun BoxScope.HistoryEpisodeMetadata(state: HistoryItemUIState) {
+    val seasonNumber = state.seasonNumber ?: return
+    val episodeNumber = state.episodeNumber ?: return
+    Text(
+        text = stringResource(
+            R.string.history_episode_metadata,
+            seasonNumber,
+            episodeNumber,
+        ),
+        modifier = Modifier
+            .align(Alignment.TopStart)
+            .padding(8.dp)
+            .background(
+                color = MaterialTheme.colorScheme.scrim.copy(alpha = 0.75f),
+                shape = RoundedCornerShape(4.dp),
+            )
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurface,
+    )
+}
+
+@Composable
+private fun BoxScope.HistoryDeletingOverlay(visible: Boolean) {
+    if (!visible) return
+    Box(
+        modifier = Modifier
+            .matchParentSize()
+            .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.6f))
+            .focusProperties { canFocus = false },
+        contentAlignment = Alignment.Center,
+    ) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun Modifier.opaqueHistoryCardTestTag(rowKey: HistoryRowKey): Modifier {
+    val accessibilityTestTag = rememberSaveable(rowKey) {
+        newHistoryCardTestTag()
+    }
+    return testTag(accessibilityTestTag)
+}
+
+private fun newHistoryCardTestTag(): String {
+    val opaqueToken = UUID.randomUUID()
+        .toString()
+        .asSequence()
+        .filterNot { it == '-' }
+        .map { hexCharacter ->
+            OPAQUE_TOKEN_ALPHABET[hexCharacter.digitToInt(radix = HEX_RADIX)]
+        }
+        .joinToString(separator = "")
+    return HISTORY_CARD_TEST_TAG_PREFIX + opaqueToken
+}
+
+internal fun HistoryRowKey.toHistoryUiKey(): String {
+    return when (this) {
+        is HistoryRowKey.Media -> when (val key = semanticKey) {
+            is HistorySemanticKey.Movie -> "movie_${key.itemId}_${key.videoNumber}"
+            is HistorySemanticKey.Episode ->
+                "episode_${key.itemId}_${key.seasonNumber}_${key.episodeNumber}"
+        }
+        is HistoryRowKey.DeletionMedia -> "deletion_media_$mediaId"
+    }
+}

--- a/app/src/main/java/com/kino/puber/ui/feature/history/component/HistoryContextMenu.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/history/component/HistoryContextMenu.kt
@@ -1,0 +1,96 @@
+package com.kino.puber.ui.feature.history.component
+
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.kino.puber.R
+import com.kino.puber.core.ui.uikit.component.TvContextMenuDialog
+import com.kino.puber.core.ui.uikit.model.TvContextMenuAction
+import com.kino.puber.core.ui.uikit.model.UIAction
+import com.kino.puber.ui.feature.history.model.HistoryAction
+import com.kino.puber.ui.feature.history.model.HistoryItemUIState
+import com.kino.puber.ui.feature.history.model.HistoryPlaybackTarget
+import com.kino.puber.ui.feature.player.model.PlayerStartMode
+
+private const val ACTION_PLAY = "history_play"
+private const val ACTION_DETAILS = "history_details"
+private const val ACTION_DELETE_EXACT_MEDIA = "history_delete_exact_media"
+
+@Composable
+internal fun HistoryContextMenu(
+    item: HistoryItemUIState?,
+    isDeleteExactMediaAvailable: Boolean,
+    onAction: (UIAction) -> Unit,
+) {
+    if (item == null) return
+    val playbackMenuAction = historyPlaybackMenuAction(item)
+    val playbackAction = playbackMenuAction?.let { action ->
+        TvContextMenuAction(
+            id = ACTION_PLAY,
+            title = stringResource(action.titleRes),
+        )
+    }
+
+    TvContextMenuDialog(
+        title = historyContextMenuTitle(item),
+        supportingText = stringResource(R.string.history_context_account_disclosure),
+        actions = listOfNotNull(
+            playbackAction,
+            TvContextMenuAction(
+                id = ACTION_DETAILS,
+                title = stringResource(R.string.context_menu_details),
+            ),
+            TvContextMenuAction(
+                id = ACTION_DELETE_EXACT_MEDIA,
+                title = stringResource(R.string.history_context_delete_exact_media),
+                enabled = isDeleteExactMediaAvailable,
+            ),
+        ),
+        onAction = { action ->
+            when (action.id) {
+                ACTION_PLAY -> playbackMenuAction?.let { playback ->
+                    onAction(HistoryAction.Play(item, playback.startMode))
+                }
+                ACTION_DETAILS -> onAction(HistoryAction.OpenDetails(item))
+                ACTION_DELETE_EXACT_MEDIA -> onAction(HistoryAction.DeleteExactMedia(item))
+            }
+        },
+        onDismiss = { onAction(HistoryAction.DismissContextMenu) },
+    )
+}
+
+internal data class HistoryPlaybackMenuAction(
+    @param:StringRes val titleRes: Int,
+    val startMode: PlayerStartMode,
+)
+
+internal fun historyPlaybackMenuAction(item: HistoryItemUIState): HistoryPlaybackMenuAction? {
+    if (item.playbackTarget == HistoryPlaybackTarget.Details) return null
+    return if (item.progressPercent?.let { it > 0f } == true && !item.isWatched) {
+        HistoryPlaybackMenuAction(
+            titleRes = R.string.history_context_continue,
+            startMode = PlayerStartMode.ResumeIfAvailable,
+        )
+    } else {
+        HistoryPlaybackMenuAction(
+            titleRes = R.string.history_context_play,
+            startMode = PlayerStartMode.StartFromBeginning,
+        )
+    }
+}
+
+@Composable
+private fun historyContextMenuTitle(item: HistoryItemUIState): String {
+    val seasonNumber = item.seasonNumber
+    val episodeNumber = item.episodeNumber
+    return if (seasonNumber != null && episodeNumber != null) {
+        stringResource(
+            R.string.history_context_episode_title,
+            item.card.title,
+            seasonNumber,
+            episodeNumber,
+        )
+    } else {
+        item.card.title
+    }
+}

--- a/app/src/main/java/com/kino/puber/ui/feature/history/component/HistoryScreen.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/history/component/HistoryScreen.kt
@@ -1,0 +1,78 @@
+package com.kino.puber.ui.feature.history.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.lifecycle.Lifecycle
+import cafe.adriel.voyager.core.screen.ScreenKey
+import com.kino.puber.core.di.DIScope
+import com.kino.puber.core.di.puberViewModel
+import com.kino.puber.core.paginator.Paginator
+import com.kino.puber.core.ui.model.VideoItemUIMapper
+import com.kino.puber.core.ui.navigation.PuberScreen
+import com.kino.puber.core.ui.uikit.component.LifecycleAction
+import com.kino.puber.core.ui.uikit.component.ScaffoldMessage
+import com.kino.puber.core.ui.uikit.model.CommonAction
+import com.kino.puber.core.ui.uikit.model.UIAction
+import com.kino.puber.data.api.models.History
+import com.kino.puber.domain.interactor.history.HistoryInteractor
+import com.kino.puber.ui.feature.history.model.HistoryUIMapper
+import com.kino.puber.ui.feature.history.model.HistoryPresentation
+import com.kino.puber.ui.feature.history.vm.HistoryRowComparator
+import com.kino.puber.ui.feature.history.vm.HistoryVM
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
+import org.koin.core.module.dsl.scopedOf
+import org.koin.core.module.dsl.viewModelOf
+import org.koin.core.qualifier.named
+import org.koin.core.scope.Scope
+import org.koin.core.scope.ScopeID
+import org.koin.dsl.module
+
+@Parcelize
+internal class HistoryScreen(
+    internal val presentation: HistoryPresentation,
+) : PuberScreen {
+
+    @IgnoredOnParcel
+    override val key: ScreenKey = when (presentation) {
+        HistoryPresentation.TopTabs -> "HistoryScreen_TopTabs"
+        HistoryPresentation.SideDrawer -> "HistoryScreen_SideDrawer"
+    }
+
+    @Suppress("unused")
+    private fun buildModule(scopeId: ScopeID, parentScope: Scope) = module {
+        scope(named(scopeId)) {
+            scopedOf(::HistoryInteractor)
+            scoped { VideoItemUIMapper(get(), get()) }
+            scopedOf(::HistoryUIMapper)
+            scoped { Paginator.Store<History>(comparator = HistoryRowComparator) }
+            viewModelOf(::HistoryVM)
+        }
+    }
+
+    @Composable
+    override fun Content() = DIScope(scopeName = key, moduleFactory = ::buildModule) {
+        val vm = puberViewModel<HistoryVM>()
+        val state by vm.collectViewState()
+        val onAction: (UIAction) -> Unit = remember(vm) { vm::onAction }
+
+        LifecycleAction(
+            event = Lifecycle.Event.ON_RESUME,
+            onAction = onAction,
+            action = CommonAction.OnResume,
+        )
+
+        HistoryScreenContent(
+            state = state,
+            presentation = presentation,
+            onAction = onAction,
+        )
+
+        val message by vm.collectMessage()
+        ScaffoldMessage(
+            message = message,
+            onAction = onAction,
+        )
+    }
+}

--- a/app/src/main/java/com/kino/puber/ui/feature/history/component/HistoryScreenContent.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/history/component/HistoryScreenContent.kt
@@ -1,0 +1,512 @@
+package com.kino.puber.ui.feature.history.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyGridScope
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.focusRestorer
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
+import androidx.compose.ui.tooling.preview.Devices.TV_1080p
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.Button
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Surface
+import androidx.tv.material3.Text
+import com.adamglin.PhosphorIcons
+import com.adamglin.phosphoricons.Duotone
+import com.adamglin.phosphoricons.duotone.ClockCounterClockwise
+import com.adamglin.phosphoricons.duotone.FilmSlate
+import com.adamglin.phosphoricons.duotone.House
+import com.adamglin.phosphoricons.duotone.Playlist
+import com.adamglin.phosphoricons.duotone.TelevisionSimple
+import com.kino.puber.R
+import com.kino.puber.core.ui.uikit.component.FullScreenError
+import com.kino.puber.core.ui.uikit.component.FullScreenProgressIndicator
+import com.kino.puber.core.ui.uikit.component.ListItemError
+import com.kino.puber.core.ui.uikit.component.modifier.LocalAutoFocusOnLaunchEnabled
+import com.kino.puber.core.ui.uikit.component.modifier.rememberFocusRequesterOnLaunch
+import com.kino.puber.core.ui.uikit.component.modifier.placeholder
+import com.kino.puber.core.ui.uikit.model.CommonAction
+import com.kino.puber.core.ui.uikit.model.UIAction
+import com.kino.puber.core.ui.uikit.theme.PuberTheme
+import com.kino.puber.domain.interactor.history.HistoryRowKey
+import com.kino.puber.ui.feature.history.component.preview.HistoryScreenPreviewProvider
+import com.kino.puber.ui.feature.history.model.HistoryAction
+import com.kino.puber.ui.feature.history.model.HistoryItemUIState
+import com.kino.puber.ui.feature.history.model.HistoryPresentation
+import com.kino.puber.ui.feature.history.model.HistoryViewState
+import com.kino.puber.ui.feature.main.model.MainTab
+import com.kino.puber.ui.feature.main.model.TabType
+import com.kino.puber.ui.feature.main.toptabs.TopTabBar
+
+internal const val HISTORY_REFRESH_TEST_TAG = "history_refresh_action"
+internal const val HISTORY_FINAL_PAGE_TEST_TAG = "history_final_page"
+internal const val HISTORY_REFRESH_INDICATOR_TEST_TAG = "history_refresh_indicator"
+internal const val HISTORY_NEXT_PAGE_SKELETON_TEST_TAG = "history_next_page_skeleton"
+internal const val HISTORY_NEXT_PAGE_SKELETON_CARD_TEST_TAG_PREFIX =
+    "history_next_page_skeleton_card_"
+
+private const val GRID_COLUMNS = 3
+private const val LOAD_MORE_THRESHOLD = GRID_COLUMNS * 2
+private const val LOADING_MORE_KEY = "history_loading_more"
+private const val NEXT_PAGE_ERROR_KEY = "history_next_page_error"
+private const val RELOAD_ERROR_KEY = "history_reload_error"
+private val REFRESH_INDICATOR_HEIGHT = 4.dp
+
+@Composable
+internal fun HistoryScreenContent(
+    state: HistoryViewState,
+    presentation: HistoryPresentation,
+    onAction: (UIAction) -> Unit,
+) {
+    var previousStateWasContent by remember { mutableStateOf(state is HistoryViewState.Content) }
+    var refreshFocusRequest by remember { mutableIntStateOf(0) }
+
+    LaunchedEffect(state) {
+        if (state is HistoryViewState.Empty && previousStateWasContent) {
+            refreshFocusRequest++
+        }
+        previousStateWasContent = state is HistoryViewState.Content
+    }
+
+    Surface(modifier = Modifier.fillMaxSize()) {
+        when (state) {
+            HistoryViewState.Loading -> FullScreenProgressIndicator()
+            HistoryViewState.Empty -> HistoryEmptyState(
+                focusRequest = refreshFocusRequest,
+                onRefresh = { onAction(CommonAction.RetryClicked) },
+            )
+            is HistoryViewState.Error -> FullScreenError(
+                error = state.message,
+                onClick = { onAction(CommonAction.RetryClicked) },
+            )
+            is HistoryViewState.Content -> when {
+                state.items.isNotEmpty() -> HistoryContent(
+                    state = state,
+                    presentation = presentation,
+                    onAction = onAction,
+                )
+                state.reloadErrorMessage != null -> FullScreenError(
+                    error = state.reloadErrorMessage,
+                    onClick = { onAction(HistoryAction.RetryReconciliation) },
+                )
+                else -> FullScreenProgressIndicator()
+            }
+        }
+    }
+}
+
+@Composable
+private fun HistoryContent(
+    state: HistoryViewState.Content,
+    presentation: HistoryPresentation,
+    onAction: (UIAction) -> Unit,
+) {
+    val gridState = rememberLazyGridState()
+    val gridFocusRequester = rememberFocusRequesterOnLaunch()
+    val focusedUiKey = state.focusKey?.toHistoryUiKey()
+    val menuUiKey = state.openMenuKey?.toHistoryUiKey()
+    val isPaginationIdle = !state.isRefreshing && !state.isLoadingMore
+    val isPaginationDefinitivelyExhausted = !state.hasMorePages &&
+        isPaginationIdle &&
+        state.nextPageErrorMessage == null &&
+        state.reloadErrorMessage == null
+    val finalPageMarkerModifier = if (isPaginationDefinitivelyExhausted) {
+        Modifier.testTag(HISTORY_FINAL_PAGE_TEST_TAG)
+    } else {
+        Modifier
+    }
+
+    HistoryGridEffects(
+        state = state,
+        gridState = gridState,
+        focusedUiKey = focusedUiKey,
+        menuUiKey = menuUiKey,
+        onAction = onAction,
+    )
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .semantics { testTagsAsResourceId = true }
+            .then(finalPageMarkerModifier),
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            when (presentation) {
+                HistoryPresentation.TopTabs -> Unit
+                HistoryPresentation.SideDrawer -> HistoryHeader()
+            }
+            HistoryRefreshIndicator(isRefreshing = state.isRefreshing)
+            HistoryGrid(
+                state = state,
+                gridState = gridState,
+                focusedUiKey = focusedUiKey,
+                menuUiKey = menuUiKey,
+                gridFocusModifier = Modifier.focusRequester(gridFocusRequester),
+                onAction = onAction,
+            )
+        }
+        HistoryContextMenu(
+            item = state.openMenuKey?.let { key ->
+                state.items.firstOrNull { it.rowKey == key }
+            },
+            isDeleteExactMediaAvailable = state.isDeleteExactMediaAvailable,
+            onAction = onAction,
+        )
+    }
+}
+
+@Composable
+private fun HistoryGridEffects(
+    state: HistoryViewState.Content,
+    gridState: LazyGridState,
+    focusedUiKey: String?,
+    menuUiKey: String?,
+    onAction: (UIAction) -> Unit,
+) {
+    val isNearEnd by remember(state.items.size) {
+        derivedStateOf {
+            if (state.items.isEmpty()) {
+                return@derivedStateOf false
+            }
+            val lastVisibleIndex = gridState.layoutInfo.visibleItemsInfo.lastOrNull()?.index
+                ?: return@derivedStateOf false
+            lastVisibleIndex >= state.items.lastIndex - LOAD_MORE_THRESHOLD
+        }
+    }
+
+    LaunchedEffect(
+        isNearEnd,
+        state.items.size,
+        state.isRefreshing,
+        state.isLoadingMore,
+        state.hasMorePages,
+        state.pageAttemptRevision,
+        state.nextPageErrorMessage,
+    ) {
+        val pagingIsIdle = !state.isRefreshing && !state.isLoadingMore
+        val canLoadMore = pagingIsIdle &&
+            state.hasMorePages &&
+            state.nextPageErrorMessage == null
+        if (isNearEnd && canLoadMore) {
+            onAction(CommonAction.LoadMore)
+        }
+    }
+
+    LaunchedEffect(focusedUiKey, menuUiKey) {
+        if (focusedUiKey != null && menuUiKey == null) {
+            val targetIndex = state.items.indexOfFirst {
+                it.rowKey.toHistoryUiKey() == focusedUiKey
+            }
+            val targetIsVisible = gridState.layoutInfo.visibleItemsInfo.any {
+                it.index == targetIndex
+            }
+            if (targetIndex >= 0 && !targetIsVisible) {
+                gridState.scrollToItem(targetIndex)
+            }
+        }
+    }
+}
+
+@Composable
+private fun HistoryHeader() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = stringResource(R.string.history_title),
+            style = MaterialTheme.typography.headlineMedium,
+        )
+    }
+}
+
+@Composable
+private fun HistoryRefreshIndicator(isRefreshing: Boolean) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(REFRESH_INDICATOR_HEIGHT)
+            .focusProperties { canFocus = false },
+        contentAlignment = Alignment.Center,
+    ) {
+        if (isRefreshing) {
+            LinearProgressIndicator(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .testTag(HISTORY_REFRESH_INDICATOR_TEST_TAG),
+            )
+        }
+    }
+}
+
+@Composable
+private fun HistoryGrid(
+    state: HistoryViewState.Content,
+    gridState: LazyGridState,
+    focusedUiKey: String?,
+    menuUiKey: String?,
+    gridFocusModifier: Modifier,
+    onAction: (UIAction) -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(GRID_COLUMNS),
+            state = gridState,
+            modifier = gridFocusModifier
+                .fillMaxSize()
+                .focusRestorer(),
+            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalArrangement = Arrangement.spacedBy(32.dp),
+        ) {
+            itemsIndexed(
+                items = state.items,
+                key = { _, item -> item.rowKey.toHistoryUiKey() },
+            ) { index, item ->
+                HistoryGridCard(
+                    state = item,
+                    blockRightFocusExit =
+                        index % GRID_COLUMNS == GRID_COLUMNS - 1 ||
+                            index == state.items.lastIndex,
+                    focusedUiKey = focusedUiKey,
+                    menuUiKey = menuUiKey,
+                    deletingKeys = state.deletingKeys,
+                    onAction = onAction,
+                )
+            }
+
+            historyStatusItems(state = state, onAction = onAction)
+        }
+    }
+}
+
+@Composable
+private fun HistoryGridCard(
+    state: HistoryItemUIState,
+    blockRightFocusExit: Boolean,
+    focusedUiKey: String?,
+    menuUiKey: String?,
+    deletingKeys: Set<HistoryRowKey>,
+    onAction: (UIAction) -> Unit,
+) {
+    val itemUiKey = state.rowKey.toHistoryUiKey()
+    val onClick = remember(state, onAction) {
+        { onAction(CommonAction.ItemSelected(state)) }
+    }
+    val onContextMenu = remember(state, onAction) {
+        { onAction(HistoryAction.OpenContextMenu(state)) }
+    }
+    val onFocus = remember(state, onAction) {
+        { onAction(CommonAction.ItemFocused(state)) }
+    }
+    HistoryCard(
+        state = state,
+        requestFocus = focusedUiKey == itemUiKey && menuUiKey == null,
+        isDeleting = state.rowKey in deletingKeys,
+        blockRightFocusExit = blockRightFocusExit,
+        onClick = onClick,
+        onContextMenu = onContextMenu,
+        onFocus = onFocus,
+    )
+}
+
+private fun LazyGridScope.historyStatusItems(
+    state: HistoryViewState.Content,
+    onAction: (UIAction) -> Unit,
+) {
+    if (state.reloadErrorMessage != null) {
+        item(
+            key = RELOAD_ERROR_KEY,
+            span = { GridItemSpan(maxLineSpan) },
+        ) {
+            ListItemError(
+                error = state.reloadErrorMessage,
+                onClick = { onAction(HistoryAction.RetryReconciliation) },
+            )
+        }
+    }
+
+    if (state.nextPageErrorMessage != null) {
+        item(
+            key = NEXT_PAGE_ERROR_KEY,
+            span = { GridItemSpan(maxLineSpan) },
+        ) {
+            ListItemError(
+                error = state.nextPageErrorMessage,
+                onClick = { onAction(CommonAction.ReloadNextPage) },
+            )
+        }
+    }
+
+    if (state.isLoadingMore) {
+        item(
+            key = LOADING_MORE_KEY,
+            span = { GridItemSpan(maxLineSpan) },
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(HISTORY_NEXT_PAGE_SKELETON_TEST_TAG)
+                    .focusProperties { canFocus = false },
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                repeat(GRID_COLUMNS) { index ->
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(PuberTheme.Defaults.HorizontalVideoItemHeight)
+                            .testTag(
+                                HISTORY_NEXT_PAGE_SKELETON_CARD_TEST_TAG_PREFIX + index,
+                            )
+                            .placeholder(visible = true),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HistoryEmptyState(
+    focusRequest: Int,
+    onRefresh: () -> Unit,
+) {
+    val refreshFocusRequester = rememberFocusRequesterOnLaunch()
+
+    LaunchedEffect(focusRequest) {
+        if (focusRequest > 0) {
+            refreshFocusRequester.requestFocus()
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = stringResource(R.string.history_empty_title),
+            style = MaterialTheme.typography.headlineSmall,
+        )
+        Spacer(Modifier.height(12.dp))
+        Text(
+            text = stringResource(R.string.history_empty_description),
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        Spacer(Modifier.height(32.dp))
+        Button(
+            onClick = onRefresh,
+            modifier = Modifier
+                .focusRequester(refreshFocusRequester)
+                .testTag(HISTORY_REFRESH_TEST_TAG),
+        ) {
+            Text(stringResource(R.string.history_refresh))
+        }
+    }
+}
+
+@Preview(
+    name = "History — TopTabs states",
+    device = TV_1080p,
+)
+@Composable
+private fun HistoryScreenContentPreview(
+    @PreviewParameter(HistoryScreenPreviewProvider::class) state: HistoryViewState,
+) = PuberTheme {
+    HistoryTopTabsPreviewHost(state)
+}
+
+@Composable
+private fun HistoryTopTabsPreviewHost(state: HistoryViewState) {
+    val tabs = listOf(
+        MainTab(
+            type = TabType.Home,
+            label = stringResource(R.string.main_tabs_home),
+            icon = PhosphorIcons.Duotone.House,
+        ),
+        MainTab(
+            type = TabType.Movies,
+            label = stringResource(R.string.main_tabs_movies),
+            icon = PhosphorIcons.Duotone.FilmSlate,
+        ),
+        MainTab(
+            type = TabType.Series,
+            label = stringResource(R.string.main_tabs_series),
+            icon = PhosphorIcons.Duotone.TelevisionSimple,
+        ),
+        MainTab(
+            type = TabType.Collections,
+            label = stringResource(R.string.main_tabs_collections),
+            icon = PhosphorIcons.Duotone.Playlist,
+        ),
+        MainTab(
+            type = TabType.History,
+            label = stringResource(R.string.main_tabs_history),
+            icon = PhosphorIcons.Duotone.ClockCounterClockwise,
+            isSelected = true,
+        ),
+    )
+    val tabFocusRequesters = remember { List(tabs.size) { FocusRequester() } }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        TopTabBar(
+            tabs = tabs,
+            selectedIndex = tabs.lastIndex,
+            tabFocusRequesters = tabFocusRequesters,
+            onContentFocusRequested = {},
+            onTabFocused = {},
+            onTabClick = {},
+            onTabContextMenu = {},
+            onSearchClick = {},
+            onSettingsClick = {},
+        )
+        Box(modifier = Modifier.weight(1f)) {
+            CompositionLocalProvider(LocalAutoFocusOnLaunchEnabled provides false) {
+                HistoryScreenContent(
+                    state = state,
+                    presentation = HistoryPresentation.TopTabs,
+                    onAction = {},
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/kino/puber/ui/feature/history/component/preview/HistoryScreenPreviewProvider.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/history/component/preview/HistoryScreenPreviewProvider.kt
@@ -1,0 +1,155 @@
+package com.kino.puber.ui.feature.history.component.preview
+
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.kino.puber.core.ui.uikit.component.moviesList.VideoItemUIState
+import com.kino.puber.domain.interactor.history.HistoryRowKey
+import com.kino.puber.domain.interactor.history.HistorySemanticKey
+import com.kino.puber.ui.feature.history.model.HistoryItemUIState
+import com.kino.puber.ui.feature.history.model.HistoryPlaybackTarget
+import com.kino.puber.ui.feature.history.model.HistoryViewState
+
+private val movieKey = HistorySemanticKey.Movie(itemId = 101, videoNumber = 2)
+private val episodeKey = HistorySemanticKey.Episode(
+    itemId = 202,
+    seasonNumber = 2,
+    episodeNumber = 5,
+)
+private val completedKey = HistorySemanticKey.Movie(itemId = 303, videoNumber = 1)
+private val longTitleKey = HistorySemanticKey.Movie(itemId = 505, videoNumber = 1)
+
+internal class HistoryScreenPreviewProvider : PreviewParameterProvider<HistoryViewState> {
+    override val values: Sequence<HistoryViewState> = sequenceOf(
+        HistoryViewState.Loading,
+        contentState(),
+        contextMenuState(),
+        deletionPendingState(),
+        HistoryViewState.Empty,
+        HistoryViewState.Error("Не удалось загрузить историю просмотров"),
+    )
+}
+
+private fun contextMenuState(): HistoryViewState.Content {
+    val rowKey = HistoryRowKey.Media(movieKey)
+    return contentState().copy(
+        isLoadingMore = false,
+        openMenuKey = rowKey,
+        focusKey = rowKey,
+    )
+}
+
+private fun deletionPendingState(): HistoryViewState.Content {
+    val rowKey = HistoryRowKey.Media(movieKey)
+    return contentState().copy(
+        isLoadingMore = false,
+        deletingKeys = setOf(rowKey),
+        focusKey = rowKey,
+    )
+}
+
+private fun contentState(): HistoryViewState.Content {
+    return HistoryViewState.Content(
+        items = listOf(
+            moviePreviewItem(),
+            episodePreviewItem(),
+            completedPreviewItem(),
+            incompleteSeriesPreviewItem(),
+            longTitlePreviewItem(),
+        ),
+        isLoadingMore = true,
+        focusKey = HistoryRowKey.Media(movieKey),
+    )
+}
+
+private fun moviePreviewItem() = previewItem(
+    itemId = 101,
+    deletionMediaId = 1001,
+    rowKey = HistoryRowKey.Media(movieKey),
+    semanticKey = movieKey,
+    title = "Дюна: Часть вторая",
+    progressPercent = 0.73f,
+    playbackTarget = HistoryPlaybackTarget.Movie(videoNumber = 2),
+)
+
+private fun episodePreviewItem() = previewItem(
+    itemId = 202,
+    deletionMediaId = 2001,
+    rowKey = HistoryRowKey.Media(episodeKey),
+    semanticKey = episodeKey,
+    title = "Разделение",
+    progressPercent = 0.31f,
+    seasonNumber = 2,
+    episodeNumber = 5,
+    playbackTarget = HistoryPlaybackTarget.Episode(
+        seasonNumber = 2,
+        episodeNumber = 5,
+    ),
+)
+
+private fun completedPreviewItem() = previewItem(
+    itemId = 303,
+    deletionMediaId = 3001,
+    rowKey = HistoryRowKey.Media(completedKey),
+    semanticKey = completedKey,
+    title = "Интерстеллар",
+    isWatched = true,
+    playbackTarget = HistoryPlaybackTarget.Movie(videoNumber = 1),
+)
+
+private fun incompleteSeriesPreviewItem() = previewItem(
+    itemId = 404,
+    deletionMediaId = 4001,
+    rowKey = HistoryRowKey.DeletionMedia(mediaId = 4001),
+    semanticKey = null,
+    title = "Сериал с неполными координатами эпизода",
+    progressPercent = 0.18f,
+    playbackTarget = HistoryPlaybackTarget.Details,
+)
+
+private fun longTitlePreviewItem() = previewItem(
+    itemId = 505,
+    deletionMediaId = 5001,
+    rowKey = HistoryRowKey.Media(longTitleKey),
+    semanticKey = longTitleKey,
+    title = "Очень длинное название фильма без доступного изображения для проверки карточки",
+    progressPercent = 0.52f,
+    playbackTarget = HistoryPlaybackTarget.Movie(videoNumber = 1),
+)
+
+private fun previewItem(
+    itemId: Int,
+    deletionMediaId: Int,
+    rowKey: HistoryRowKey,
+    semanticKey: HistorySemanticKey?,
+    title: String,
+    progressPercent: Float? = null,
+    isWatched: Boolean = false,
+    seasonNumber: Int? = null,
+    episodeNumber: Int? = null,
+    playbackTarget: HistoryPlaybackTarget,
+): HistoryItemUIState {
+    return HistoryItemUIState(
+        itemId = itemId,
+        deletionMediaId = deletionMediaId,
+        rowKey = rowKey,
+        semanticKey = semanticKey,
+        videoNumber = (playbackTarget as? HistoryPlaybackTarget.Movie)?.videoNumber,
+        seasonNumber = seasonNumber,
+        episodeNumber = episodeNumber,
+        progressPercent = progressPercent,
+        isWatched = isWatched,
+        lastViewedAt = "2099-07-23T12:00:00Z",
+        playbackTarget = playbackTarget,
+        card = VideoItemUIState(
+            id = itemId,
+            title = title,
+            imageUrl = "",
+            bigImageUrl = "",
+            wideImageUrl = "",
+            showTitle = true,
+            progressPercent = progressPercent,
+            isWatched = isWatched,
+            seasonNumber = seasonNumber,
+            episodeNumber = episodeNumber,
+        ),
+    )
+}

--- a/app/src/main/java/com/kino/puber/ui/feature/history/model/HistoryAction.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/history/model/HistoryAction.kt
@@ -1,0 +1,27 @@
+package com.kino.puber.ui.feature.history.model
+
+import com.kino.puber.core.ui.uikit.model.UIAction
+import com.kino.puber.ui.feature.player.model.PlayerStartMode
+
+internal sealed interface HistoryAction : UIAction {
+    data class OpenContextMenu(
+        val item: HistoryItemUIState,
+    ) : HistoryAction
+
+    data object DismissContextMenu : HistoryAction
+
+    data class Play(
+        val item: HistoryItemUIState,
+        val startMode: PlayerStartMode,
+    ) : HistoryAction
+
+    data class OpenDetails(
+        val item: HistoryItemUIState,
+    ) : HistoryAction
+
+    data class DeleteExactMedia(
+        val item: HistoryItemUIState,
+    ) : HistoryAction
+
+    data object RetryReconciliation : HistoryAction
+}

--- a/app/src/main/java/com/kino/puber/ui/feature/history/model/HistoryItemUIState.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/history/model/HistoryItemUIState.kt
@@ -1,0 +1,36 @@
+package com.kino.puber.ui.feature.history.model
+
+import androidx.compose.runtime.Immutable
+import com.kino.puber.core.ui.uikit.component.moviesList.VideoItemUIState
+import com.kino.puber.domain.interactor.history.HistoryRowKey
+import com.kino.puber.domain.interactor.history.HistorySemanticKey
+
+@Immutable
+internal data class HistoryItemUIState(
+    val itemId: Int,
+    val deletionMediaId: Int,
+    val rowKey: HistoryRowKey,
+    val semanticKey: HistorySemanticKey?,
+    val videoNumber: Int?,
+    val seasonNumber: Int?,
+    val episodeNumber: Int?,
+    val progressPercent: Float?,
+    val isWatched: Boolean,
+    val lastViewedAt: String?,
+    val playbackTarget: HistoryPlaybackTarget,
+    val card: VideoItemUIState,
+)
+
+@Immutable
+internal sealed interface HistoryPlaybackTarget {
+    data class Movie(
+        val videoNumber: Int,
+    ) : HistoryPlaybackTarget
+
+    data class Episode(
+        val seasonNumber: Int,
+        val episodeNumber: Int,
+    ) : HistoryPlaybackTarget
+
+    data object Details : HistoryPlaybackTarget
+}

--- a/app/src/main/java/com/kino/puber/ui/feature/history/model/HistoryPresentation.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/history/model/HistoryPresentation.kt
@@ -1,0 +1,6 @@
+package com.kino.puber.ui.feature.history.model
+
+enum class HistoryPresentation {
+    TopTabs,
+    SideDrawer,
+}

--- a/app/src/main/java/com/kino/puber/ui/feature/history/model/HistoryUIMapper.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/history/model/HistoryUIMapper.kt
@@ -1,0 +1,72 @@
+package com.kino.puber.ui.feature.history.model
+
+import com.kino.puber.core.ui.model.VideoItemUIMapper
+import com.kino.puber.data.api.models.History
+import com.kino.puber.domain.interactor.history.HistoryRowKey
+import com.kino.puber.domain.interactor.history.HistorySemanticKey
+import com.kino.puber.domain.interactor.history.rowKeyOrNull
+import com.kino.puber.domain.interactor.history.semanticKeyOrNull
+
+internal class HistoryUIMapper(
+    private val videoItemUIMapper: VideoItemUIMapper,
+) {
+    fun map(items: List<History>): List<HistoryItemUIState> {
+        return items.mapNotNull(::map)
+    }
+
+    fun map(history: History): HistoryItemUIState? {
+        val media = history.video ?: return null
+        val rowKey = history.rowKeyOrNull() ?: return null
+        val semanticKey = history.semanticKeyOrNull()
+        val playbackTarget = semanticKey?.toPlaybackTarget() ?: HistoryPlaybackTarget.Details
+        val progressPercent = media.watching?.let { watching ->
+            watching.duration
+                .takeIf { it > 0 }
+                ?.let { duration -> watching.time.toFloat() / duration.toFloat() }
+        }
+        val isWatched = media.watched?.let { it == WATCHED_STATUS }
+            ?: (media.watching?.status == WATCHED_STATUS)
+        val seasonNumber = (semanticKey as? HistorySemanticKey.Episode)?.seasonNumber
+        val episodeNumber = (semanticKey as? HistorySemanticKey.Episode)?.episodeNumber
+        val videoNumber = (semanticKey as? HistorySemanticKey.Movie)?.videoNumber
+        val sharedCard = videoItemUIMapper.mapShortItem(history.item)
+        val card = sharedCard.copy(
+            unwatchedCount = null,
+            ratings = emptyList(),
+            progressPercent = progressPercent,
+            isWatched = isWatched,
+            showWatchedIndicator = isWatched || sharedCard.showWatchedIndicator,
+            seasonNumber = seasonNumber,
+            episodeNumber = episodeNumber,
+        )
+
+        return HistoryItemUIState(
+            itemId = history.item.id,
+            deletionMediaId = media.id,
+            rowKey = rowKey,
+            semanticKey = semanticKey,
+            videoNumber = videoNumber,
+            seasonNumber = seasonNumber,
+            episodeNumber = episodeNumber,
+            progressPercent = progressPercent,
+            isWatched = isWatched,
+            lastViewedAt = history.updated,
+            playbackTarget = playbackTarget,
+            card = card,
+        )
+    }
+
+    private fun HistorySemanticKey.toPlaybackTarget(): HistoryPlaybackTarget {
+        return when (this) {
+            is HistorySemanticKey.Movie -> HistoryPlaybackTarget.Movie(videoNumber)
+            is HistorySemanticKey.Episode -> HistoryPlaybackTarget.Episode(
+                seasonNumber = seasonNumber,
+                episodeNumber = episodeNumber,
+            )
+        }
+    }
+
+    private companion object {
+        const val WATCHED_STATUS = 1
+    }
+}

--- a/app/src/main/java/com/kino/puber/ui/feature/history/model/HistoryViewState.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/history/model/HistoryViewState.kt
@@ -1,0 +1,29 @@
+package com.kino.puber.ui.feature.history.model
+
+import androidx.compose.runtime.Immutable
+import com.kino.puber.domain.interactor.history.HistoryRowKey
+
+@Immutable
+internal sealed class HistoryViewState {
+    data object Loading : HistoryViewState()
+
+    data object Empty : HistoryViewState()
+
+    data class Error(
+        val message: String,
+    ) : HistoryViewState()
+
+    data class Content(
+        val items: List<HistoryItemUIState>,
+        val isRefreshing: Boolean = false,
+        val isLoadingMore: Boolean = false,
+        val hasMorePages: Boolean = false,
+        val pageAttemptRevision: Long = 0L,
+        val nextPageErrorMessage: String? = null,
+        val isDeleteExactMediaAvailable: Boolean = true,
+        val openMenuKey: HistoryRowKey? = null,
+        val deletingKeys: Set<HistoryRowKey> = emptySet(),
+        val focusKey: HistoryRowKey? = null,
+        val reloadErrorMessage: String? = null,
+    ) : HistoryViewState()
+}

--- a/app/src/main/java/com/kino/puber/ui/feature/history/vm/HistoryContentPublication.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/history/vm/HistoryContentPublication.kt
@@ -1,0 +1,39 @@
+package com.kino.puber.ui.feature.history.vm
+
+import com.kino.puber.domain.interactor.history.HistoryRowKey
+import com.kino.puber.ui.feature.history.model.HistoryItemUIState
+import com.kino.puber.ui.feature.history.model.HistoryViewState
+
+internal fun HistoryRuntimeState.toContentViewState(
+    items: List<HistoryItemUIState>,
+    availableKeys: Set<HistoryRowKey>,
+    isRefreshing: Boolean,
+    isLoadingMore: Boolean,
+): HistoryViewState.Content {
+    val deletingKeys = (operation as? HistoryOperation.Deleting)
+        ?.item
+        ?.rowKey
+        ?.takeIf(availableKeys::contains)
+        ?.let(::setOf)
+        .orEmpty()
+    val focusKey = (requestedFocusKey ?: focusedKey)
+        ?.takeIf(availableKeys::contains)
+    val operationIsRefreshing = operation is HistoryOperation.RefreshRequested ||
+        operation is HistoryOperation.LoadingFirstPage && operation.retainsContent
+    val reloadErrorMessage =
+        (operation as? HistoryOperation.ReconciliationFailed)?.message
+    return HistoryViewState.Content(
+        items = items,
+        isRefreshing = isRefreshing || operationIsRefreshing,
+        isLoadingMore = isLoadingMore,
+        hasMorePages = !isFullDataNext,
+        pageAttemptRevision = pageAttemptRevision,
+        nextPageErrorMessage = nextPageErrorMessage,
+        isDeleteExactMediaAvailable =
+            operation == HistoryOperation.Idle && queuedDeletion == null,
+        openMenuKey = openMenuKey,
+        deletingKeys = deletingKeys,
+        focusKey = focusKey,
+        reloadErrorMessage = reloadErrorMessage,
+    )
+}

--- a/app/src/main/java/com/kino/puber/ui/feature/history/vm/HistoryInputGuard.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/history/vm/HistoryInputGuard.kt
@@ -1,0 +1,13 @@
+package com.kino.puber.ui.feature.history.vm
+
+import com.kino.puber.core.ui.uikit.model.CommonAction
+import com.kino.puber.core.ui.uikit.model.UIAction
+import com.kino.puber.ui.feature.history.model.HistoryAction
+
+internal fun UIAction.isBlockedDuringDeletionFlow(): Boolean {
+    return this is CommonAction.ItemSelected<*> ||
+        this is HistoryAction.OpenContextMenu ||
+        this is HistoryAction.Play ||
+        this is HistoryAction.OpenDetails ||
+        this is HistoryAction.DeleteExactMedia
+}

--- a/app/src/main/java/com/kino/puber/ui/feature/history/vm/HistoryRuntimeState.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/history/vm/HistoryRuntimeState.kt
@@ -1,0 +1,573 @@
+package com.kino.puber.ui.feature.history.vm
+
+import com.kino.puber.data.api.models.History
+import com.kino.puber.domain.interactor.history.HistoryRowKey
+import com.kino.puber.ui.feature.history.model.HistoryItemUIState
+
+internal data class HistoryRuntimeState(
+    val currentPage: Int = 0,
+    val isFullDataNext: Boolean = false,
+    val hasCompletedInitialLoad: Boolean = false,
+    val stableHistory: List<History> = emptyList(),
+    val operation: HistoryOperation = HistoryOperation.Idle,
+    val focusedKey: HistoryRowKey? = null,
+    val requestedFocusKey: HistoryRowKey? = null,
+    val openMenuKey: HistoryRowKey? = null,
+    val queuedDeletion: HistoryQueuedDeletion? = null,
+    val refreshAfterPendingOperation: Boolean = false,
+    val nextPageErrorMessage: String? = null,
+    val pageAttemptRevision: Long = 0L,
+    val operationSequence: Long = 0L,
+) {
+    fun nextOperationId(): Long = operationSequence + 1L
+}
+
+internal sealed interface HistoryOperation {
+    data object Idle : HistoryOperation
+
+    data class RefreshRequested(
+        val operationId: Long,
+    ) : HistoryOperation
+
+    data class RestartRequested(
+        val operationId: Long,
+    ) : HistoryOperation
+
+    data class LoadingFirstPage(
+        val operationId: Long,
+        val retainsContent: Boolean,
+    ) : HistoryOperation
+
+    data class LoadingNextPage(
+        val operationId: Long,
+    ) : HistoryOperation
+
+    data class Deleting(
+        val operationId: Long,
+        val item: HistoryItemUIState,
+        val reconciliation: HistoryReconciliationContext,
+    ) : HistoryOperation
+
+    data class Reconciling(
+        val operationId: Long,
+        val reconciliation: HistoryReconciliationContext,
+    ) : HistoryOperation
+
+    data class ReconciliationFailed(
+        val reconciliation: HistoryReconciliationContext,
+        val message: String,
+    ) : HistoryOperation
+
+    data class AwaitingPublication(
+        val operationId: Long,
+        val kind: HistoryPublicationKind,
+    ) : HistoryOperation
+}
+
+internal enum class HistoryPublicationKind {
+    FIRST_PAGE,
+    FIRST_PAGE_ERROR,
+    REFRESH_ERROR,
+    NEXT_PAGE,
+    NEXT_PAGE_ERROR,
+    RECONCILIATION,
+}
+
+internal data class HistoryReconciliationContext(
+    val oldIndex: Int,
+    val nextKey: HistoryRowKey?,
+    val previousKey: HistoryRowKey?,
+    val loadedPageDepth: Int,
+)
+
+internal data class HistoryQueuedDeletion(
+    val rowKey: HistoryRowKey,
+)
+
+internal class HistoryRuntimeStore(
+    initialState: HistoryRuntimeState = HistoryRuntimeState(),
+) {
+    private var state = initialState
+
+    @Synchronized
+    fun snapshot(): HistoryRuntimeState = state
+
+    @Synchronized
+    fun update(transform: (HistoryRuntimeState) -> HistoryRuntimeState): HistoryRuntimeState {
+        state = transform(state)
+        return state
+    }
+
+    @Synchronized
+    fun <T> reduce(
+        transform: (HistoryRuntimeState) -> Pair<HistoryRuntimeState, T>,
+    ): T {
+        val (nextState, result) = transform(state)
+        state = nextState
+        return result
+    }
+}
+
+internal data class HistoryFirstPageRequest(
+    val operationId: Long,
+    val loadedPageDepth: Int,
+)
+
+internal data class HistoryDeletionStart(
+    val operation: HistoryOperation.Deleting? = null,
+    val queued: Boolean = false,
+)
+
+internal data class HistoryReconciliationStart(
+    val operationId: Long,
+    val retained: List<History>,
+)
+
+internal data class HistoryPageDepthResult(
+    val items: List<History>,
+    val currentPage: Int,
+    val totalPages: Int,
+)
+
+internal data class HistoryNextPageResult(
+    val items: List<History>,
+    val currentPage: Int,
+    val totalPages: Int,
+)
+
+internal fun HistoryRuntimeStore.beginFirstPage(): HistoryFirstPageRequest? {
+    return reduce { state ->
+        val operationId = when (val operation = state.operation) {
+            HistoryOperation.Idle -> state.nextOperationId()
+            is HistoryOperation.RefreshRequested -> operation.operationId
+            is HistoryOperation.RestartRequested -> operation.operationId
+            else -> null
+        }
+        if (operationId == null) {
+            state to null
+        } else {
+            val nextState = state.copy(
+                operation = HistoryOperation.LoadingFirstPage(
+                    operationId = operationId,
+                    retainsContent = state.stableHistory.isNotEmpty(),
+                ),
+                operationSequence = maxOf(state.operationSequence, operationId),
+            )
+            nextState to HistoryFirstPageRequest(
+                operationId = operationId,
+                loadedPageDepth = state.currentPage.coerceAtLeast(FIRST_PAGE),
+            )
+        }
+    }
+}
+
+internal fun HistoryRuntimeStore.acceptFirstPage(
+    operationId: Long,
+    result: HistoryPageDepthResult,
+): HistoryRuntimeState? {
+    return reduce { state ->
+        val operation = state.operation as? HistoryOperation.LoadingFirstPage
+        if (operation?.operationId != operationId) {
+            state to null
+        } else {
+            val nextState = state.copy(
+                currentPage = result.currentPage,
+                isFullDataNext = result.currentPage >= result.totalPages,
+                hasCompletedInitialLoad = true,
+                stableHistory = result.items,
+                operation = HistoryOperation.AwaitingPublication(
+                    operationId = operationId,
+                    kind = HistoryPublicationKind.FIRST_PAGE,
+                ),
+                nextPageErrorMessage = null,
+                pageAttemptRevision = state.pageAttemptRevision + 1L,
+            )
+            nextState to nextState
+        }
+    }
+}
+
+internal fun HistoryRuntimeStore.cancelFirstPage(operationId: Long) {
+    update { state ->
+        val operation = state.operation as? HistoryOperation.LoadingFirstPage
+        if (operation?.operationId == operationId) {
+            state.copy(operation = HistoryOperation.Idle)
+        } else {
+            state
+        }
+    }
+}
+
+internal fun HistoryRuntimeStore.currentNextPageRequest(): HistoryOperation.LoadingNextPage? {
+    return snapshot().operation as? HistoryOperation.LoadingNextPage
+}
+
+internal fun HistoryRuntimeStore.acceptNextPage(
+    operationId: Long,
+    result: HistoryNextPageResult,
+    merge: (List<History>, List<History>) -> List<History>,
+): Boolean {
+    return reduce { state ->
+        val operation = state.operation as? HistoryOperation.LoadingNextPage
+        if (operation?.operationId != operationId) {
+            state to false
+        } else {
+            state.copy(
+                currentPage = result.currentPage,
+                isFullDataNext = result.currentPage >= result.totalPages,
+                stableHistory = merge(state.stableHistory, result.items),
+                operation = HistoryOperation.AwaitingPublication(
+                    operationId = operationId,
+                    kind = HistoryPublicationKind.NEXT_PAGE,
+                ),
+                nextPageErrorMessage = null,
+                pageAttemptRevision = state.pageAttemptRevision + 1L,
+            ) to true
+        }
+    }
+}
+
+internal fun HistoryRuntimeStore.cancelNextPage(operationId: Long) {
+    update { state ->
+        val operation = state.operation as? HistoryOperation.LoadingNextPage
+        if (operation?.operationId == operationId) {
+            state.copy(operation = HistoryOperation.Idle)
+        } else {
+            state
+        }
+    }
+}
+
+internal fun HistoryRuntimeStore.failNextPage(
+    operationId: Long,
+    message: String,
+): Boolean {
+    return reduce { state ->
+        val operation = state.operation as? HistoryOperation.LoadingNextPage
+        if (operation?.operationId != operationId) {
+            state to false
+        } else {
+            state.copy(
+                operation = HistoryOperation.AwaitingPublication(
+                    operationId = operationId,
+                    kind = HistoryPublicationKind.NEXT_PAGE_ERROR,
+                ),
+                nextPageErrorMessage = message,
+                pageAttemptRevision = state.pageAttemptRevision + 1L,
+            ) to true
+        }
+    }
+}
+
+internal fun HistoryRuntimeStore.resetAfterUnhandledError(): HistoryRuntimeState {
+    return update {
+        it.copy(
+            operation = HistoryOperation.Idle,
+            nextPageErrorMessage = null,
+        )
+    }
+}
+
+internal fun HistoryRuntimeStore.completePublication(
+    vararg kinds: HistoryPublicationKind,
+) {
+    update { state ->
+        val publication = state.operation as? HistoryOperation.AwaitingPublication
+        if (publication?.kind in kinds) {
+            state.copy(operation = HistoryOperation.Idle)
+        } else {
+            state
+        }
+    }
+}
+
+internal fun HistoryRuntimeStore.completeEmptyPublication(): Boolean {
+    return reduce { state ->
+        val publication = state.operation as? HistoryOperation.AwaitingPublication
+        val accepted = publication?.kind == HistoryPublicationKind.FIRST_PAGE
+        if (accepted) {
+            state.copy(
+                operation = HistoryOperation.Idle,
+                refreshAfterPendingOperation = false,
+                queuedDeletion = null,
+                focusedKey = null,
+                requestedFocusKey = null,
+                openMenuKey = null,
+            ) to true
+        } else {
+            state to false
+        }
+    }
+}
+
+internal fun HistoryRuntimeStore.beginNextPage(): Boolean {
+    return reduce { state ->
+        when {
+            state.operation != HistoryOperation.Idle -> state to false
+            state.queuedDeletion != null -> state to false
+            state.refreshAfterPendingOperation -> state to false
+            state.isFullDataNext -> state to false
+            else -> {
+                val operationId = state.nextOperationId()
+                state.copy(
+                    operation = HistoryOperation.LoadingNextPage(operationId),
+                    nextPageErrorMessage = null,
+                    operationSequence = operationId,
+                ) to true
+            }
+        }
+    }
+}
+
+internal fun HistoryRuntimeStore.beginRefresh(deferIfBusy: Boolean): Boolean {
+    return reduce { state ->
+        if (state.operation == HistoryOperation.Idle && state.queuedDeletion == null) {
+            val operationId = state.nextOperationId()
+            state.copy(
+                operation = HistoryOperation.RefreshRequested(operationId),
+                nextPageErrorMessage = null,
+                operationSequence = operationId,
+            ) to true
+        } else {
+            val nextState = if (deferIfBusy) {
+                state.copy(refreshAfterPendingOperation = true)
+            } else {
+                state
+            }
+            nextState to false
+        }
+    }
+}
+
+internal fun HistoryRuntimeStore.beginRestart(): Boolean {
+    return reduce { state ->
+        if (state.operation == HistoryOperation.Idle && state.queuedDeletion == null) {
+            val operationId = state.nextOperationId()
+            state.copy(
+                operation = HistoryOperation.RestartRequested(operationId),
+                nextPageErrorMessage = null,
+                operationSequence = operationId,
+            ) to true
+        } else {
+            state to false
+        }
+    }
+}
+
+internal fun HistoryRuntimeStore.focus(item: HistoryItemUIState) {
+    update {
+        it.copy(
+            focusedKey = item.rowKey,
+            requestedFocusKey = null,
+        )
+    }
+}
+
+internal fun HistoryRuntimeStore.openMenu(item: HistoryItemUIState): Boolean {
+    return reduce { state ->
+        if (state.isDeletionFlowActive()) {
+            state to false
+        } else {
+            state.copy(
+                focusedKey = item.rowKey,
+                openMenuKey = item.rowKey,
+            ) to true
+        }
+    }
+}
+
+internal fun HistoryRuntimeStore.dismissMenu() {
+    update { it.copy(openMenuKey = null) }
+}
+
+internal fun HistoryRuntimeStore.beginDeletion(
+    item: HistoryItemUIState,
+    reconciliation: HistoryReconciliationContext,
+    queueIfBusy: Boolean,
+): HistoryDeletionStart {
+    return reduce { state ->
+        when {
+            state.operation == HistoryOperation.Idle -> {
+                val operationId = state.nextOperationId()
+                val operation = HistoryOperation.Deleting(
+                    operationId = operationId,
+                    item = item,
+                    reconciliation = reconciliation,
+                )
+                state.copy(
+                    operation = operation,
+                    focusedKey = item.rowKey,
+                    openMenuKey = null,
+                    queuedDeletion = null,
+                    nextPageErrorMessage = null,
+                    operationSequence = operationId,
+                ) to HistoryDeletionStart(operation = operation)
+            }
+            queueIfBusy &&
+                state.queuedDeletion == null &&
+                state.operation.canQueueDeletion() ->
+                state.copy(
+                    focusedKey = item.rowKey,
+                    openMenuKey = null,
+                    queuedDeletion = HistoryQueuedDeletion(item.rowKey),
+                ) to HistoryDeletionStart(queued = true)
+            else -> state to HistoryDeletionStart()
+        }
+    }
+}
+
+internal fun HistoryRuntimeStore.cancelDeletion(operationId: Long) {
+    update { state ->
+        val operation = state.operation as? HistoryOperation.Deleting
+        if (operation?.operationId == operationId) {
+            state.copy(operation = HistoryOperation.Idle)
+        } else {
+            state
+        }
+    }
+}
+
+internal fun HistoryRuntimeStore.failDeletion(operationId: Long): HistoryRuntimeState? {
+    return reduce { state ->
+        val operation = state.operation as? HistoryOperation.Deleting
+        if (operation?.operationId == operationId) {
+            val nextState = state.copy(operation = HistoryOperation.Idle)
+            nextState to nextState
+        } else {
+            state to null
+        }
+    }
+}
+
+internal fun HistoryRuntimeStore.beginReconciliation(
+    deletionId: Long,
+    reconciliation: HistoryReconciliationContext,
+    retained: List<History>,
+    requestedFocusKey: HistoryRowKey?,
+): HistoryReconciliationStart? {
+    return reduce { state ->
+        val operation = state.operation as? HistoryOperation.Deleting
+        if (operation?.operationId != deletionId) {
+            state to null
+        } else {
+            val operationId = state.nextOperationId()
+            val nextState = state.copy(
+                stableHistory = retained,
+                operation = HistoryOperation.Reconciling(
+                    operationId = operationId,
+                    reconciliation = reconciliation,
+                ),
+                requestedFocusKey = requestedFocusKey,
+                openMenuKey = null,
+                operationSequence = operationId,
+            )
+            nextState to HistoryReconciliationStart(
+                operationId = operationId,
+                retained = retained,
+            )
+        }
+    }
+}
+
+internal fun HistoryRuntimeStore.beginReconciliationRetry(
+    reconciliation: HistoryReconciliationContext,
+): Long? {
+    return reduce { state ->
+        val failed = state.operation as? HistoryOperation.ReconciliationFailed
+        if (failed?.reconciliation != reconciliation) {
+            state to null
+        } else {
+            val operationId = state.nextOperationId()
+            state.copy(
+                operation = HistoryOperation.Reconciling(
+                    operationId = operationId,
+                    reconciliation = reconciliation,
+                ),
+                operationSequence = operationId,
+            ) to operationId
+        }
+    }
+}
+
+internal fun HistoryRuntimeStore.acceptReconciliation(
+    operationId: Long,
+    reconciliation: HistoryReconciliationContext,
+    result: HistoryPageDepthResult,
+    requestedFocusKey: HistoryRowKey?,
+): HistoryRuntimeState? {
+    return reduce { state ->
+        val operation = state.operation as? HistoryOperation.Reconciling
+        if (operation?.operationId != operationId) {
+            state to null
+        } else {
+            val nextState = state.copy(
+                currentPage = result.currentPage,
+                isFullDataNext = result.currentPage >= result.totalPages,
+                stableHistory = result.items,
+                operation = HistoryOperation.AwaitingPublication(
+                    operationId = operationId,
+                    kind = HistoryPublicationKind.RECONCILIATION,
+                ),
+                requestedFocusKey = requestedFocusKey,
+                nextPageErrorMessage = null,
+                pageAttemptRevision = state.pageAttemptRevision + 1L,
+            )
+            nextState to nextState
+        }
+    }
+}
+
+private const val FIRST_PAGE = 1
+
+internal fun HistoryRuntimeStore.failReconciliation(
+    operationId: Long,
+    reconciliation: HistoryReconciliationContext,
+    message: String,
+    requestedFocusKey: HistoryRowKey?,
+): HistoryRuntimeState? {
+    return reduce { state ->
+        val operation = state.operation as? HistoryOperation.Reconciling
+        if (operation?.operationId != operationId) {
+            state to null
+        } else {
+            val nextState = state.copy(
+                operation = HistoryOperation.ReconciliationFailed(
+                    reconciliation = reconciliation,
+                    message = message,
+                ),
+                requestedFocusKey = requestedFocusKey,
+            )
+            nextState to nextState
+        }
+    }
+}
+
+internal fun HistoryRuntimeStore.failFirstPage(
+    operationId: Long,
+): HistoryRuntimeState? {
+    return reduce { state ->
+        val operation = state.operation as? HistoryOperation.LoadingFirstPage
+        if (operation?.operationId != operationId) {
+            state to null
+        } else {
+            val publicationKind = if (state.stableHistory.isEmpty()) {
+                HistoryPublicationKind.FIRST_PAGE_ERROR
+            } else {
+                HistoryPublicationKind.REFRESH_ERROR
+            }
+            val nextState = state.copy(
+                hasCompletedInitialLoad = true,
+                operation = HistoryOperation.AwaitingPublication(
+                    operationId = operationId,
+                    kind = publicationKind,
+                ),
+                pageAttemptRevision = if (state.stableHistory.isEmpty()) {
+                    state.pageAttemptRevision
+                } else {
+                    state.pageAttemptRevision + 1L
+                },
+            )
+            nextState to nextState
+        }
+    }
+}

--- a/app/src/main/java/com/kino/puber/ui/feature/history/vm/HistoryRuntimeTransitions.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/history/vm/HistoryRuntimeTransitions.kt
@@ -1,0 +1,123 @@
+package com.kino.puber.ui.feature.history.vm
+
+import com.kino.puber.domain.interactor.history.HistoryRowKey
+import com.kino.puber.ui.feature.history.model.HistoryItemUIState
+
+internal fun resolveHistoryFocusKey(
+    items: List<HistoryItemUIState>,
+    reconciliation: HistoryReconciliationContext,
+): HistoryRowKey? {
+    val keys = items.map(HistoryItemUIState::rowKey)
+    return reconciliation.nextKey?.takeIf(keys::contains)
+        ?: reconciliation.previousKey?.takeIf(keys::contains)
+        ?: keys.getOrNull(reconciliation.oldIndex.coerceAtMost(keys.lastIndex))
+}
+
+internal fun HistoryOperation.canQueueDeletion(): Boolean {
+    return this is HistoryOperation.RefreshRequested ||
+        this is HistoryOperation.LoadingFirstPage ||
+        this is HistoryOperation.LoadingNextPage ||
+        this is HistoryOperation.AwaitingPublication
+}
+
+internal fun HistoryRuntimeStore.isDeleteAvailable(): Boolean {
+    val state = snapshot()
+    return state.operation == HistoryOperation.Idle &&
+        state.queuedDeletion == null
+}
+
+internal fun HistoryOperation.isDeletionFlowActive(): Boolean {
+    return when (this) {
+        is HistoryOperation.Deleting,
+        is HistoryOperation.Reconciling,
+        is HistoryOperation.ReconciliationFailed -> true
+        is HistoryOperation.AwaitingPublication ->
+            kind == HistoryPublicationKind.RECONCILIATION
+        else -> false
+    }
+}
+
+internal fun HistoryRuntimeState.isDeletionFlowActive(): Boolean {
+    return queuedDeletion != null || operation.isDeletionFlowActive()
+}
+
+internal fun HistoryRuntimeStore.isDeletionFlowActive(): Boolean {
+    return snapshot().isDeletionFlowActive()
+}
+
+internal fun HistoryRuntimeStore.hasPendingEmptyPublication(): Boolean {
+    val publication = snapshot().operation as? HistoryOperation.AwaitingPublication
+    return publication?.kind == HistoryPublicationKind.FIRST_PAGE
+}
+
+internal fun HistoryRuntimeStore.beginDeferredRefresh(): Boolean {
+    return reduce { state ->
+        if (
+            state.refreshAfterPendingOperation &&
+            state.operation == HistoryOperation.Idle &&
+            state.queuedDeletion == null
+        ) {
+            val operationId = state.nextOperationId()
+            state.copy(
+                operation = HistoryOperation.RefreshRequested(operationId),
+                refreshAfterPendingOperation = false,
+                nextPageErrorMessage = null,
+                operationSequence = operationId,
+            ) to true
+        } else {
+            state to false
+        }
+    }
+}
+
+internal fun HistoryRuntimeStore.dropQueuedDeletion(rowKey: HistoryRowKey): Boolean {
+    return reduce { state ->
+        val queued = state.queuedDeletion
+        if (
+            state.operation == HistoryOperation.Idle &&
+            queued?.rowKey == rowKey
+        ) {
+            state.copy(queuedDeletion = null) to true
+        } else {
+            state to false
+        }
+    }
+}
+
+internal fun HistoryRuntimeStore.completeReconciliationPublication(
+    operationId: Long,
+): HistoryRuntimeState? {
+    return reduce { state ->
+        val publication = state.operation as? HistoryOperation.AwaitingPublication
+        if (
+            publication?.operationId != operationId ||
+            publication.kind != HistoryPublicationKind.RECONCILIATION
+        ) {
+            state to null
+        } else {
+            val isEmpty = state.stableHistory.isEmpty()
+            val nextState = state.copy(
+                operation = HistoryOperation.Idle,
+                focusedKey = state.focusedKey.takeUnless { isEmpty },
+                requestedFocusKey = state.requestedFocusKey.takeUnless { isEmpty },
+                openMenuKey = state.openMenuKey.takeUnless { isEmpty },
+                queuedDeletion = state.queuedDeletion.takeUnless { isEmpty },
+                refreshAfterPendingOperation = state.refreshAfterPendingOperation && !isEmpty,
+            )
+            nextState to nextState
+        }
+    }
+}
+
+internal fun HistoryRuntimeStore.prepareContentPublication(
+    availableKeys: Set<HistoryRowKey>,
+    paginatorFocusKey: HistoryRowKey?,
+): HistoryRuntimeState {
+    return update { state ->
+        val nextState = state.copy(
+            requestedFocusKey = paginatorFocusKey ?: state.requestedFocusKey,
+            openMenuKey = state.openMenuKey?.takeIf(availableKeys::contains),
+        )
+        nextState
+    }
+}

--- a/app/src/main/java/com/kino/puber/ui/feature/history/vm/HistoryVM.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/history/vm/HistoryVM.kt
@@ -1,0 +1,700 @@
+package com.kino.puber.ui.feature.history.vm
+
+import androidx.annotation.VisibleForTesting
+import com.kino.puber.core.collections.EquallyFunction
+import com.kino.puber.core.error.ErrorEntity
+import com.kino.puber.core.error.ErrorHandler
+import com.kino.puber.core.paginator.Paginator
+import com.kino.puber.core.paginator.PagingVM
+import com.kino.puber.core.ui.navigation.AppRouter
+import com.kino.puber.core.ui.navigation.PuberScreen
+import com.kino.puber.core.ui.navigation.Screens
+import com.kino.puber.core.ui.uikit.model.CommonAction
+import com.kino.puber.core.ui.uikit.model.UIAction
+import com.kino.puber.data.api.models.History
+import com.kino.puber.domain.interactor.history.HistoryInteractor
+import com.kino.puber.domain.interactor.history.HistoryRowKey
+import com.kino.puber.domain.interactor.history.HistoryTraversal
+import com.kino.puber.domain.interactor.history.rowKeyOrNull
+import com.kino.puber.domain.interactor.history.semanticKeyOrNull
+import com.kino.puber.ui.feature.history.model.HistoryAction
+import com.kino.puber.ui.feature.history.model.HistoryItemUIState
+import com.kino.puber.ui.feature.history.model.HistoryPlaybackTarget
+import com.kino.puber.ui.feature.history.model.HistoryUIMapper
+import com.kino.puber.ui.feature.history.model.HistoryViewState
+import com.kino.puber.ui.feature.details.model.DetailsEpisodeTarget
+import com.kino.puber.ui.feature.player.model.PlayerStartMode
+import kotlinx.coroutines.CancellationException
+import kotlin.math.min
+
+private const val FIRST_PAGE = 1
+
+internal val HistoryRowComparator = EquallyFunction<History> { oldItem, newItem ->
+    oldItem.rowKeyOrNull()?.let { it == newItem.rowKeyOrNull() } ?: false
+}
+
+private fun rawItemForKey(key: HistoryRowKey?, history: List<History>): History? {
+    return key?.let { target ->
+        history.firstOrNull { it.rowKeyOrNull() == target }
+    }
+}
+
+internal class HistoryVM(
+    paginator: Paginator.Store<History>,
+    private val interactor: HistoryInteractor,
+    private val mapper: HistoryUIMapper,
+    router: AppRouter,
+    errorHandler: ErrorHandler,
+) : PagingVM<History, HistoryViewState>(paginator, router, errorHandler) {
+
+    override val initialViewState: HistoryViewState = HistoryViewState.Loading
+
+    private val runtime = HistoryRuntimeStore()
+    private val contentPublicationLock = Any()
+
+    @VisibleForTesting
+    internal val testRuntimeState: HistoryRuntimeState
+        get() = runtime.snapshot()
+
+    @VisibleForTesting
+    internal var testAfterDeleteAvailabilityRead: (() -> Unit)? = null
+
+    @VisibleForTesting
+    internal var testBeforeFocusPublicationLockAcquire: (() -> Unit)? = null
+
+    override fun onStart() = init()
+
+    override fun onAction(action: UIAction) {
+        if (action.isBlockedDuringDeletionFlow() && runtime.isDeletionFlowActive()) return
+        when (action) {
+            is CommonAction.ItemSelected<*> -> openDetails(action.item as HistoryItemUIState)
+            is CommonAction.ItemFocused<*> -> onItemFocused(action.item as HistoryItemUIState)
+            CommonAction.LoadMore,
+            CommonAction.ReloadNextPage -> requestNextPage()
+            CommonAction.Refresh -> requestRefresh()
+            CommonAction.OnResume -> requestResumeRefresh()
+            CommonAction.RetryClicked -> retry()
+            is HistoryAction.OpenContextMenu -> openContextMenu(action.item)
+            HistoryAction.DismissContextMenu -> dismissContextMenu()
+            is HistoryAction.Play -> play(
+                item = action.item,
+                startMode = action.startMode,
+            )
+            is HistoryAction.OpenDetails -> openDetails(action.item)
+            is HistoryAction.DeleteExactMedia -> deleteExactMedia(action.item)
+            HistoryAction.RetryReconciliation -> retry()
+            else -> super.onAction(action)
+        }
+    }
+
+    override fun onLoadFirstPage() {
+        val request = runtime.beginFirstPage() ?: return
+        pagingLaunch {
+            try {
+                val result = loadHistoryPageDepth(request.loadedPageDepth)
+                val accepted = runtime.acceptFirstPage(
+                    operationId = request.operationId,
+                    result = result,
+                ) ?: return@pagingLaunch
+                replace(
+                    result.items,
+                    rawItemForKey(accepted.focusedKey, result.items),
+                )
+            } catch (error: CancellationException) {
+                runtime.cancelFirstPage(request.operationId)
+                throw error
+            } catch (error: Throwable) {
+                handleFirstPageFailure(
+                    operationId = request.operationId,
+                    error = errorHandler.map(error),
+                )
+            }
+        }
+    }
+
+    override fun onLoadNextPage(key: History?) {
+        val request = runtime.currentNextPageRequest() ?: return
+        pagingLaunch {
+            try {
+                val result = loadNextRenderablePage(runtime.snapshot().currentPage)
+                val accepted = runtime.acceptNextPage(
+                    operationId = request.operationId,
+                    result = result,
+                    merge = ::mergeStableHistory,
+                )
+                if (accepted) {
+                    setNextPage(result.items)
+                }
+            } catch (error: CancellationException) {
+                runtime.cancelNextPage(request.operationId)
+                throw error
+            } catch (error: Throwable) {
+                val mappedError = errorHandler.map(error)
+                val accepted = runtime.failNextPage(
+                    operationId = request.operationId,
+                    message = mappedError.message,
+                )
+                if (accepted) {
+                    setPageError(mappedError)
+                }
+            }
+        }
+    }
+
+    override fun dispatchError(error: ErrorEntity) {
+        val state = runtime.resetAfterUnhandledError()
+        if (state.stableHistory.isEmpty()) {
+            updateViewState(HistoryViewState.Error(error.message))
+        } else {
+            replace(
+                state.stableHistory,
+                rawItemForKey(state.focusedKey, state.stableHistory),
+            )
+            showMessage(error.message)
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun dispatchListState(state: Paginator.State) {
+        when (state) {
+            Paginator.State.Loading -> dispatchLoadingState()
+            Paginator.State.Empty -> dispatchEmptyState()
+            is Paginator.State.ErrorEmpty -> {
+                runtime.update { it.copy(operation = HistoryOperation.Idle) }
+                updateViewState(HistoryViewState.Error(state.error.message))
+            }
+            is Paginator.State.Data<*> -> {
+                showContent(
+                    history = state.data as List<History>,
+                    paginatorFocus = state.key as History?,
+                )
+                finishContentPublication(
+                    HistoryPublicationKind.FIRST_PAGE,
+                    HistoryPublicationKind.REFRESH_ERROR,
+                    HistoryPublicationKind.NEXT_PAGE,
+                )
+            }
+            is Paginator.State.Refreshing<*> -> showContent(
+                history = state.data as List<History>,
+                isRefreshing = true,
+            )
+            is Paginator.State.LoadingNext<*> -> showContent(
+                history = state.data as List<History>,
+                isLoadingMore = true,
+            )
+            is Paginator.State.LoadingPrev<*> -> showContent(state.data as List<History>)
+            is Paginator.State.Error<*> -> {
+                showMessage(state.error.message)
+                showContent(state.data as List<History>)
+                finishContentPublication(HistoryPublicationKind.REFRESH_ERROR)
+            }
+            is Paginator.State.PageErrorNext<*> -> {
+                showMessage(state.error.message)
+                showContent(state.data as List<History>)
+                finishContentPublication(HistoryPublicationKind.NEXT_PAGE_ERROR)
+            }
+            is Paginator.State.PageErrorPrev<*> -> {
+                showMessage(state.error.message)
+                showContent(state.data as List<History>)
+            }
+        }
+    }
+
+    private fun dispatchLoadingState() {
+        val runtimeState = runtime.snapshot()
+        if (runtimeState.stableHistory.isEmpty()) {
+            updateViewState(HistoryViewState.Loading)
+        } else {
+            showContent(
+                history = runtimeState.stableHistory,
+                isRefreshing = true,
+            )
+        }
+    }
+
+    private fun dispatchEmptyState() {
+        if (!runtime.hasPendingEmptyPublication()) return
+        updateViewState(HistoryViewState.Empty)
+        runtime.completeEmptyPublication()
+        runQueuedDeletionIfReady()
+    }
+
+    private fun completePublishedOperation(vararg kinds: HistoryPublicationKind) {
+        runtime.completePublication(*kinds)
+    }
+
+    private fun finishContentPublication(vararg kinds: HistoryPublicationKind) {
+        completePublishedOperation(*kinds)
+        runQueuedDeletionIfReady()
+        runDeferredRefreshIfReady()
+        updateDeleteExactMediaAvailability()
+    }
+
+    private fun showContent(
+        history: List<History>,
+        isRefreshing: Boolean = false,
+        isLoadingMore: Boolean = false,
+        paginatorFocus: History? = null,
+    ) {
+        synchronized(contentPublicationLock) {
+            val items = mapper.map(history)
+            val availableKeys = items.mapTo(mutableSetOf(), HistoryItemUIState::rowKey)
+            val paginatorFocusKey = paginatorFocus?.rowKeyOrNull()
+            val runtimeState = runtime.prepareContentPublication(availableKeys, paginatorFocusKey)
+            updateViewState(
+                runtimeState.toContentViewState(
+                    items = items,
+                    availableKeys = availableKeys,
+                    isRefreshing = isRefreshing,
+                    isLoadingMore = isLoadingMore,
+                ),
+            )
+        }
+    }
+
+    private fun requestNextPage() {
+        val started = runtime.beginNextPage()
+        if (!started) return
+        updateDeleteExactMediaAvailability()
+        notifyLoadNextPage()
+    }
+
+    private fun requestRefresh(deferIfBusy: Boolean = false) {
+        if (stateValue !is HistoryViewState.Content) return
+        val started = runtime.beginRefresh(deferIfBusy)
+        if (!started) return
+        enqueueRefresh()
+    }
+
+    private fun enqueueRefresh() {
+        val state = runtime.snapshot()
+        updateDeleteExactMediaAvailability()
+        replace(
+            state.stableHistory,
+            rawItemForKey(state.focusedKey, state.stableHistory),
+        )
+        refresh()
+    }
+
+    private fun requestResumeRefresh() {
+        if (!runtime.snapshot().hasCompletedInitialLoad) return
+        when (stateValue) {
+            HistoryViewState.Loading -> Unit
+            HistoryViewState.Empty,
+            is HistoryViewState.Error -> requestRestart()
+            is HistoryViewState.Content -> requestRefresh(deferIfBusy = true)
+        }
+    }
+
+    private fun retry() {
+        val operation = runtime.snapshot().operation
+        if (operation is HistoryOperation.ReconciliationFailed) {
+            retryReconciliation(operation.reconciliation)
+        } else {
+            requestRestart()
+        }
+    }
+
+    private fun requestRestart() {
+        if (runtime.beginRestart()) {
+            resetPaging()
+        }
+    }
+
+    private fun onItemFocused(item: HistoryItemUIState) {
+        testBeforeFocusPublicationLockAcquire?.invoke()
+        synchronized(contentPublicationLock) {
+            runtime.focus(item)
+            updateViewState<HistoryViewState.Content> { copy(focusKey = item.rowKey) }
+        }
+    }
+
+    private fun openContextMenu(item: HistoryItemUIState) {
+        synchronized(contentPublicationLock) {
+            val opened = runtime.openMenu(item)
+            if (!opened) return
+            updateViewState<HistoryViewState.Content> {
+                copy(openMenuKey = item.rowKey, focusKey = item.rowKey)
+            }
+        }
+    }
+
+    private fun dismissContextMenu() {
+        synchronized(contentPublicationLock) {
+            runtime.dismissMenu()
+            updateViewState<HistoryViewState.Content> { copy(openMenuKey = null) }
+        }
+    }
+
+    private fun play(
+        item: HistoryItemUIState,
+        startMode: PlayerStartMode = PlayerStartMode.ResumeIfAvailable,
+    ) {
+        when (val target = item.playbackTarget) {
+            is HistoryPlaybackTarget.Movie -> {
+                interactor.invalidateItemDetails(item.itemId)
+                router.navigateTo(
+                    router.screens.player(
+                        itemId = item.itemId,
+                        videoNumber = target.videoNumber,
+                        startMode = startMode,
+                    ),
+                )
+            }
+            is HistoryPlaybackTarget.Episode -> {
+                interactor.invalidateItemDetails(item.itemId)
+                router.navigateTo(
+                    router.screens.player(
+                        itemId = item.itemId,
+                        seasonNumber = target.seasonNumber,
+                        episodeNumber = target.episodeNumber,
+                        startMode = startMode,
+                    ),
+                )
+            }
+            HistoryPlaybackTarget.Details -> openDetails(item)
+        }
+    }
+
+    private fun openDetails(item: HistoryItemUIState) {
+        dismissContextMenu()
+        router.navigateTo(router.screens.historyDetails(item))
+    }
+
+    private fun deleteExactMedia(item: HistoryItemUIState) {
+        val content = stateValue as? HistoryViewState.Content ?: return
+        val currentItem = content.items.firstOrNull { it.rowKey == item.rowKey } ?: return
+        val reconciliation = createReconciliationContext(content, currentItem) ?: return
+        startDeletion(
+            item = currentItem,
+            reconciliation = reconciliation,
+            queueIfBusy = true,
+        )
+    }
+
+    private fun startDeletion(
+        item: HistoryItemUIState,
+        reconciliation: HistoryReconciliationContext,
+        queueIfBusy: Boolean = false,
+    ) {
+        val transition = runtime.beginDeletion(item, reconciliation, queueIfBusy)
+        if (transition.queued) {
+            showQueuedDeletion(item)
+            return
+        }
+        val deletion = transition.operation ?: return
+        showDeletionPending(item)
+        launch { performDeletion(deletion, item, reconciliation) }
+    }
+
+    private fun showQueuedDeletion(item: HistoryItemUIState) {
+        synchronized(contentPublicationLock) {
+            updateViewState<HistoryViewState.Content> {
+                copy(
+                    openMenuKey = null,
+                    focusKey = item.rowKey,
+                    isDeleteExactMediaAvailable = false,
+                )
+            }
+        }
+    }
+
+    private fun showDeletionPending(item: HistoryItemUIState) {
+        synchronized(contentPublicationLock) {
+            val content = stateValue as? HistoryViewState.Content
+            val deletingKeys = if (content?.items?.any { it.rowKey == item.rowKey } == true) {
+                setOf(item.rowKey)
+            } else {
+                emptySet()
+            }
+            if (content != null) {
+                updateViewState(
+                    content.copy(
+                        openMenuKey = null,
+                        deletingKeys = deletingKeys,
+                        nextPageErrorMessage = null,
+                        focusKey = item.rowKey,
+                        isDeleteExactMediaAvailable = false,
+                    ),
+                )
+            }
+        }
+    }
+
+    private suspend fun performDeletion(
+        deletion: HistoryOperation.Deleting,
+        item: HistoryItemUIState,
+        reconciliation: HistoryReconciliationContext,
+    ) {
+        try {
+            interactor.clearExactMediaHistory(
+                mediaId = item.deletionMediaId,
+                itemId = item.itemId,
+            )
+        } catch (error: CancellationException) {
+            runtime.cancelDeletion(deletion.operationId)
+            throw error
+        } catch (error: Throwable) {
+            onMutationFailure(
+                operationId = deletion.operationId,
+                error = errorHandler.map(error),
+            )
+            return
+        }
+
+        val retained = runtime.snapshot().stableHistory.filterNot { history ->
+            if (item.semanticKey != null) {
+                history.semanticKeyOrNull() == item.semanticKey
+            } else {
+                history.video?.id == item.deletionMediaId
+            }
+        }
+        val requestedFocusKey = resolveHistoryFocusKey(
+            items = mapper.map(retained),
+            reconciliation = reconciliation,
+        )
+        val reconciliationStart = runtime.beginReconciliation(
+            deletionId = deletion.operationId,
+            reconciliation = reconciliation,
+            retained = retained,
+            requestedFocusKey = requestedFocusKey,
+        ) ?: return
+        showContent(reconciliationStart.retained, isRefreshing = true)
+        reconcile(
+            operationId = reconciliationStart.operationId,
+            reconciliation = reconciliation,
+        )
+    }
+
+    private fun onMutationFailure(
+        operationId: Long,
+        error: ErrorEntity,
+    ) {
+        val restored = runtime.failDeletion(operationId) ?: return
+        showContent(restored.stableHistory)
+        showMessage(error.message)
+        runDeferredRefreshIfReady()
+    }
+
+    private fun retryReconciliation(reconciliation: HistoryReconciliationContext) {
+        val operationId = runtime.beginReconciliationRetry(reconciliation) ?: return
+        showContent(runtime.snapshot().stableHistory, isRefreshing = true)
+        launch {
+            reconcile(
+                operationId = operationId,
+                reconciliation = reconciliation,
+            )
+        }
+    }
+
+    private suspend fun reconcile(
+        operationId: Long,
+        reconciliation: HistoryReconciliationContext,
+    ) {
+        try {
+            val result = loadHistoryPageDepth(reconciliation.loadedPageDepth)
+            val requestedFocusKey = resolveHistoryFocusKey(
+                items = mapper.map(result.items),
+                reconciliation = reconciliation,
+            )
+            runtime.acceptReconciliation(
+                operationId = operationId,
+                reconciliation = reconciliation,
+                result = result,
+                requestedFocusKey = requestedFocusKey,
+            ) ?: return
+            if (result.items.isEmpty()) {
+                updateViewState(HistoryViewState.Empty)
+            } else {
+                showContent(
+                    history = result.items,
+                    paginatorFocus = rawItemForKey(requestedFocusKey, result.items),
+                )
+            }
+            val published = runtime.completeReconciliationPublication(operationId) ?: return
+            replace(
+                result.items,
+                rawItemForKey(published.requestedFocusKey, result.items),
+            )
+            runQueuedDeletionIfReady()
+            runDeferredRefreshIfReady()
+            updateDeleteExactMediaAvailability()
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Throwable) {
+            val errorMessage = errorHandler.map(error).message
+            val stableHistory = runtime.snapshot().stableHistory
+            val requestedFocusKey = resolveHistoryFocusKey(
+                items = mapper.map(stableHistory),
+                reconciliation = reconciliation,
+            )
+            val failed = runtime.failReconciliation(
+                operationId = operationId,
+                reconciliation = reconciliation,
+                message = errorMessage,
+                requestedFocusKey = requestedFocusKey,
+            ) ?: return
+            showContent(failed.stableHistory)
+            showMessage(errorMessage)
+        }
+    }
+
+    private suspend fun loadHistoryPageDepth(loadedPageDepth: Int): HistoryPageDepthResult {
+        val traversal = HistoryTraversal()
+        val items = mutableListOf<History>()
+        val requestedDepth = loadedPageDepth.coerceAtLeast(FIRST_PAGE)
+        var page = FIRST_PAGE
+        var current = FIRST_PAGE
+        var totalPages = FIRST_PAGE
+        var boundedDepth = FIRST_PAGE
+
+        do {
+            val response = interactor.getPage(page)
+            check(response.pagination.current == page) {
+                "History pagination did not match the requested page"
+            }
+            items += traversal.filterFirstOccurrences(response.items)
+            current = response.pagination.current
+            totalPages = response.pagination.total
+            boundedDepth = min(
+                requestedDepth,
+                totalPages.coerceAtLeast(FIRST_PAGE),
+            )
+            page++
+        } while (
+            page <= boundedDepth ||
+                (items.isEmpty() && current < totalPages)
+        )
+
+        return HistoryPageDepthResult(
+            items = items,
+            currentPage = current,
+            totalPages = totalPages,
+        )
+    }
+
+    private suspend fun loadNextRenderablePage(startPage: Int): HistoryNextPageResult {
+        val traversal = HistoryTraversal(runtime.snapshot().stableHistory)
+        var currentPage = startPage
+        var totalPages = startPage + 1
+        var items: List<History>
+        do {
+            val requestedPage = currentPage + 1
+            val response = interactor.getPage(page = requestedPage)
+            check(response.pagination.current == requestedPage) {
+                "History pagination did not match the requested next page"
+            }
+            items = traversal.filterFirstOccurrences(response.items)
+            currentPage = response.pagination.current
+            totalPages = response.pagination.total
+        } while (items.isEmpty() && currentPage < totalPages)
+        return HistoryNextPageResult(
+            items = items,
+            currentPage = currentPage,
+            totalPages = totalPages,
+        )
+    }
+
+    private fun handleFirstPageFailure(
+        operationId: Long,
+        error: ErrorEntity,
+    ) {
+        val failed = runtime.failFirstPage(operationId) ?: return
+        if (failed.stableHistory.isEmpty()) {
+            setGeneralError(error)
+            return
+        }
+        replace(
+            failed.stableHistory,
+            rawItemForKey(failed.focusedKey, failed.stableHistory),
+        )
+        showMessage(error.message)
+    }
+
+    private fun runDeferredRefreshIfReady() {
+        if (stateValue !is HistoryViewState.Content) return
+        if (runtime.beginDeferredRefresh()) {
+            enqueueRefresh()
+        }
+    }
+
+    private fun runQueuedDeletionIfReady() {
+        val state = runtime.snapshot()
+        if (state.operation != HistoryOperation.Idle) return
+        val queued = state.queuedDeletion ?: return
+        val latestContent = stateValue as? HistoryViewState.Content
+        val currentItem = latestContent
+            ?.items
+            ?.firstOrNull { it.rowKey == queued.rowKey }
+        val reconciliation = currentItem
+            ?.let { createReconciliationContext(latestContent, it) }
+        if (currentItem == null || reconciliation == null) {
+            if (runtime.dropQueuedDeletion(queued.rowKey)) {
+                updateDeleteExactMediaAvailability()
+                runDeferredRefreshIfReady()
+            }
+            return
+        }
+        startDeletion(currentItem, reconciliation)
+    }
+
+    private fun createReconciliationContext(
+        content: HistoryViewState.Content,
+        item: HistoryItemUIState,
+    ): HistoryReconciliationContext? {
+        val oldIndex = content.items.indexOfFirst { it.rowKey == item.rowKey }
+        if (oldIndex < 0) return null
+        return HistoryReconciliationContext(
+            oldIndex = oldIndex,
+            nextKey = content.items.getOrNull(oldIndex + 1)?.rowKey,
+            previousKey = content.items.getOrNull(oldIndex - 1)?.rowKey,
+            loadedPageDepth = runtime.snapshot().currentPage.coerceAtLeast(FIRST_PAGE),
+        )
+    }
+
+    private fun updateDeleteExactMediaAvailability() {
+        synchronized(contentPublicationLock) {
+            val content = stateValue as? HistoryViewState.Content ?: return
+            val isDeleteExactMediaAvailable = runtime.isDeleteAvailable()
+            testAfterDeleteAvailabilityRead?.invoke()
+            updateViewState(
+                content.copy(
+                    isDeleteExactMediaAvailable = isDeleteExactMediaAvailable,
+                ),
+            )
+        }
+    }
+
+    private fun mergeStableHistory(
+        oldItems: List<History>,
+        newItems: List<History>,
+    ): List<History> {
+        val merged = oldItems.toMutableList()
+        newItems.forEach { newItem ->
+            val index = merged.indexOfFirst { oldItem ->
+                HistoryRowComparator.isItemTheSame(oldItem, newItem)
+            }
+            if (index >= 0) {
+                merged[index] = newItem
+            } else {
+                merged += newItem
+            }
+        }
+        return merged
+    }
+
+}
+
+private fun Screens.historyDetails(item: HistoryItemUIState): PuberScreen {
+    return when (val target = item.playbackTarget) {
+        is HistoryPlaybackTarget.Episode -> details(
+            itemId = item.itemId,
+            initialEpisode = DetailsEpisodeTarget(
+                seasonNumber = target.seasonNumber,
+                episodeNumber = target.episodeNumber,
+            ),
+        )
+        is HistoryPlaybackTarget.Movie,
+        HistoryPlaybackTarget.Details -> details(item.itemId)
+    }
+}

--- a/app/src/main/java/com/kino/puber/ui/feature/main/model/MainUIMapper.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/main/model/MainUIMapper.kt
@@ -25,6 +25,7 @@ import com.kino.puber.core.ui.navigation.PuberScreen
 import com.kino.puber.core.ui.navigation.PuberTab
 import com.kino.puber.core.ui.navigation.Screens
 import com.kino.puber.data.preferences.NavigationPreferencesRepository
+import com.kino.puber.ui.feature.history.model.HistoryPresentation
 
 internal class MainUIMapper(
     private val resources: ResourceProvider,
@@ -84,15 +85,19 @@ internal class MainUIMapper(
         )
     }
 
-    fun buildTabContent(type: TabType, refreshVersion: Int = 0): PuberTab {
+    fun buildTabContent(
+        type: TabType,
+        navigationMode: NavigationMode,
+        refreshVersion: Int = 0,
+    ): PuberTab {
         return PuberTab(
-            screen = tabScreen(type),
+            screen = tabScreen(type, navigationMode),
             tag = type,
             instanceKey = refreshVersion.takeIf { it > 0 }?.let { "refresh_$it" }.orEmpty(),
         )
     }
 
-    private fun tabScreen(type: TabType): PuberScreen {
+    private fun tabScreen(type: TabType, navigationMode: NavigationMode): PuberScreen {
         return when (type) {
             TabType.Home -> screens.home()
             TabType.Search -> screens.search()
@@ -106,7 +111,12 @@ internal class MainUIMapper(
             TabType.DocSeries,
             TabType.TvShows -> screens.contentList(type)
             TabType.Bookmarks -> screens.bookmarks()
-            TabType.History -> screens.underDevelopment()
+            TabType.History -> screens.history(
+                presentation = when (navigationMode) {
+                    NavigationMode.TopTabs -> HistoryPresentation.TopTabs
+                    NavigationMode.SideDrawer -> HistoryPresentation.SideDrawer
+                },
+            )
             TabType.Collections -> screens.collections()
             TabType.SportTV -> screens.underDevelopment()
             TabType.Settings -> screens.deviceSettings()

--- a/app/src/main/java/com/kino/puber/ui/feature/main/model/MainViewState.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/main/model/MainViewState.kt
@@ -31,7 +31,7 @@ enum class TabType(val title: Int, val enabled: Boolean = true) : Parcelable {
     Search(R.string.main_tabs_search),
     Favourites(R.string.main_tabs_favorites),
     Bookmarks(R.string.main_tabs_bookmarks, enabled = false),
-    History(R.string.main_tabs_history, enabled = false),
+    History(R.string.main_tabs_history),
     Movies(R.string.main_tabs_movies),
     Series(R.string.main_tabs_series),
     Cartoons(R.string.main_tabs_cartoons),

--- a/app/src/main/java/com/kino/puber/ui/feature/main/toptabs/TopTabBarPreview.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/main/toptabs/TopTabBarPreview.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.tooling.preview.Devices.TV_1080p
 import androidx.compose.ui.tooling.preview.Preview
 import com.adamglin.PhosphorIcons
 import com.adamglin.phosphoricons.Duotone
+import com.adamglin.phosphoricons.duotone.ClockCounterClockwise
 import com.adamglin.phosphoricons.duotone.FilmSlate
 import com.adamglin.phosphoricons.duotone.House
 import com.adamglin.phosphoricons.duotone.Playlist
@@ -16,10 +17,11 @@ import com.kino.puber.ui.feature.main.model.MainTab
 import com.kino.puber.ui.feature.main.model.TabType
 
 private val previewTabs = listOf(
-    MainTab(type = TabType.Home, label = "Главная", icon = PhosphorIcons.Duotone.House, isSelected = true),
+    MainTab(type = TabType.Home, label = "Главная", icon = PhosphorIcons.Duotone.House),
     MainTab(type = TabType.Movies, label = "Фильмы", icon = PhosphorIcons.Duotone.FilmSlate),
     MainTab(type = TabType.Series, label = "Сериалы", icon = PhosphorIcons.Duotone.TelevisionSimple),
     MainTab(type = TabType.Collections, label = "Подборки", icon = PhosphorIcons.Duotone.Playlist),
+    MainTab(type = TabType.History, label = "История", icon = PhosphorIcons.Duotone.ClockCounterClockwise),
 )
 
 @Preview(name = "TopTabBar — Home selected", device = TV_1080p)
@@ -39,13 +41,13 @@ private fun TopTabBarHomePreview() = PuberTheme {
     )
 }
 
-@Preview(name = "TopTabBar — Movies selected", device = TV_1080p)
+@Preview(name = "TopTabBar — History selected", device = TV_1080p)
 @Composable
-private fun TopTabBarMoviesPreview() = PuberTheme {
+private fun TopTabBarHistoryPreview() = PuberTheme {
     val tabFocusRequesters = remember { List(previewTabs.size) { FocusRequester() } }
     TopTabBar(
         tabs = previewTabs,
-        selectedIndex = 1,
+        selectedIndex = previewTabs.lastIndex,
         tabFocusRequesters = tabFocusRequesters,
         onContentFocusRequested = {},
         onTabFocused = {},

--- a/app/src/main/java/com/kino/puber/ui/feature/main/toptabs/TopTabMainContent.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/main/toptabs/TopTabMainContent.kt
@@ -35,6 +35,7 @@ import com.kino.puber.core.ui.uikit.component.LocalTvDialogFocusRestorer
 import com.kino.puber.core.ui.uikit.component.TopTabContextMenuDialog
 import com.kino.puber.core.ui.uikit.component.TvDialogFocusRestorer
 import com.kino.puber.core.ui.uikit.component.modifier.LocalAutoFocusOnLaunchEnabled
+import com.kino.puber.core.ui.uikit.component.modifier.LocalContentFocusActive
 import com.kino.puber.core.ui.uikit.model.CommonAction
 import com.kino.puber.core.ui.uikit.model.UIAction
 import com.kino.puber.ui.feature.main.model.MainAction
@@ -147,7 +148,10 @@ internal fun TopTabMainContent(
                         .focusRequester(tabRowFocus),
                 )
 
-                CompositionLocalProvider(LocalAutoFocusOnLaunchEnabled provides false) {
+                CompositionLocalProvider(
+                    LocalAutoFocusOnLaunchEnabled provides false,
+                    LocalContentFocusActive provides isContentFocused,
+                ) {
                     TopTabContentBox(
                         contentFocus = contentFocus,
                         tabRowFocus = tabRowFocus,

--- a/app/src/main/java/com/kino/puber/ui/feature/main/toptabs/TopTabMainContent.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/main/toptabs/TopTabMainContent.kt
@@ -148,10 +148,7 @@ internal fun TopTabMainContent(
                         .focusRequester(tabRowFocus),
                 )
 
-                CompositionLocalProvider(
-                    LocalAutoFocusOnLaunchEnabled provides false,
-                    LocalContentFocusActive provides isContentFocused,
-                ) {
+                TopTabContentFocusProvider(isContentFocused) {
                     TopTabContentBox(
                         contentFocus = contentFocus,
                         tabRowFocus = tabRowFocus,
@@ -179,6 +176,16 @@ internal fun TopTabMainContent(
         }
     }
 }
+
+@Composable
+private fun TopTabContentFocusProvider(
+    isContentFocused: Boolean,
+    content: @Composable () -> Unit,
+) = CompositionLocalProvider(
+    LocalAutoFocusOnLaunchEnabled provides false,
+    LocalContentFocusActive provides isContentFocused,
+    content = content,
+)
 
 @Composable
 private fun RefreshContentFocusEffect(

--- a/app/src/main/java/com/kino/puber/ui/feature/main/vm/MainVM.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/main/vm/MainVM.kt
@@ -21,7 +21,6 @@ internal class MainVM(
     override val initialViewState = MainViewState()
     internal val tabAppRouterHolder = TabAppRouterHolder(router.screens)
     private val tabRefreshVersions = mutableMapOf<TabType, Int>()
-    private val staleTabDisposeVersions = mutableMapOf<TabType, Int>()
 
     override fun onStart() {
         val state = mainUIMapper.buildViewState()
@@ -31,7 +30,7 @@ internal class MainVM(
         } else {
             TabType.Favourites
         }
-        tabRouter.openTab(buildTabContent(startTab))
+        tabRouter.openTab(buildTabContent(startTab, state.navigationMode))
     }
 
     override fun onAction(action: UIAction) {
@@ -46,35 +45,26 @@ internal class MainVM(
         updateViewState<MainViewState> {
             mainUIMapper.updateSelectedTab(state = this, item)
         }
-        tabRouter.openTab(buildTabContent(item.type))
+        tabRouter.openTab(buildTabContent(item.type, stateValue.navigationMode))
     }
 
     private fun onTabRefresh(item: MainTab) {
-        val staleTab = buildTabContent(item.type)
         tabRefreshVersions[item.type] = (tabRefreshVersions[item.type] ?: 0) + 1
-        val refreshedTab = buildTabContent(item.type)
+        val refreshedTab = buildTabContent(item.type, stateValue.navigationMode)
         updateViewState<MainViewState> {
             mainUIMapper.updateSelectedTab(state = this, item)
         }
         tabRouter.openTab(refreshedTab)
-        disposeStaleTabAfterRefresh(type = item.type, tab = staleTab)
     }
 
-    private fun buildTabContent(type: TabType) = mainUIMapper.buildTabContent(
+    private fun buildTabContent(
+        type: TabType,
+        navigationMode: NavigationMode,
+    ) = mainUIMapper.buildTabContent(
         type = type,
+        navigationMode = navigationMode,
         refreshVersion = tabRefreshVersions[type] ?: 0,
     )
-
-    private fun disposeStaleTabAfterRefresh(type: TabType, tab: com.kino.puber.core.ui.navigation.PuberTab) {
-        val version = (staleTabDisposeVersions[type] ?: 0) + 1
-        staleTabDisposeVersions[type] = version
-        launch {
-            kotlinx.coroutines.delay(STALE_TAB_DISPOSE_DELAY_MS)
-            if (staleTabDisposeVersions[type] == version) {
-                tabAppRouterHolder.dispose(tab.key)
-            }
-        }
-    }
 
     fun onSearchClick() {
         router.navigateTo(router.screens.search())
@@ -87,9 +77,5 @@ internal class MainVM(
     override fun onCleared() {
         tabAppRouterHolder.dispose()
         super.onCleared()
-    }
-
-    private companion object {
-        const val STALE_TAB_DISPOSE_DELAY_MS = 500L
     }
 }

--- a/app/src/main/java/com/kino/puber/ui/feature/player/component/EpisodesPanel.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/player/component/EpisodesPanel.kt
@@ -25,6 +25,7 @@ import com.kino.puber.core.ui.uikit.component.moviesList.VideoItemUIState
 internal fun EpisodesPanel(
     visible: Boolean,
     episodes: VideoGridUIState?,
+    initialFocusedItemId: Int? = null,
     onEpisodeSelected: (VideoItemUIState) -> Unit,
     onEpisodeContextMenu: ((VideoItemUIState) -> Unit)? = null,
     onBackPressed: (() -> Unit)? = null,
@@ -54,6 +55,7 @@ internal fun EpisodesPanel(
             if (episodes != null) {
                 VideoGrid(
                     state = episodes,
+                    initialFocusedItemId = initialFocusedItemId,
                     onItemClick = onEpisodeSelected,
                     onItemContextMenu = onEpisodeContextMenu,
                     enableTopSideGradient = true,

--- a/app/src/main/java/com/kino/puber/ui/feature/player/component/PlayerScreen.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/player/component/PlayerScreen.kt
@@ -14,6 +14,7 @@ import com.kino.puber.ui.feature.player.model.PlayerAction
 import com.kino.puber.domain.interactor.player.PlayerInteractor
 import com.kino.puber.domain.interactor.player.SkipSegmentInteractor
 import com.kino.puber.ui.feature.player.model.PlayerScreenParams
+import com.kino.puber.ui.feature.player.model.PlayerStartMode
 import com.kino.puber.ui.feature.player.model.PlayerUIMapper
 import com.kino.puber.ui.feature.player.vm.ContentStateFactory
 import com.kino.puber.ui.feature.player.vm.PlaybackControl
@@ -38,6 +39,8 @@ internal data class PlayerScreen(private val params: PlayerScreenParams) : Fulls
         append(params.itemId)
         params.seasonNumber?.let { season -> append("_s").append(season) }
         params.episodeNumber?.let { episode -> append("_e").append(episode) }
+        params.videoNumber?.let { video -> append("_v").append(video) }
+        if (params.startMode == PlayerStartMode.StartFromBeginning) append("_startOver")
     }
 
     @Suppress("unused")

--- a/app/src/main/java/com/kino/puber/ui/feature/player/model/PlayerScreenParams.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/player/model/PlayerScreenParams.kt
@@ -8,4 +8,6 @@ internal class PlayerScreenParams(
     val itemId: Int,
     val seasonNumber: Int? = null,
     val episodeNumber: Int? = null,
+    val videoNumber: Int? = null,
+    val startMode: PlayerStartMode = PlayerStartMode.ResumeIfAvailable,
 ) : Parcelable

--- a/app/src/main/java/com/kino/puber/ui/feature/player/model/PlayerStartMode.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/player/model/PlayerStartMode.kt
@@ -1,0 +1,6 @@
+package com.kino.puber.ui.feature.player.model
+
+enum class PlayerStartMode {
+    ResumeIfAvailable,
+    StartFromBeginning,
+}

--- a/app/src/main/java/com/kino/puber/ui/feature/player/vm/PlayerProgressDiagnostics.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/player/vm/PlayerProgressDiagnostics.kt
@@ -1,0 +1,15 @@
+package com.kino.puber.ui.feature.player.vm
+
+import com.kino.puber.core.logger.log
+
+internal const val PROGRESS_SAVE_FAILURE_DIAGNOSTIC = "Playback progress save failed"
+
+/**
+ * This boundary deliberately accepts no throwable or media parameters so progress failures
+ * cannot add account viewing identity to application logs.
+ */
+internal object PlayerProgressDiagnostics {
+    fun reportSaveFailure() {
+        log(PROGRESS_SAVE_FAILURE_DIAGNOSTIC)
+    }
+}

--- a/app/src/main/java/com/kino/puber/ui/feature/player/vm/PlayerVM.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/player/vm/PlayerVM.kt
@@ -9,7 +9,6 @@ import com.kino.puber.core.content.ContentChangeSet
 import com.kino.puber.core.content.ContentChangeType
 import com.kino.puber.core.error.ErrorEntity
 import com.kino.puber.core.error.ErrorHandler
-import com.kino.puber.core.logger.log
 import com.kino.puber.core.system.ResourceProvider
 import com.kino.puber.core.ui.PuberVM
 import com.kino.puber.core.ui.navigation.AppRouter
@@ -32,6 +31,7 @@ import com.kino.puber.ui.feature.player.model.PlayerAction
 import com.kino.puber.ui.feature.player.model.PlayPauseIndicatorState
 import com.kino.puber.ui.feature.player.model.PlayerContentState
 import com.kino.puber.ui.feature.player.model.PlayerScreenParams
+import com.kino.puber.ui.feature.player.model.PlayerStartMode
 import com.kino.puber.ui.feature.player.model.BufferPreset
 import com.kino.puber.ui.feature.player.model.PlayerUIMapper
 import com.kino.puber.ui.feature.player.model.PlayerViewState
@@ -214,13 +214,19 @@ internal class PlayerVM(
     }
 
     private fun loadContent() {
-        startPreparingPlayback(params.seasonNumber, params.episodeNumber)
+        startPreparingPlayback(
+            seasonNumber = params.seasonNumber,
+            episodeNumber = params.episodeNumber,
+            startMode = params.startMode,
+            videoNumber = params.videoNumber,
+        )
     }
 
     private fun startPreparingPlayback(
         seasonNumber: Int?,
         episodeNumber: Int?,
-        forceFromBeginning: Boolean = false,
+        startMode: PlayerStartMode = PlayerStartMode.ResumeIfAvailable,
+        videoNumber: Int? = null,
     ) {
         val generation = ++mediaGeneration
         launch {
@@ -228,7 +234,8 @@ internal class PlayerVM(
                 generation = generation,
                 seasonNumber = seasonNumber,
                 episodeNumber = episodeNumber,
-                forceFromBeginning = forceFromBeginning,
+                startMode = startMode,
+                videoNumber = videoNumber,
             )
         }
     }
@@ -237,12 +244,22 @@ internal class PlayerVM(
         generation: Long,
         seasonNumber: Int?,
         episodeNumber: Int?,
-        forceFromBeginning: Boolean = false,
+        startMode: PlayerStartMode = PlayerStartMode.ResumeIfAvailable,
+        videoNumber: Int? = null,
     ) {
         val item = interactor.getItemDetails(params.itemId)
         if (!isCurrentPrepare(generation)) return
-        val resolved = interactor.resolveMedia(item, seasonNumber, episodeNumber)
+        val resolved = interactor.resolveMedia(item, seasonNumber, episodeNumber, videoNumber)
         if (!isCurrentPrepare(generation)) return
+        if (videoNumber != null && !resolved.isSeries && resolved.videoNumber != videoNumber) {
+            dispatchError(
+                ErrorEntity(
+                    message = resources.getString(R.string.player_error_playback),
+                    code = "PlaybackContent",
+                )
+            )
+            return
+        }
         val token = MediaToken(
             generation = generation,
             key = MediaKey(
@@ -262,7 +279,10 @@ internal class PlayerVM(
             files = resolved.files,
             subtitles = resolved.subtitles,
         )
-        val resumeDialog = if (!forceFromBeginning) buildResumeDialog(resolved.watchingTime) else null
+        val resumeDialog = when (startMode) {
+            PlayerStartMode.ResumeIfAvailable -> buildResumeDialog(resolved.watchingTime)
+            PlayerStartMode.StartFromBeginning -> null
+        }
         val contentState = contentStateFactory.build(
             item = item,
             resolved = resolved,
@@ -628,7 +648,11 @@ internal class PlayerVM(
         tracksRestoredForCurrentMedia = false
 
         updateViewState(PlayerViewState.Loading)
-        startPreparingPlayback(seasonNumber, episodeNumber, forceFromBeginning = true)
+        startPreparingPlayback(
+            seasonNumber = seasonNumber,
+            episodeNumber = episodeNumber,
+            startMode = PlayerStartMode.StartFromBeginning,
+        )
     }
 
     private fun playNextEpisode() {
@@ -764,7 +788,7 @@ internal class PlayerVM(
                     interactor.markCurrentAsWatched(
                         id = token.key.itemId,
                         season = token.key.seasonNumber,
-                        episode = token.key.episodeNumber,
+                        videoNumber = token.key.videoNumber,
                     )
                 }
                 markContentChanged(ContentChangeType.Watched)
@@ -792,8 +816,6 @@ internal class PlayerVM(
                     autoMarkHandledToken = token
                     if (origin == WatchedOrigin.Manual) {
                         showMessage(errorHandler.map(error.cause ?: error).message)
-                    } else {
-                        log(error, "Watched status saved without refreshed item details")
                     }
                 }
             } catch (throwable: Throwable) {
@@ -850,6 +872,7 @@ internal class PlayerVM(
             isMovie = content.isMovie,
             seasonNumber = media.seasonNumber,
             episodeNumber = media.episodeNumber,
+            videoNumber = media.videoNumber,
         ) ?: fallbackCurrentWatched ?: content.isCurrentMediaWatched
         val episodes = if (content.isMovie) {
             content.episodes
@@ -874,6 +897,7 @@ internal class PlayerVM(
             isMovie = content.isMovie,
             seasonNumber = media.seasonNumber,
             episodeNumber = media.episodeNumber,
+            videoNumber = media.videoNumber,
         )
         syncContentWithItem(updated, fallbackCurrentWatched = watched)
     }
@@ -926,9 +950,20 @@ internal class PlayerVM(
         )
     }
 
-    private fun Item.currentMediaWatched(isMovie: Boolean, seasonNumber: Int?, episodeNumber: Int?): Boolean? {
+    private fun Item.currentMediaWatched(
+        isMovie: Boolean,
+        seasonNumber: Int?,
+        episodeNumber: Int?,
+        videoNumber: Int?,
+    ): Boolean? {
         return if (isMovie) {
-            isWatchedStatus(watched)
+            videos
+                ?.find { it.number == videoNumber }
+                ?.let { video ->
+                    isWatchedStatus(video.watched)
+                        ?: isWatchedStatus(video.watching?.status)
+                }
+                ?: isWatchedStatus(watched)
         } else {
             seasons
                 ?.find { it.number == seasonNumber }
@@ -943,10 +978,27 @@ internal class PlayerVM(
         isMovie: Boolean,
         seasonNumber: Int?,
         episodeNumber: Int?,
+        videoNumber: Int?,
     ): Item {
         val status = if (watched) WATCHED_STATUS else UNWATCHED_STATUS
         return if (isMovie) {
-            copy(watched = status)
+            val hasExactVideo = videos?.any { it.number == videoNumber } == true
+            if (hasExactVideo) {
+                copy(
+                    videos = videos.map { video ->
+                        if (video.number == videoNumber) {
+                            video.copy(
+                                watched = status,
+                                watching = video.watching?.copy(status = status),
+                            )
+                        } else {
+                            video
+                        }
+                    },
+                )
+            } else {
+                copy(watched = status)
+            }
         } else {
             copy(
                 seasons = seasons?.map { season ->
@@ -1172,7 +1224,6 @@ internal class PlayerVM(
     }
 
     private fun loadSkipSegments(item: Item, season: Int?, episode: Int?, token: MediaToken) {
-        log("loadSkipSegments called: title='${item.title}', imdb=${item.imdb}, s=$season, e=$episode")
         skipSegmentsJob?.cancel()
         skipSegmentsJob = launch {
             val loadedSegments = skipSegmentInteractor.loadSegments(item, season, episode)
@@ -1328,8 +1379,8 @@ internal class PlayerVM(
                             markContentChanged(ContentChangeType.PlaybackProgress)
                         } catch (error: CancellationException) {
                             throw error
-                        } catch (throwable: Throwable) {
-                            log(throwable, "Failed to save playback progress")
+                        } catch (_: Throwable) {
+                            PlayerProgressDiagnostics.reportSaveFailure()
                         }
                     }
                 } finally {

--- a/app/src/main/java/com/kino/puber/ui/feature/player/vm/PlayerVM.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/player/vm/PlayerVM.kt
@@ -950,78 +950,6 @@ internal class PlayerVM(
         )
     }
 
-    private fun Item.currentMediaWatched(
-        isMovie: Boolean,
-        seasonNumber: Int?,
-        episodeNumber: Int?,
-        videoNumber: Int?,
-    ): Boolean? {
-        return if (isMovie) {
-            videos
-                ?.find { it.number == videoNumber }
-                ?.let { video ->
-                    isWatchedStatus(video.watched)
-                        ?: isWatchedStatus(video.watching?.status)
-                }
-                ?: isWatchedStatus(watched)
-        } else {
-            seasons
-                ?.find { it.number == seasonNumber }
-                ?.episodes
-                ?.find { it.number == episodeNumber }
-                ?.let { episode -> isWatchedStatus(episode.watched) }
-        }
-    }
-
-    private fun Item.withCurrentMediaWatched(
-        watched: Boolean,
-        isMovie: Boolean,
-        seasonNumber: Int?,
-        episodeNumber: Int?,
-        videoNumber: Int?,
-    ): Item {
-        val status = if (watched) WATCHED_STATUS else UNWATCHED_STATUS
-        return if (isMovie) {
-            val hasExactVideo = videos?.any { it.number == videoNumber } == true
-            if (hasExactVideo) {
-                copy(
-                    videos = videos.map { video ->
-                        if (video.number == videoNumber) {
-                            video.copy(
-                                watched = status,
-                                watching = video.watching?.copy(status = status),
-                            )
-                        } else {
-                            video
-                        }
-                    },
-                )
-            } else {
-                copy(watched = status)
-            }
-        } else {
-            copy(
-                seasons = seasons?.map { season ->
-                    if (season.number != seasonNumber) {
-                        season
-                    } else {
-                        season.copy(
-                            episodes = season.episodes?.map { episode ->
-                                if (episode.number == episodeNumber) episode.copy(watched = status) else episode
-                            }
-                        )
-                    }
-                }
-            )
-        }
-    }
-
-    private fun isWatchedStatus(status: Int?): Boolean? {
-        return status?.let { it == WATCHED_STATUS }
-    }
-
-    private fun Boolean.toStatus(): Int = if (this) WATCHED_STATUS else UNWATCHED_STATUS
-
     private fun currentEpisode(): CurrentEpisode? {
         val media = currentMedia ?: return null
         return if (canUseCurrentEpisode(media)) {
@@ -1476,8 +1404,6 @@ internal class PlayerVM(
     }
 
     private companion object {
-        const val WATCHED_STATUS = 1
-        const val UNWATCHED_STATUS = 0
         const val CONTROLS_HIDE_DELAY_MS = 3000L
         const val SEEK_INDICATOR_HIDE_DELAY_MS = 1500L
         const val PROGRESS_SYNC_INTERVAL_MS = 30_000L

--- a/app/src/main/java/com/kino/puber/ui/feature/player/vm/PlayerWatchedItemState.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/player/vm/PlayerWatchedItemState.kt
@@ -1,0 +1,86 @@
+package com.kino.puber.ui.feature.player.vm
+
+import com.kino.puber.data.api.models.Item
+
+internal fun Item.currentMediaWatched(
+    isMovie: Boolean,
+    seasonNumber: Int?,
+    episodeNumber: Int?,
+    videoNumber: Int?,
+): Boolean? {
+    return if (isMovie) {
+        videos
+            ?.find { it.number == videoNumber }
+            ?.let { video ->
+                watchedStatus(video.watched)
+                    ?: watchedStatus(video.watching?.status)
+            }
+            ?: watchedStatus(watched)
+    } else {
+        seasons
+            ?.find { it.number == seasonNumber }
+            ?.episodes
+            ?.find { it.number == episodeNumber }
+            ?.let { episode -> watchedStatus(episode.watched) }
+    }
+}
+
+internal fun Item.withCurrentMediaWatched(
+    watched: Boolean,
+    isMovie: Boolean,
+    seasonNumber: Int?,
+    episodeNumber: Int?,
+    videoNumber: Int?,
+): Item {
+    val status = watched.toStatus()
+    return if (isMovie) {
+        withCurrentMovieVideoWatched(videoNumber, status)
+    } else {
+        withCurrentEpisodeWatched(seasonNumber, episodeNumber, status)
+    }
+}
+
+private fun Item.withCurrentMovieVideoWatched(videoNumber: Int?, status: Int): Item {
+    if (videos?.any { it.number == videoNumber } != true) {
+        return copy(watched = status)
+    }
+    return copy(
+        videos = videos.map { video ->
+            if (video.number == videoNumber) {
+                video.copy(
+                    watched = status,
+                    watching = video.watching?.copy(status = status),
+                )
+            } else {
+                video
+            }
+        },
+    )
+}
+
+private fun Item.withCurrentEpisodeWatched(
+    seasonNumber: Int?,
+    episodeNumber: Int?,
+    status: Int,
+): Item {
+    return copy(
+        seasons = seasons?.map { season ->
+            if (season.number != seasonNumber) {
+                season
+            } else {
+                season.copy(
+                    episodes = season.episodes?.map { episode ->
+                        if (episode.number == episodeNumber) episode.copy(watched = status) else episode
+                    },
+                )
+            }
+        },
+    )
+}
+
+private fun watchedStatus(status: Int?): Boolean? = status?.let { it == WATCHED_STATUS }
+
+internal fun Boolean.toStatus(): Int = if (this) WATCHED_STATUS else UNWATCHED_STATUS
+
+private const val WATCHED_STATUS = 1
+private const val UNWATCHED_STATUS = 0

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="error_generic">Не удалось выполнить запрос. Попробуйте ещё раз.</string>
+    <string name="history_title">История</string>
+    <string name="history_empty_title">История просмотров пуста</string>
+    <string name="history_empty_description">Начните смотреть фильм или сериал — он появится здесь.</string>
+    <string name="history_refresh">Обновить</string>
+    <string name="history_episode_metadata">Сезон %1$d · Серия %2$d</string>
+    <string name="history_context_episode_title">%1$s · Сезон %2$d · Серия %3$d</string>
+    <string name="history_context_continue">Продолжить просмотр</string>
+    <string name="history_context_play">Смотреть сначала</string>
+    <string name="history_context_delete_exact_media">Удалить эту запись</string>
+    <string name="history_context_account_disclosure">Удаление влияет на историю просмотров вашего аккаунта.</string>
     <string name="settings_updates_title">Обновления</string>
     <string name="settings_auto_update_check">Автоматически проверять обновления</string>
     <string name="settings_auto_update_check_subtitle">Puber будет искать новую версию при запуске приложения.</string>

--- a/app/src/test/kotlin/com/kino/puber/core/error/DefaultErrorHandlerTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/core/error/DefaultErrorHandlerTest.kt
@@ -1,0 +1,22 @@
+package com.kino.puber.core.error
+
+import com.kino.puber.R
+import com.kino.puber.util.FakeResourceProvider
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+
+class DefaultErrorHandlerTest {
+
+    @Test
+    fun map_usesLocalizedGenericCopyInsteadOfThrowableTransportDetails() {
+        val transportDetails =
+            "OAuth response decoding failed: https://api.example.test/oauth?access_token=secret"
+
+        val error = DefaultErrorHandler(FakeResourceProvider())
+            .map(IllegalStateException(transportDetails))
+
+        assertEquals("string_${R.string.error_generic}", error.message)
+        assertFalse(error.message.contains(transportDetails))
+    }
+}

--- a/app/src/test/kotlin/com/kino/puber/core/ui/navigation/AppRouterSessionTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/core/ui/navigation/AppRouterSessionTest.kt
@@ -1,0 +1,66 @@
+package com.kino.puber.core.ui.navigation
+
+import com.kino.puber.util.MainDispatcherExtension
+import io.mockk.mockk
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+internal class AppRouterSessionTest {
+
+    companion object {
+        private val dispatcher = StandardTestDispatcher()
+
+        @JvmField
+        @RegisterExtension
+        val mainDispatcher = MainDispatcherExtension(dispatcher)
+    }
+
+    @Test
+    fun resetSessionDropsBackDispatchersAndPendingResultListeners() = runTest(dispatcher) {
+        val router = AppRouter(
+            screens = mockk(relaxed = true),
+            coroutineScope = this,
+        )
+        var result: String? = null
+        router.addBackDispatcher(mockk(relaxed = true))
+        router.setOnceResultListener<String>(resultCode = 7) {
+            result = it
+        }
+
+        router.resetSession()
+        router.back(resultCode = 7, result = "stale")
+
+        assertFalse(router.hasBackDispatchers())
+        assertNull(result)
+    }
+
+    @Test
+    fun resetSessionRejectsCommandsScheduledByThePreviousSession() = runTest(dispatcher) {
+        val router = AppRouter(
+            screens = mockk(relaxed = true),
+            coroutineScope = this,
+        )
+        val staleScreen = mockk<PuberScreen>()
+        val activeScreen = mockk<PuberScreen>()
+        val observed = mutableListOf<Command>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            router.events().collect(observed::add)
+        }
+
+        router.navigateTo(staleScreen)
+        router.resetSession()
+        runCurrent()
+        router.navigateTo(activeScreen)
+        runCurrent()
+
+        assertEquals(listOf(Command.NavigateTo(activeScreen)), observed)
+    }
+}

--- a/app/src/test/kotlin/com/kino/puber/core/ui/navigation/component/TabAppRouterHolderTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/core/ui/navigation/component/TabAppRouterHolderTest.kt
@@ -1,0 +1,40 @@
+package com.kino.puber.core.ui.navigation.component
+
+import com.kino.puber.core.ui.navigation.Screens
+import com.kino.puber.util.MainDispatcherExtension
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+internal class TabAppRouterHolderTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val mainDispatcher = MainDispatcherExtension()
+    }
+
+    @Test
+    fun logicalTabKeyOwnsOneRouterAcrossRefreshGenerations() {
+        val holder = TabAppRouterHolder(mockk<Screens>(relaxed = true))
+        val initial = holder.getOrCreate(
+            key = "Tab:HistoryScreen",
+            initialContentInstanceKey = "Tab:HistoryScreen",
+        )
+        val refreshed = holder.getOrCreate(
+            key = "Tab:HistoryScreen",
+            initialContentInstanceKey = "Tab:HistoryScreen:refresh_1",
+        )
+        val other = holder.getOrCreate(
+            key = "Tab:HomeScreen",
+            initialContentInstanceKey = "Tab:HomeScreen",
+        )
+
+        assertSame(initial, refreshed)
+        assertNotSame(initial, other)
+
+        holder.dispose()
+    }
+}

--- a/app/src/test/kotlin/com/kino/puber/core/ui/navigation/component/TabFlowLifecycleKeyTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/core/ui/navigation/component/TabFlowLifecycleKeyTest.kt
@@ -1,0 +1,71 @@
+package com.kino.puber.core.ui.navigation.component
+
+import com.kino.puber.core.ui.navigation.PuberTab
+import com.kino.puber.ui.feature.history.component.HistoryScreen
+import com.kino.puber.ui.feature.history.model.HistoryPresentation
+import com.kino.puber.ui.feature.main.model.TabType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+
+internal class TabFlowLifecycleKeyTest {
+
+    @Test
+    fun refreshedHistoryTabNamespacesScreenLifecycleAndReusesTheLogicalNavigatorSlot() {
+        val historyScreen = HistoryScreen(HistoryPresentation.TopTabs)
+        val historyKey = historyScreen.key
+        val initialTab = PuberTab(
+            screen = historyScreen,
+            tag = TabType.History,
+        )
+        val refreshedTab = PuberTab(
+            screen = HistoryScreen(HistoryPresentation.TopTabs),
+            tag = TabType.History,
+            instanceKey = "refresh_2",
+        )
+
+        assertEquals(initialTab.key, refreshedTab.key)
+        assertNotEquals(initialTab.contentInstanceKey, refreshedTab.contentInstanceKey)
+        assertNotEquals(
+            tabRootScreenKey(initialTab.contentInstanceKey, historyKey),
+            tabRootScreenKey(refreshedTab.contentInstanceKey, historyKey),
+        )
+        assertEquals(
+            tabFlowNavigatorKey(initialTab.navigationSlotKey),
+            tabFlowNavigatorKey(refreshedTab.navigationSlotKey),
+        )
+        assertEquals(
+            "TabRoot:${refreshedTab.contentInstanceKey}:$historyKey",
+            tabRootScreenKey(refreshedTab.contentInstanceKey, historyKey),
+        )
+    }
+
+    @Test
+    fun historyPresentationsUseDistinctLifecycleAndRestorationNamespaces() {
+        val topTabsScreen = HistoryScreen(HistoryPresentation.TopTabs)
+        val sideDrawerScreen = HistoryScreen(HistoryPresentation.SideDrawer)
+        val topTabs = PuberTab(
+            screen = topTabsScreen,
+            tag = TabType.History,
+        )
+        val sideDrawer = PuberTab(
+            screen = sideDrawerScreen,
+            tag = TabType.History,
+        )
+
+        assertEquals("HistoryScreen_TopTabs", topTabsScreen.key)
+        assertEquals("HistoryScreen_SideDrawer", sideDrawerScreen.key)
+        assertNotEquals(topTabsScreen.key, sideDrawerScreen.key)
+        assertNotEquals(topTabs.key, sideDrawer.key)
+        assertNotEquals(topTabs.navigationSlotKey, sideDrawer.navigationSlotKey)
+        assertNotEquals(topTabs.contentInstanceKey, sideDrawer.contentInstanceKey)
+        assertNotEquals(
+            tabRootScreenKey(topTabs.contentInstanceKey, topTabsScreen.key),
+            tabRootScreenKey(sideDrawer.contentInstanceKey, sideDrawerScreen.key),
+        )
+        assertNotEquals(
+            tabFlowNavigatorKey(topTabs.navigationSlotKey),
+            tabFlowNavigatorKey(sideDrawer.navigationSlotKey),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/kino/puber/core/ui/navigation/component/TabNavigatorChildRetentionTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/core/ui/navigation/component/TabNavigatorChildRetentionTest.kt
@@ -1,0 +1,194 @@
+package com.kino.puber.core.ui.navigation.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.saveable.SaveableStateHolder
+import cafe.adriel.voyager.core.annotation.InternalVoyagerApi
+import cafe.adriel.voyager.navigator.Navigator
+import cafe.adriel.voyager.navigator.NavigatorDisposeBehavior
+import com.kino.puber.core.ui.navigation.AppRouter
+import com.kino.puber.core.ui.navigation.PuberScreen
+import com.kino.puber.core.ui.navigation.PuberTab
+import com.kino.puber.ui.feature.main.model.TabType
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(InternalVoyagerApi::class)
+internal class TabNavigatorChildRetentionTest {
+
+    @Test
+    fun firstObservedRefreshReplacesTheInitialRoot() {
+        val initialRoot = RetentionProbeScreen(0)
+        val refreshedRoot = RetentionProbeScreen(1)
+        val child = navigator(
+            key = "TabFlow:Tab:HistoryScreen",
+            parent = null,
+            screen = initialRoot,
+        )
+        val router = mockk<AppRouter>(relaxed = true)
+        val tabSession = TabFlowSession(
+            router = router,
+            initialContentInstanceKey = "Tab:HistoryScreen",
+        )
+
+        assertTrue(
+            replaceTabRootIfChanged(
+                navigator = child,
+                rootScreen = refreshedRoot,
+                contentInstanceKey = "Tab:HistoryScreen:refresh_1",
+                tabSession = tabSession,
+            )
+        )
+        assertEquals(listOf(refreshedRoot), child.items)
+        verify(exactly = 1) { router.resetSession() }
+    }
+
+    @Test
+    fun unchangedContentGenerationDoesNotResetARetainedStack() {
+        val initialRoot = RetentionProbeScreen(0)
+        val retainedRoot = RetentionProbeScreen(99)
+        val child = navigator(
+            key = "TabFlow:Tab:HistoryScreen",
+            parent = null,
+            screen = initialRoot,
+        )
+        val router = mockk<AppRouter>(relaxed = true)
+        val tabSession = TabFlowSession(
+            router = router,
+            initialContentInstanceKey = "Tab:HistoryScreen",
+        )
+        assertFalse(
+            replaceTabRootIfChanged(
+                navigator = child,
+                rootScreen = initialRoot,
+                contentInstanceKey = "Tab:HistoryScreen",
+                tabSession = tabSession,
+            )
+        )
+        child.replaceAll(retainedRoot)
+
+        assertFalse(
+            replaceTabRootIfChanged(
+                navigator = child,
+                rootScreen = initialRoot,
+                contentInstanceKey = "Tab:HistoryScreen",
+                tabSession = tabSession,
+            )
+        )
+        assertEquals(listOf(retainedRoot), child.items)
+        verify(exactly = 0) { router.resetSession() }
+    }
+
+    @Test
+    fun repeatedRefreshKeepsOneLogicalChildInTheParentRegistry() {
+        val parent = navigator(
+            key = "TabNavigator",
+            parent = null,
+            disposeNestedNavigators = false,
+        )
+        val children = parent.childrenForTest()
+        val initialTab = PuberTab(
+            screen = RetentionProbeScreen(0),
+            tag = TabType.History,
+        )
+        val refreshedTab = PuberTab(
+            screen = RetentionProbeScreen(0),
+            tag = TabType.History,
+            instanceKey = "refresh_1",
+        )
+        val initialRoot = RetentionProbeScreen(0)
+        val child = navigator(
+            key = tabFlowNavigatorKey(initialTab.navigationSlotKey),
+            parent = parent,
+            screen = initialRoot,
+        )
+        children[child.key] = child
+        val router = mockk<AppRouter>(relaxed = true)
+        val tabSession = TabFlowSession(
+            router = router,
+            initialContentInstanceKey = initialTab.contentInstanceKey,
+        )
+        val refreshTwoTab = PuberTab(
+            screen = RetentionProbeScreen(0),
+            tag = TabType.History,
+            instanceKey = "refresh_2",
+        )
+
+        assertEquals(initialTab.key, refreshedTab.key)
+        assertNotEquals(initialTab.contentInstanceKey, refreshedTab.contentInstanceKey)
+        assertFalse(
+            replaceTabRootIfChanged(
+                navigator = child,
+                rootScreen = initialRoot,
+                contentInstanceKey = initialTab.contentInstanceKey,
+                tabSession = tabSession,
+            )
+        )
+        assertTrue(
+            replaceTabRootIfChanged(
+                navigator = child,
+                rootScreen = RetentionProbeScreen(1),
+                contentInstanceKey = refreshedTab.contentInstanceKey,
+                tabSession = tabSession,
+            )
+        )
+        assertTrue(
+            replaceTabRootIfChanged(
+                navigator = child,
+                rootScreen = RetentionProbeScreen(2),
+                contentInstanceKey = refreshTwoTab.contentInstanceKey,
+                tabSession = tabSession,
+            )
+        )
+
+        assertEquals(setOf(child.key), children.keys)
+        assertSame(child, children[child.key])
+        assertEquals(listOf(RetentionProbeScreen(2)), child.items)
+        verify(exactly = 2) { router.resetSession() }
+    }
+
+    private fun navigator(
+        key: String,
+        parent: Navigator?,
+        disposeNestedNavigators: Boolean = true,
+        screen: PuberScreen = LoadingScreen,
+    ): Navigator {
+        return Navigator(
+            screens = listOf(screen),
+            key = key,
+            stateHolder = mockk<SaveableStateHolder>(relaxed = true),
+            disposeBehavior = NavigatorDisposeBehavior(
+                disposeNestedNavigators = disposeNestedNavigators,
+            ),
+            parent = parent,
+        )
+    }
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun Navigator.childrenForTest(): MutableMap<String, Navigator> {
+    val childrenGetter = javaClass.declaredMethods.single { method ->
+        method.name.startsWith("getChildren$") &&
+            MutableMap::class.java.isAssignableFrom(method.returnType)
+    }
+    return childrenGetter.invoke(this) as MutableMap<String, Navigator>
+}
+
+@Parcelize
+private data class RetentionProbeScreen(
+    private val generation: Int,
+) : PuberScreen {
+
+    @IgnoredOnParcel
+    override val key = "RetentionProbeScreen:$generation"
+
+    @Composable
+    override fun Content() = Unit
+}

--- a/app/src/test/kotlin/com/kino/puber/data/api/KinoPubApiClientHistoryTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/data/api/KinoPubApiClientHistoryTest.kt
@@ -1,0 +1,183 @@
+package com.kino.puber.data.api
+
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.util.Log
+import com.kino.puber.core.session.SessionEventBus
+import com.kino.puber.data.repository.ICryptoPreferenceRepository
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+internal class KinoPubApiClientHistoryTest {
+
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        fun setUpAndroidLogging() {
+            mockkStatic(Log::class)
+            every { Log.isLoggable(any(), any()) } returns false
+            every { Log.println(any(), any(), any()) } returns 0
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun tearDownAndroidLogging() {
+            unmockkStatic(Log::class)
+        }
+    }
+
+    @Test
+    fun getHistoryData_usesExplicitGetWithPageAndNoStore(
+        @TempDir cacheDir: Path,
+    ) = runTest {
+        val request = AtomicReference<CapturedRequest>()
+        withServer(
+            path = "/v1/history",
+            handler = { exchange ->
+                request.set(exchange.capture())
+                exchange.respond(
+                    status = 200,
+                    body = """
+                        {
+                          "history": [],
+                          "pagination": {
+                            "current": 3,
+                            "perpage": 20,
+                            "total": 3,
+                            "total_items": 0
+                          }
+                        }
+                    """.trimIndent(),
+                )
+            },
+        ) { baseUrl ->
+            val result = client(cacheDir, baseUrl).getHistoryData(page = 3)
+
+            assertTrue(result.isSuccess, result.exceptionOrNull()?.stackTraceToString())
+            assertEquals(3, result.getOrThrow().pagination.current)
+        }
+
+        assertEquals(
+            CapturedRequest(
+                method = "GET",
+                query = "page=3",
+                cacheControl = "no-store",
+            ),
+            request.get(),
+        )
+    }
+
+    @Test
+    fun clearExactMediaHistory_non2xxFailsBeforeUnitConversion(
+        @TempDir cacheDir: Path,
+    ) = runTest {
+        val request = AtomicReference<CapturedRequest>()
+        withServer(
+            path = "/v1/history/clear-for-media",
+            handler = { exchange ->
+                request.set(exchange.capture())
+                exchange.respond(status = 422, body = """{"error":"synthetic rejection"}""")
+            },
+        ) { baseUrl ->
+            val result = client(cacheDir, baseUrl).clearExactMediaHistory(mediaId = 73_001)
+
+            assertTrue(result.isFailure)
+            assertTrue(
+                result.exceptionOrNull()?.message
+                    ?.contains("HTTP 422") == true,
+                result.exceptionOrNull()?.stackTraceToString(),
+            )
+        }
+
+        assertEquals(
+            CapturedRequest(
+                method = "POST",
+                query = "id=73001",
+                cacheControl = "no-store",
+            ),
+            request.get(),
+        )
+    }
+
+    private fun client(cacheDir: Path, baseUrl: String): KinoPubApiClient {
+        val connectivityManager = mockk<ConnectivityManager>()
+        val network = mockk<Network>()
+        val capabilities = mockk<NetworkCapabilities>()
+        every { connectivityManager.activeNetwork } returns network
+        every { connectivityManager.getNetworkCapabilities(network) } returns capabilities
+        every {
+            capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+        } returns true
+
+        val preferences = mockk<ICryptoPreferenceRepository>(relaxed = true)
+        every { preferences.getAccessToken() } returns null
+        every { preferences.getRefreshToken() } returns null
+        every { preferences.getUsername() } returns null
+        every { preferences.getAndroidId() } returns null
+
+        return KinoPubApiClient(
+            okHttpClient = OkHttpClient(),
+            cacheDir = cacheDir.toFile(),
+            connectivityManager = connectivityManager,
+            cryptoPreferenceRepository = preferences,
+            sessionEventBus = SessionEventBus(),
+            mainApiBaseUrl = baseUrl,
+        )
+    }
+
+    private suspend fun withServer(
+        path: String,
+        handler: (HttpExchange) -> Unit,
+        block: suspend (baseUrl: String) -> Unit,
+    ) {
+        val server = HttpServer.create(
+            InetSocketAddress(InetAddress.getLoopbackAddress(), 0),
+            0,
+        )
+        server.createContext(path, handler)
+        server.start()
+        try {
+            block("http://127.0.0.1:${server.address.port}/v1/")
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    private fun HttpExchange.capture(): CapturedRequest {
+        return CapturedRequest(
+            method = requestMethod,
+            query = requestURI.rawQuery,
+            cacheControl = requestHeaders.getFirst("Cache-Control"),
+        )
+    }
+
+    private fun HttpExchange.respond(status: Int, body: String) {
+        val bytes = body.toByteArray()
+        responseHeaders.add("Content-Type", "application/json")
+        sendResponseHeaders(status, bytes.size.toLong())
+        responseBody.use { it.write(bytes) }
+    }
+
+    private data class CapturedRequest(
+        val method: String,
+        val query: String?,
+        val cacheControl: String?,
+    )
+}

--- a/app/src/test/kotlin/com/kino/puber/data/api/history/HistoryRequestTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/data/api/history/HistoryRequestTest.kt
@@ -1,0 +1,67 @@
+package com.kino.puber.data.api.history
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class HistoryRequestTest {
+
+    @Test
+    fun page_buildsVerifiedReadRequest() {
+        val request = HistoryRequest.page(page = 3)
+
+        assertEquals("history", request.path)
+        assertEquals(mapOf("page" to "3"), request.query)
+        assertEquals("no-store", request.cacheControl)
+    }
+
+    @Test
+    fun clearExactMedia_buildsVerifiedMediaRequest() {
+        val request = HistoryRequest.clearExactMedia(mediaId = 73001)
+
+        assertEquals("history/clear-for-media", request.path)
+        assertEquals(mapOf("id" to "73001"), request.query)
+        assertEquals("no-store", request.cacheControl)
+    }
+
+    @Test
+    fun resolveUrl_composesEachBuiltInMainApiPresetExactlyOnce() {
+        val baseUrls = listOf(
+            "https://api.service-kp.com/v1/",
+            "https://api.alador.space/v1/",
+            "https://cdn-service.online/api/v1/",
+        )
+        val requests = listOf(
+            HistoryRequest.page(page = 1) to "history",
+            HistoryRequest.clearExactMedia(mediaId = 1) to "history/clear-for-media",
+        )
+
+        baseUrls.forEach { baseUrl ->
+            requests.forEach { (request, expectedPath) ->
+                assertEquals("$baseUrl$expectedPath", request.resolveUrl(baseUrl))
+            }
+        }
+    }
+
+    @Test
+    fun resolveUrl_normalizesMissingOrRepeatedTrailingSeparator() {
+        val request = HistoryRequest.clearExactMedia(mediaId = 1)
+
+        assertEquals(
+            "https://example.test/v1/history/clear-for-media",
+            request.resolveUrl("https://example.test/v1"),
+        )
+        assertEquals(
+            "https://example.test/v1/history/clear-for-media",
+            request.resolveUrl("https://example.test/v1///"),
+        )
+    }
+
+    @Test
+    fun factories_rejectInvalidPaginationAndMediaIdentity() {
+        assertThrows(IllegalArgumentException::class.java) { HistoryRequest.page(page = 0) }
+        assertThrows(IllegalArgumentException::class.java) {
+            HistoryRequest.clearExactMedia(mediaId = 0)
+        }
+    }
+}

--- a/app/src/test/kotlin/com/kino/puber/data/api/models/HistorySerializationTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/data/api/models/HistorySerializationTest.kt
@@ -1,0 +1,187 @@
+package com.kino.puber.data.api.models
+
+import com.kino.puber.data.api.history.HistoryPageResponse
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class HistorySerializationTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+    @Test
+    fun movieFixture_decodesVerifiedHistoryAndProgressShape() {
+        val response = decodeHistoryPage("history/history-page-movie.json")
+        val history = response.items.single()
+        val video = requireNotNull(history.video)
+        val watching = requireNotNull(video.watching)
+
+        assertEquals(1, response.pagination.current)
+        assertEquals(20, response.pagination.perpage)
+        assertEquals(1, response.pagination.total)
+        assertEquals(1, response.pagination.totalItems)
+        assertNull(history.recordId)
+        assertEquals(72001, history.item.id)
+        assertEquals(ItemType.MOVIE, history.item.type)
+        assertEquals(73001, video.id)
+        assertEquals(2, video.number)
+        assertEquals(5_400, video.duration)
+        assertEquals(0, video.watched)
+        assertEquals(1_200, watching.time)
+        assertEquals(5_400, watching.duration)
+        assertEquals(0, watching.status)
+        assertEquals("4102444810", watching.updatedAt)
+        assertEquals(1_200, history.time)
+        assertEquals("4102444810", history.updated)
+        assertNull(history.season)
+    }
+
+    @Test
+    fun seriesFixture_decodesExactSeasonAndEpisodeShape() {
+        val response = decodeHistoryPage("history/history-page-series.json")
+        val history = response.items.single()
+        val video = requireNotNull(history.video)
+        val watching = requireNotNull(video.watching)
+
+        assertNull(history.recordId)
+        assertEquals(82001, history.item.id)
+        assertEquals(ItemType.SERIAL, history.item.type)
+        assertEquals(4, history.season)
+        assertEquals(83001, video.id)
+        assertEquals(9, video.number)
+        assertEquals(2_700, video.duration)
+        assertEquals(1, video.watched)
+        assertEquals(2_700, watching.time)
+        assertEquals(2_700, watching.duration)
+        assertEquals(1, watching.status)
+        assertEquals("4105296010", history.updated)
+    }
+
+    @Test
+    fun fixtures_tolerateUnknownResponseFields() {
+        assertEquals(1, decodeHistoryPage("history/history-page-movie.json").items.size)
+        assertEquals(1, decodeHistoryPage("history/history-page-series.json").items.size)
+    }
+
+    @Test
+    fun serverContractFixture_decodesHistoryEnvelopeAndMediaShape() {
+        val response = json.decodeFromString<HistoryPageResponse>(
+            readFixture("history/history-page-server-contract.json"),
+        ).toModel()
+        val history = response.items.single()
+        val video = requireNotNull(history.video)
+
+        assertEquals(1, response.items.size)
+        assertEquals(92001, history.item.id)
+        assertNull(history.recordId)
+        assertEquals(93001, video.id)
+        assertEquals(2, video.number)
+        assertEquals(1_200, video.watching?.time)
+        assertEquals(4_800, video.watching?.duration)
+        assertEquals(0, video.watched)
+        assertEquals("411111111", history.updated)
+    }
+
+    @Test
+    fun deletedServerEntry_isNotPublishedToHistoryUi() {
+        val response = json.decodeFromString<HistoryPageResponse>(
+            """
+            {
+              "history": [{
+                "counter": 1,
+                "first_seen": 1,
+                "item": {"id": 92001, "title": "Synthetic Deleted Movie", "type": "movie"},
+                "last_seen": 2,
+                "media": {"id": 93001, "number": 1, "snumber": 0, "duration": 2700},
+                "time": 100,
+                "deleted": true
+              }],
+              "pagination": {"current": 1, "perpage": 20, "total": 1, "total_items": 1}
+            }
+            """.trimIndent(),
+        ).toModel()
+
+        assertTrue(response.items.isEmpty())
+    }
+
+    @Test
+    fun missingExactCoordinates_remainNullableForNonPlayableMapping() {
+        val response = json.decodeFromString<HistoryPageResponse>(
+            """
+            {
+              "history": [{
+                "counter": 1,
+                "first_seen": 1,
+                "item": {"id": 92001, "title": "Synthetic Incomplete Series", "type": "serial"},
+                "last_seen": 2,
+                "media": {"id": 93001, "number": 9, "snumber": 0, "duration": 2700},
+                "time": 100,
+                "deleted": false
+              }],
+              "pagination": {"current": 1, "perpage": 20, "total": 1, "total_items": 1}
+            }
+            """.trimIndent(),
+        ).toModel()
+
+        val history = response.items.single()
+        assertNull(history.season)
+        assertEquals(9, history.video?.number)
+    }
+
+    @Test
+    fun missingMediaId_isRejected() {
+        val malformed = """
+            {
+              "history": [{
+                "counter": 1,
+                "first_seen": 1,
+                "item": {"id": 92001, "title": "Synthetic Invalid Movie", "type": "movie"},
+                "last_seen": 2,
+                "media": {"number": 1, "snumber": 0, "duration": 2700},
+                "time": 100,
+                "deleted": false
+              }],
+              "pagination": {"current": 1, "perpage": 20, "total": 1, "total_items": 1}
+            }
+        """.trimIndent()
+
+        assertThrows(SerializationException::class.java) {
+            json.decodeFromString<HistoryPageResponse>(malformed)
+        }
+    }
+
+    @Test
+    fun fixtures_containOnlyClearlySyntheticContent() {
+        val fixtures = listOf(
+            readFixture("history/history-page-movie.json"),
+            readFixture("history/history-page-series.json"),
+        )
+
+        fixtures.forEach { fixture ->
+            val normalized = fixture.lowercase()
+            assertTrue(normalized.contains("synthetic"))
+            assertTrue(normalized.contains("example.test"))
+            assertFalse(normalized.contains("authorization"))
+            assertFalse(normalized.contains("bearer "))
+            assertFalse(normalized.contains("access_token"))
+            assertFalse(normalized.contains("refresh_token"))
+        }
+    }
+
+    private fun decodeHistoryPage(path: String): PaginatedResponse<History> =
+        json.decodeFromString<HistoryPageResponse>(readFixture(path)).toModel()
+
+    private fun readFixture(path: String): String =
+        requireNotNull(javaClass.classLoader?.getResource(path)) {
+            "Missing test fixture: $path"
+        }.readText()
+}

--- a/app/src/test/kotlin/com/kino/puber/data/api/network/CurlLogFormatterTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/data/api/network/CurlLogFormatterTest.kt
@@ -1,0 +1,398 @@
+package com.kino.puber.data.api.network
+
+import com.kino.puber.core.logger.REDACTED_LOG_BODY
+import com.kino.puber.core.logger.REDACTED_LOG_VALUE
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+internal class CurlLogFormatterTest {
+
+    private val formatter = CurlLogFormatter()
+
+    @Test
+    fun requestFormattingRedactsSensitiveUrlHeadersAndTextBody() {
+        val lines = formatter.formatRequest(
+            method = "POST",
+            url = "https://example.test/v1/history?page=page-secret&id=history-secret",
+            headers = listOf(
+                "Authorization" to "Bearer access-secret",
+                "X-Request-Id" to "request-diagnostic",
+                "User-Agent" to "Puber/account-user/android-id-secret",
+            ),
+            textBody = """{"title":"Private title","refresh_token":"refresh-secret"}""",
+        )
+        val output = lines.joinToString("\n")
+
+        assertEquals(3, lines.size)
+        assertNoSecrets(
+            output,
+            "page-secret",
+            "history-secret",
+            "access-secret",
+            "Private title",
+            "refresh-secret",
+            "account-user",
+            "android-id-secret",
+        )
+        assertTrue(output.contains("curl -X 'POST'"))
+        assertTrue(output.contains("/v1/history"))
+        assertTrue(output.contains("Authorization: $REDACTED_LOG_VALUE"))
+        assertTrue(output.contains("X-Request-Id: request-diagnostic"))
+        assertTrue(output.contains("User-Agent: $REDACTED_LOG_VALUE"))
+        assertTrue(output.contains(REDACTED_LOG_BODY))
+    }
+
+    @Test
+    fun responseFormattingRedactsUrlHeadersBodyAndUsesSanitizedLength() {
+        val lines = formatter.formatResponse(
+            status = "200 OK",
+            url = "https://example.test/v1/watching/marktime?id=item-secret&time=time-secret",
+            headers = listOf(
+                "Set-Cookie" to "access_token=access-secret",
+                "X-Trace" to "trace-diagnostic",
+            ),
+            body = """{"title":"Private title","id":"history-secret"}""",
+        )
+        val output = lines.joinToString("\n")
+
+        assertEquals(6, lines.size)
+        assertNoSecrets(
+            output,
+            "item-secret",
+            "time-secret",
+            "access-secret",
+            "Private title",
+            "history-secret",
+        )
+        assertTrue(output.contains("<-- 200 OK"))
+        assertTrue(output.contains("Set-Cookie: $REDACTED_LOG_VALUE"))
+        assertTrue(output.contains("X-Trace: trace-diagnostic"))
+        assertTrue(output.contains(REDACTED_LOG_BODY))
+        assertTrue(output.contains("(${REDACTED_LOG_BODY.length}-char body)"))
+    }
+
+    @Test
+    fun authenticationFormattingNeverEmitsOAuthSecrets() {
+        val request = formatter.formatRequest(
+            method = "POST",
+            url = "https://example.test/oauth2/device?client_secret=client-secret&refresh_token=refresh-secret",
+            headers = emptyList(),
+            textBody = """{"code":"device-secret"}""",
+        )
+        val response = formatter.formatResponse(
+            status = "200 OK",
+            url = "https://example.test/oauth2/device",
+            headers = emptyList(),
+            body = """{"access_token":"access-secret","refresh_token":"new-refresh-secret"}""",
+        )
+        val output = (request + response).joinToString("\n")
+
+        assertNoSecrets(
+            output,
+            "client-secret",
+            "refresh-secret",
+            "device-secret",
+            "access-secret",
+            "new-refresh-secret",
+        )
+        assertTrue(output.contains(REDACTED_LOG_BODY))
+    }
+
+    @Test
+    fun accountAndDeviceResponseFormattingSuppressesPersonalBodies() {
+        val accountResponse = formatter.formatResponse(
+            status = "200 OK",
+            url = "https://example.test/v1/user",
+            headers = listOf("Content-Type" to "application/json"),
+            body = """{"username":"account-user","email":"private@example.test"}""",
+        )
+        val deviceResponse = formatter.formatResponse(
+            status = "200 OK",
+            url = "https://example.test/v1/device/devices",
+            headers = listOf("Content-Type" to "application/json"),
+            body = """
+                {
+                  "title":"Living room",
+                  "hardware":"private-hardware",
+                  "software":"private-software",
+                  "last_seen":"private-time"
+                }
+            """.trimIndent(),
+        )
+        val output = (accountResponse + deviceResponse).joinToString("\n")
+
+        assertNoSecrets(
+            output,
+            "account-user",
+            "private@example.test",
+            "Living room",
+            "private-hardware",
+            "private-software",
+            "private-time",
+        )
+        assertEquals(2, output.lines().count { it == REDACTED_LOG_BODY })
+        assertTrue(output.contains("/v1/user"))
+        assertTrue(output.contains("/v1/device/devices"))
+    }
+
+    @Test
+    fun watchingResponseFormattingSuppressesAccountViewingPayloads() {
+        val routes = listOf(
+            "https://example.test/v1/watching/movie?subscribed=account-subscription-secret",
+            "https://example.test/v1/watching/serials?subscribed=account-subscription-secret",
+        )
+        val output = routes.flatMap { url ->
+            formatter.formatResponse(
+                status = "200 OK",
+                url = url,
+                headers = listOf("Content-Type" to "application/json"),
+                body = """
+                    {
+                      "items":[{
+                        "id":"private-item-id",
+                        "title":"Private watched title",
+                        "watching":{"time":"private-watching-time"}
+                      }]
+                    }
+                """.trimIndent(),
+            )
+        }.joinToString("\n")
+
+        assertNoSecrets(
+            output,
+            "account-subscription-secret",
+            "private-item-id",
+            "Private watched title",
+            "private-watching-time",
+        )
+        assertEquals(2, output.lines().count { it == REDACTED_LOG_BODY })
+        assertTrue(output.contains("/v1/watching/movie"))
+        assertTrue(output.contains("/v1/watching/serials"))
+    }
+
+    @Test
+    fun requestAndResponseFormattingRedactFragmentAndUrlValuedHeaderCredentials() {
+        val request = formatter.formatRequest(
+            method = "GET",
+            url = "https://client.test/callback#access_token=request-access-secret&state=request-state",
+            headers = listOf(
+                "Link" to "<https://request-user:request-password@api.test/next" +
+                    "?page=2&refresh%5Ftoken=request-refresh-secret" +
+                    "#access%5Ftoken=request-link-access-secret>; rel=\"next\"",
+            ),
+            textBody = null,
+        )
+        val response = formatter.formatResponse(
+            status = "302 Found",
+            url = "https://example.test/v1/items?page=3" +
+                "#tab=history&refresh_token=response-url-refresh-secret",
+            headers = listOf(
+                "Location" to "https://response-user:response-password@client.test/callback" +
+                    "?refresh%5Ftoken=response-location-refresh-secret&state=response-state" +
+                    "#access%5Ftoken=response-location-access-secret",
+            ),
+            body = """{"count":2}""",
+        )
+        val output = (request + response).joinToString("\n")
+
+        assertNoSecrets(
+            output,
+            "request-access-secret",
+            "request-user",
+            "request-password",
+            "request-refresh-secret",
+            "request-link-access-secret",
+            "response-url-refresh-secret",
+            "response-user",
+            "response-password",
+            "response-location-refresh-secret",
+            "response-location-access-secret",
+        )
+        assertTrue(output.contains("state=request-state"))
+        assertTrue(output.contains("page=2"))
+        assertTrue(output.contains("page=3"))
+        assertTrue(output.contains("tab=history"))
+        assertTrue(output.contains("state=response-state"))
+        assertTrue(output.contains("access%5Ftoken=$REDACTED_LOG_VALUE"))
+        assertTrue(output.contains("refresh%5Ftoken=$REDACTED_LOG_VALUE"))
+    }
+
+    @Test
+    fun copyPasteCommandPreservesHostileArgumentsWithoutExecutingThem(
+        @TempDir tempDir: Path,
+    ) {
+        val commandSubstitutionMarker = tempDir.resolve("command-substitution-ran")
+        val backtickMarker = tempDir.resolve("backtick-ran")
+        val hostileValue = buildString {
+            append("\$HOME ")
+            append("\$(touch '").append(commandSubstitutionMarker).append("') ")
+            append("`touch '").append(backtickMarker).append("'` ")
+            append("'single' \"double\" \\\\backslash")
+        }
+        val url = "https://example.test/v1/items?diagnostic=$hostileValue"
+        val body = "@body=$hostileValue"
+        val command = formatter.formatRequest(
+            method = "POST",
+            url = url,
+            headers = listOf("X-Hostile" to hostileValue),
+            textBody = body,
+        )[1]
+        val capturedArguments = executeWithFakeCurl(
+            command = command,
+            tempDir = tempDir,
+        )
+
+        assertEquals(
+            listOf(
+                "-X",
+                "POST",
+                "-H",
+                "X-Hostile: $hostileValue",
+                "--data-raw",
+                body,
+                "--",
+                url,
+            ),
+            capturedArguments,
+        )
+        assertFalse(Files.exists(commandSubstitutionMarker))
+        assertFalse(Files.exists(backtickMarker))
+    }
+
+    @Test
+    fun historyToExactPlayerFlowNeverEmitsViewingOrCredentialValues() {
+        val historyResponse = formatter.formatResponse(
+            status = "200 OK",
+            url = "https://example.test/v1/history?page=history-page-secret",
+            headers = listOf("Authorization" to "Bearer history-token-secret"),
+            body = """
+                {
+                  "id":"history-id-secret",
+                  "item":{"id":4242,"title":"Watched title secret"},
+                  "video":{"id":"video-id-secret","watching":{"time":"watch-time-secret","duration":"duration-secret"}}
+                }
+            """.trimIndent(),
+        )
+        val detailsRequest = formatter.formatRequest(
+            method = "GET",
+            url = "https://example.test/v1/items/4242",
+            headers = listOf("Authorization" to "Bearer player-token-secret"),
+            textBody = null,
+        )
+        val detailsResponse = formatter.formatResponse(
+            status = "200 OK",
+            url = "https://example.test/v1/items/4242",
+            headers = listOf("Set-Cookie" to "refresh_token=refresh-token-secret"),
+            body = """
+                {
+                  "title":"Watched title secret",
+                  "videos":[
+                    {"id":"video-id-secret","watching":{"time":"watch-time-secret","duration":"duration-secret"}}
+                  ]
+                }
+            """.trimIndent(),
+        )
+        val marktimeRequest = formatter.formatRequest(
+            method = "GET",
+            url = "https://example.test/v1/watching/marktime?id=video-id-secret&time=marktime-secret",
+            headers = listOf("Authorization" to "Bearer marktime-token-secret"),
+            textBody = null,
+        )
+        val output = (historyResponse + detailsRequest + detailsResponse + marktimeRequest).joinToString("\n")
+
+        assertNoSecrets(
+            output,
+            "history-page-secret",
+            "history-token-secret",
+            "history-id-secret",
+            "4242",
+            "Watched title secret",
+            "video-id-secret",
+            "watch-time-secret",
+            "duration-secret",
+            "player-token-secret",
+            "refresh-token-secret",
+            "marktime-secret",
+            "marktime-token-secret",
+        )
+        assertTrue(output.contains("/v1/history"))
+        assertTrue(output.contains("/v1/items/$REDACTED_LOG_VALUE"))
+        assertTrue(output.contains("/v1/watching/marktime"))
+        assertTrue(output.contains(REDACTED_LOG_BODY))
+    }
+
+    @Test
+    fun normalRequestAndResponseKeepUsefulDiagnostics() {
+        val request = formatter.formatRequest(
+            method = "GET",
+            url = "https://example.test/v1/items?page=3",
+            headers = listOf("Accept" to "application/json"),
+            textBody = null,
+        )
+        val response = formatter.formatResponse(
+            status = "200 OK",
+            url = "https://example.test/v1/items?page=3",
+            headers = listOf("Content-Type" to "application/json"),
+            body = """{"count":2}""",
+        )
+        val output = (request + response).joinToString("\n")
+
+        assertTrue(output.contains("https://example.test/v1/items?page=3"))
+        assertTrue(output.contains("Accept: application/json"))
+        assertTrue(output.contains("<non-text or unknown body>"))
+        assertTrue(output.contains("Content-Type: application/json"))
+        assertTrue(output.contains("""{"count":2}"""))
+        assertFalse(output.contains(REDACTED_LOG_BODY))
+    }
+
+    private fun assertNoSecrets(output: String, vararg secrets: String) {
+        secrets.forEach { secret ->
+            assertFalse(output.contains(secret), "Leaked secret: $secret")
+        }
+    }
+
+    private fun executeWithFakeCurl(
+        command: String,
+        tempDir: Path,
+    ): List<String> {
+        val curlScript = tempDir.resolve("curl")
+        val capturedArguments = tempDir.resolve("curl-arguments")
+        Files.write(
+            curlScript,
+            """
+                #!/bin/sh
+                : > "${'$'}CURL_CAPTURE_FILE"
+                for argument in "${'$'}@"; do
+                  printf '%s\0' "${'$'}argument" >> "${'$'}CURL_CAPTURE_FILE"
+                done
+            """.trimIndent().toByteArray(StandardCharsets.UTF_8),
+        )
+        assertTrue(curlScript.toFile().setExecutable(true))
+
+        val process = ProcessBuilder("sh", "-c", command)
+            .apply {
+                environment()["CURL_CAPTURE_FILE"] = capturedArguments.toString()
+                environment()["PATH"] = listOf(
+                    tempDir.toString(),
+                    System.getenv("PATH").orEmpty(),
+                ).joinToString(File.pathSeparator)
+            }
+            .start()
+        val errorOutput = process.errorStream
+            .bufferedReader()
+            .use { it.readText() }
+
+        assertEquals(0, process.waitFor(), errorOutput)
+        return Files.readAllBytes(capturedArguments)
+            .toString(StandardCharsets.UTF_8)
+            .split('\u0000')
+            .filter(String::isNotEmpty)
+    }
+}

--- a/app/src/test/kotlin/com/kino/puber/data/api/network/SensitiveRequestLogPolicyTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/data/api/network/SensitiveRequestLogPolicyTest.kt
@@ -1,0 +1,263 @@
+package com.kino.puber.data.api.network
+
+import com.kino.puber.core.logger.REDACTED_LOG_BODY
+import com.kino.puber.core.logger.REDACTED_LOG_VALUE
+import com.kino.puber.core.logger.SensitiveRequestKind
+import com.kino.puber.core.logger.SensitiveRequestLogPolicy
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class SensitiveRequestLogPolicyTest {
+
+    private val policy = SensitiveRequestLogPolicy()
+
+    @Test
+    fun classifyRecognizesSensitiveApiPaths() {
+        assertEquals(
+            SensitiveRequestKind.History,
+            policy.classify("https://example.test/v1/history?page=page-secret"),
+        )
+        assertEquals(
+            SensitiveRequestKind.History,
+            policy.classify("https://example.test/api/v1/history/clear-for-media?id=media-secret"),
+        )
+        assertEquals(
+            SensitiveRequestKind.ItemDetails,
+            policy.classify("https://example.test/v1/items/4242"),
+        )
+        assertEquals(
+            SensitiveRequestKind.ItemDetails,
+            policy.classify("https://example.test/api/v1/items/4242/"),
+        )
+        assertEquals(
+            SensitiveRequestKind.PlaybackProgress,
+            policy.classify("https://example.test/v1/watching/marktime?id=item-secret"),
+        )
+        assertEquals(
+            SensitiveRequestKind.PlaybackProgress,
+            policy.classify("https://example.test/v1/watching/toggle?id=item-secret"),
+        )
+        assertEquals(
+            SensitiveRequestKind.PlaybackProgress,
+            policy.classify("https://example.test/v1/watching/movie?subscribed=account-secret"),
+        )
+        assertEquals(
+            SensitiveRequestKind.PlaybackProgress,
+            policy.classify("https://example.test/v1/watching/serials?subscribed=account-secret"),
+        )
+        assertEquals(
+            SensitiveRequestKind.PlaybackProgress,
+            policy.classify("https://example.test/v1/watching/togglewatchlist?id=item-secret"),
+        )
+        assertEquals(
+            SensitiveRequestKind.Authentication,
+            policy.classify("https://example.test/oauth2/device?code=device-secret"),
+        )
+        assertEquals(
+            SensitiveRequestKind.AccountOrDevice,
+            policy.classify("https://example.test/v1/user"),
+        )
+        assertEquals(
+            SensitiveRequestKind.AccountOrDevice,
+            policy.classify("https://example.test/v1/device/devices"),
+        )
+        assertEquals(
+            SensitiveRequestKind.Standard,
+            policy.classify("https://example.test/v1/items/search?q=title"),
+        )
+    }
+
+    @Test
+    fun sensitiveEndpointsRedactEveryQueryValue() {
+        val urls = listOf(
+            "https://example.test/v1/history?page=page-secret&id=history-secret",
+            "https://example.test/v1/watching/marktime?id=item-secret&time=time-secret",
+            "https://example.test/v1/watching/toggle?id=item-secret&status=status-secret",
+            "https://example.test/v1/watching/movie?subscribed=account-secret",
+            "https://example.test/v1/watching/serials?subscribed=account-secret",
+        )
+
+        urls.forEach { url ->
+            val sanitized = policy.sanitizeUrl(url)
+
+            assertFalse(sanitized.contains("secret"))
+            assertTrue(sanitized.contains("=$REDACTED_LOG_VALUE"))
+        }
+    }
+
+    @Test
+    fun itemDetailsUrlsRedactMediaIdentityButKeepRouteShape() {
+        assertEquals(
+            "https://example.test/api/v1/items/$REDACTED_LOG_VALUE/" +
+                "?diagnostic=$REDACTED_LOG_VALUE",
+            policy.sanitizeUrl(
+                "https://example.test/api/v1/items/4242/?diagnostic=request-value",
+            ),
+        )
+    }
+
+    @Test
+    fun standardUrlsRedactCredentialParametersButKeepUsefulValues() {
+        val sanitized = policy.sanitizeUrl(
+            "https://example.test/v1/items?page=3&refresh_token=refresh-secret",
+        )
+
+        assertTrue(sanitized.contains("page=3"))
+        assertTrue(sanitized.contains("refresh_token=$REDACTED_LOG_VALUE"))
+        assertFalse(sanitized.contains("refresh-secret"))
+    }
+
+    @Test
+    fun urlFragmentsRedactCredentialParametersAndKeepNonSensitiveComponents() {
+        val fragmentOnly = policy.sanitizeUrl(
+            "https://client.test/callback#access_token=access-secret&state=state-diagnostic",
+        )
+        val queryAndFragment = policy.sanitizeUrl(
+            "https://example.test/v1/items?page=3#tab=history&refresh_token=refresh-secret",
+        )
+
+        assertEquals(
+            "https://client.test/callback#access_token=$REDACTED_LOG_VALUE&state=state-diagnostic",
+            fragmentOnly,
+        )
+        assertEquals(
+            "https://example.test/v1/items?page=3#tab=history&refresh_token=$REDACTED_LOG_VALUE",
+            queryAndFragment,
+        )
+    }
+
+    @Test
+    fun sensitiveHeadersAndEmbeddedCredentialsAreRedacted() {
+        assertEquals(
+            REDACTED_LOG_VALUE,
+            policy.sanitizeHeader("Authorization", "Bearer access-secret"),
+        )
+        assertEquals(
+            REDACTED_LOG_VALUE,
+            policy.sanitizeHeader("Set-Cookie", "refresh_token=refresh-secret"),
+        )
+        assertEquals(
+            REDACTED_LOG_VALUE,
+            policy.sanitizeHeader(
+                "User-Agent",
+                "Puber/account-user/android-id-secret",
+            ),
+        )
+        assertEquals(
+            "trace refresh_token=$REDACTED_LOG_VALUE",
+            policy.sanitizeHeader("X-Debug", "trace refresh_token=refresh-secret"),
+        )
+        assertEquals(
+            "https://client.test/callback?refresh_token=$REDACTED_LOG_VALUE" +
+                "#access_token=$REDACTED_LOG_VALUE&state=state-diagnostic",
+            policy.sanitizeHeader(
+                "Location",
+                "https://client.test/callback?refresh_token=refresh-secret" +
+                    "#access_token=access-secret&state=state-diagnostic",
+            ),
+        )
+        assertEquals(
+            "<https://api.test/next?page=2&refresh_token=$REDACTED_LOG_VALUE" +
+                "#access_token=$REDACTED_LOG_VALUE>; rel=\"next\"",
+            policy.sanitizeHeader(
+                "Link",
+                "<https://api.test/next?page=2&refresh_token=refresh-secret" +
+                    "#access_token=access-secret>; rel=\"next\"",
+            ),
+        )
+    }
+
+    @Test
+    fun urlValuedHeadersRedactUserInfoAndEncodedCredentialNames() {
+        assertEquals(
+            "https://$REDACTED_LOG_VALUE@client.test/callback" +
+                "?access%5Ftoken=$REDACTED_LOG_VALUE&state=location-diagnostic",
+            policy.sanitizeHeader(
+                "Location",
+                "https://location-user:location-password@client.test/callback" +
+                    "?access%5Ftoken=location-secret&state=location-diagnostic",
+            ),
+        )
+        assertEquals(
+            "<https://$REDACTED_LOG_VALUE@api.test/next" +
+                "?page=2&refresh%5Ftoken=$REDACTED_LOG_VALUE>; rel=\"next\"",
+            policy.sanitizeHeader(
+                "Link",
+                "<https://link-user:link-password@api.test/next" +
+                    "?page=2&refresh%5Ftoken=link-secret>; rel=\"next\"",
+            ),
+        )
+    }
+
+    @Test
+    fun historyItemDetailsPlaybackAndAuthenticationBodiesAreSuppressed() {
+        val body = """{"title":"Private title","id":"history-secret"}"""
+        val urls = listOf(
+            "https://example.test/v1/history?page=1",
+            "https://example.test/v1/items/4242",
+            "https://example.test/v1/watching/marktime?id=1",
+            "https://example.test/v1/watching/movie?subscribed=1",
+            "https://example.test/v1/watching/serials?subscribed=1",
+            "https://example.test/oauth2/device?code=secret",
+        )
+
+        urls.forEach { url ->
+            assertEquals(REDACTED_LOG_BODY, policy.sanitizeRequestBody(url, body))
+            assertEquals(REDACTED_LOG_BODY, policy.sanitizeResponseBody(url, body))
+        }
+    }
+
+    @Test
+    fun standardBodiesRedactTokenFieldsAndBearerValues() {
+        val body = """
+            {"access_token":"access-secret","refresh_token":"refresh-secret","note":"Bearer bearer-secret"}
+        """.trimIndent()
+
+        val sanitized = policy.sanitizeResponseBody(
+            url = "https://example.test/v1/items",
+            body = body,
+        )
+
+        assertFalse(sanitized.contains("access-secret"))
+        assertFalse(sanitized.contains("refresh-secret"))
+        assertFalse(sanitized.contains("bearer-secret"))
+        assertTrue(sanitized.contains("access_token"))
+        assertTrue(sanitized.contains(REDACTED_LOG_VALUE))
+    }
+
+    @Test
+    fun accountAndDeviceResponseBodiesAreSuppressed() {
+        val responses = mapOf(
+            "https://example.test/v1/user" to
+                """{"username":"account-user","email":"private@example.test"}""",
+            "https://example.test/v1/device/devices" to
+                """{"title":"Living room","hardware":"private-hardware","software":"private-software",""" +
+                """"last_seen":"private-time"}""",
+        )
+
+        responses.forEach { (url, body) ->
+            assertEquals(REDACTED_LOG_BODY, policy.sanitizeResponseBody(url, body))
+        }
+    }
+
+    @Test
+    fun throwableSanitizationPreservesCauseChainWithoutAuthenticationSecrets() {
+        val refreshFailure = IllegalStateException(
+            "Failed to refresh token",
+            IllegalStateException(
+                "POST https://example.test/oauth2/device?refresh_token=refresh-secret",
+            ),
+        )
+
+        val sanitized = policy.sanitizeThrowable(refreshFailure)
+        val output = sanitized.stackTraceToString()
+
+        assertNotNull(sanitized.cause)
+        assertTrue(output.contains("Failed to refresh token"))
+        assertTrue(output.contains("refresh_token=$REDACTED_LOG_VALUE"))
+        assertFalse(output.contains("refresh-secret"))
+    }
+}

--- a/app/src/test/kotlin/com/kino/puber/data/preferences/NavigationPreferencesRepositoryTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/data/preferences/NavigationPreferencesRepositoryTest.kt
@@ -1,0 +1,221 @@
+package com.kino.puber.data.preferences
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.kino.puber.core.model.NavigationMode
+import com.kino.puber.ui.feature.main.model.TabType
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+private const val TOP_TABS_KEY = "toptabs_tabs_visible"
+private const val SIDE_DRAWER_KEY = "drawer_tabs_visible"
+private const val TOP_TABS_SCHEMA_VERSION_KEY = "toptabs_schema_version"
+private const val HISTORY_SCHEMA_VERSION = 1
+
+internal class NavigationPreferencesRepositoryTest {
+
+    @Test
+    fun defaultSideDrawer_usesEnabledDeclarationOrderWithHistory() {
+        val fixture = fixture()
+
+        val tabs = fixture.repository.getVisibleTabs(NavigationMode.SideDrawer)
+
+        assertEquals(
+            listOf(
+                TabType.Search,
+                TabType.Favourites,
+                TabType.History,
+                TabType.Movies,
+                TabType.Series,
+                TabType.Cartoons,
+                TabType.For4k,
+                TabType.Concerts,
+                TabType.DocMovies,
+                TabType.DocSeries,
+                TabType.TvShows,
+                TabType.Settings,
+            ),
+            tabs,
+        )
+        assertEquals(TabType.entries.filter(TabType::enabled), tabs)
+        assertTrue(fixture.preferences.transactions.isEmpty())
+    }
+
+    @Test
+    fun storedSideDrawerSelection_isReturnedWithoutInsertionOrReordering() {
+        val fixture = fixture(
+            storedDrawerTabs = "Movies,Favourites,Settings",
+        )
+
+        val tabs = fixture.repository.getVisibleTabs(NavigationMode.SideDrawer)
+
+        assertEquals(
+            listOf(TabType.Movies, TabType.Favourites, TabType.Settings),
+            tabs,
+        )
+        assertFalse(TabType.History in tabs)
+        assertTrue(fixture.preferences.transactions.isEmpty())
+    }
+
+    @Test
+    fun defaultTopTabs_placeHistoryAfterCollectionsAndPersistSchema() {
+        val fixture = fixture()
+
+        val tabs = fixture.repository.getVisibleTabs(NavigationMode.TopTabs)
+
+        assertEquals(
+            listOf(
+                TabType.Home,
+                TabType.Movies,
+                TabType.Series,
+                TabType.Collections,
+                TabType.History,
+            ),
+            tabs,
+        )
+        assertEquals(1, fixture.preferences.transactions.size)
+        assertEquals(
+            setOf(TOP_TABS_KEY, TOP_TABS_SCHEMA_VERSION_KEY),
+            fixture.preferences.transactions.single().keys,
+        )
+        assertEquals(HISTORY_SCHEMA_VERSION, fixture.preferences.values[TOP_TABS_SCHEMA_VERSION_KEY])
+    }
+
+    @Test
+    fun migrationNormalizesRequiredTabsAndDuplicateHistory() {
+        val fixture = fixture(
+            storedTabs = "Movies,Search,History,Series,History,Settings,Collections",
+        )
+
+        val tabs = fixture.repository.getVisibleTabs(NavigationMode.TopTabs)
+
+        assertEquals(
+            listOf(
+                TabType.Home,
+                TabType.Movies,
+                TabType.Series,
+                TabType.Collections,
+                TabType.History,
+            ),
+            tabs,
+        )
+    }
+
+    @Test
+    fun migrationAppendsHistoryWhenCollectionsAreMissing() {
+        val fixture = fixture(storedTabs = "History,Series,Movies")
+
+        val tabs = fixture.repository.getVisibleTabs(NavigationMode.TopTabs)
+
+        assertEquals(
+            listOf(TabType.Home, TabType.Series, TabType.Movies, TabType.History),
+            tabs,
+        )
+    }
+
+    @Test
+    fun migrationIgnoresUnknownAndMalformedTabNames() {
+        val fixture = fixture(storedTabs = "Unknown,Movies,, Series ,DocMovies,broken")
+
+        val tabs = fixture.repository.getVisibleTabs(NavigationMode.TopTabs)
+
+        assertEquals(
+            listOf(TabType.Home, TabType.Movies, TabType.DocMovies, TabType.History),
+            tabs,
+        )
+    }
+
+    @Test
+    fun migrationRunsOnlyOnceAcrossRepeatedReads() {
+        val fixture = fixture(storedTabs = "Movies,Collections")
+
+        val first = fixture.repository.getVisibleTabs(NavigationMode.TopTabs)
+        val transactionsAfterFirstRead = fixture.preferences.transactions.size
+        val second = fixture.repository.getVisibleTabs(NavigationMode.TopTabs)
+
+        assertEquals(first, second)
+        assertEquals(1, transactionsAfterFirstRead)
+        assertEquals(transactionsAfterFirstRead, fixture.preferences.transactions.size)
+    }
+
+    @Test
+    fun userCanRemoveHistoryAfterVersionOneWhileSearchAndSettingsStayOutside() {
+        val fixture = fixture()
+        fixture.repository.getVisibleTabs(NavigationMode.TopTabs)
+
+        fixture.repository.setVisibleTabs(
+            mode = NavigationMode.TopTabs,
+            tabs = listOf(
+                TabType.Search,
+                TabType.Home,
+                TabType.Movies,
+                TabType.Settings,
+            ),
+        )
+        val tabs = fixture.repository.getVisibleTabs(NavigationMode.TopTabs)
+
+        assertEquals(listOf(TabType.Home, TabType.Movies), tabs)
+        assertFalse(TabType.History in tabs)
+        assertFalse(TabType.Search in tabs)
+        assertFalse(TabType.Settings in tabs)
+    }
+
+    private fun fixture(
+        storedTabs: String? = null,
+        storedDrawerTabs: String? = null,
+    ): Fixture {
+        val preferences = TestPreferences()
+        storedTabs?.let { preferences.values[TOP_TABS_KEY] = it }
+        storedDrawerTabs?.let { preferences.values[SIDE_DRAWER_KEY] = it }
+        val context = mockk<Context>()
+        every {
+            context.getSharedPreferences(any(), Context.MODE_PRIVATE)
+        } returns preferences.sharedPreferences
+        return Fixture(
+            repository = NavigationPreferencesRepository(context),
+            preferences = preferences,
+        )
+    }
+
+    private data class Fixture(
+        val repository: NavigationPreferencesRepository,
+        val preferences: TestPreferences,
+    )
+}
+
+private class TestPreferences {
+    val values: MutableMap<String, Any?> = mutableMapOf()
+    val transactions: MutableList<Map<String, Any?>> = mutableListOf()
+    val sharedPreferences: SharedPreferences = mockk()
+
+    private val pending: MutableMap<String, Any?> = linkedMapOf()
+    private val editor: SharedPreferences.Editor = mockk()
+
+    init {
+        every { sharedPreferences.getString(any(), any()) } answers {
+            values[firstArg()] as? String ?: secondArg<String?>()
+        }
+        every { sharedPreferences.getInt(any(), any()) } answers {
+            values[firstArg()] as? Int ?: secondArg()
+        }
+        every { sharedPreferences.edit() } returns editor
+        every { editor.putString(any(), any()) } answers {
+            pending[firstArg()] = secondArg<String?>()
+            editor
+        }
+        every { editor.putInt(any(), any()) } answers {
+            pending[firstArg()] = secondArg<Int>()
+            editor
+        }
+        every { editor.apply() } answers {
+            val transaction = pending.toMap()
+            values.putAll(transaction)
+            transactions += transaction
+            pending.clear()
+        }
+    }
+}

--- a/app/src/test/kotlin/com/kino/puber/data/repository/SkipSegmentPrivacyTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/data/repository/SkipSegmentPrivacyTest.kt
@@ -1,0 +1,159 @@
+package com.kino.puber.data.repository
+
+import com.kino.puber.core.di.ScopeModuleManager
+import com.kino.puber.data.api.IntroDbAppApiClient
+import com.kino.puber.data.api.TheIntroDbApiClient
+import com.kino.puber.data.api.TmdbApiClient
+import com.kino.puber.ui.feature.player.component.PlayerScreen
+import com.kino.puber.ui.feature.player.model.PlayerScreenParams
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import timber.log.Timber
+
+internal class SkipSegmentPrivacyTest {
+
+    @Test
+    fun transitiveSkipSegmentRuntimeDoesNotLogMediaIdentity() = runTest {
+        val tmdbApiClient = mockk<TmdbApiClient>()
+        val theIntroDbApiClient = mockk<TheIntroDbApiClient>()
+        val introDbAppApiClient = mockk<IntroDbAppApiClient>()
+        val tmdbIdRepository = mockk<TmdbIdRepository>()
+        val logTree = CollectingLogTree()
+        val service = SkipSegmentService(
+            tmdbApiClient = tmdbApiClient,
+            introDbClient = theIntroDbApiClient,
+            introDbAppClient = introDbAppApiClient,
+            tmdbIdRepository = tmdbIdRepository,
+            segmentRepository = SkipSegmentRepository(),
+        )
+        every { tmdbIdRepository.getTmdbId(IMDB_ID) } returns null
+        every { tmdbIdRepository.saveTmdbId(IMDB_ID, TMDB_ID) } just runs
+        coEvery { tmdbApiClient.findByImdbId(IMDB_ID) } returns Result.success(TMDB_ID)
+        coEvery {
+            theIntroDbApiClient.getSegments(TMDB_ID, SEASON, EPISODE)
+        } returns Result.success(emptyList())
+        coEvery {
+            introDbAppApiClient.getSegments(IMDB_ID, SEASON, EPISODE)
+        } returns Result.success(emptyList())
+
+        Timber.plant(logTree)
+        try {
+            assertTrue(service.getSegments(IMDB_ID, SEASON, EPISODE).isEmpty())
+        } finally {
+            Timber.uproot(logTree)
+        }
+
+        coVerify(exactly = 1) { tmdbApiClient.findByImdbId(IMDB_ID) }
+        coVerify(exactly = 1) {
+            theIntroDbApiClient.getSegments(TMDB_ID, SEASON, EPISODE)
+        }
+        coVerify(exactly = 1) {
+            introDbAppApiClient.getSegments(IMDB_ID, SEASON, EPISODE)
+        }
+        assertTrue(logTree.messages.isEmpty())
+    }
+
+    @Test
+    fun transitiveSkipSegmentSourcesContainNoApplicationLogging() {
+        SKIP_SEGMENT_PATH_FILES.forEach { relativePath ->
+            val source = String(
+                Files.readAllBytes(resolveSource(relativePath)),
+                StandardCharsets.UTF_8,
+            )
+
+            assertFalse(
+                source.contains("com.kino.puber.core.logger.log"),
+                "$relativePath imports application logging",
+            )
+            assertFalse(
+                LOG_CALL_REGEX.containsMatchIn(source),
+                "$relativePath emits application logging",
+            )
+        }
+    }
+
+    @Test
+    fun parameterizedPlayerScopeDoesNotLogExactMediaIdentity() {
+        val playerScopeName = PlayerScreen(
+            PlayerScreenParams(
+                itemId = ITEM_ID,
+                seasonNumber = SEASON,
+                episodeNumber = EPISODE,
+                videoNumber = VIDEO_NUMBER,
+            ),
+        ).key
+        val logTree = CollectingLogTree()
+        val manager = ScopeModuleManager(
+            scopeName = playerScopeName,
+            moduleFactory = { _, _ -> mockk() },
+            parentScope = mockk(),
+            koin = mockk(),
+        )
+
+        Timber.plant(logTree)
+        try {
+            manager.onRemembered()
+            manager.onAbandoned()
+            manager.onForgotten()
+        } finally {
+            Timber.uproot(logTree)
+        }
+
+        assertTrue(logTree.messages.isEmpty())
+    }
+
+    private fun resolveSource(relativePath: String): Path {
+        val workingDirectory = Path.of(System.getProperty("user.dir"))
+        val candidates = listOf(
+            workingDirectory.resolve("src/main/java").resolve(relativePath),
+            workingDirectory.resolve("app/src/main/java").resolve(relativePath),
+        )
+        return candidates.firstOrNull(Files::exists)
+            ?: error("Unable to locate source file: $relativePath")
+    }
+
+    private class CollectingLogTree : Timber.Tree() {
+        val messages = mutableListOf<String>()
+
+        override fun log(
+            priority: Int,
+            tag: String?,
+            message: String,
+            t: Throwable?,
+        ) {
+            messages += message
+        }
+    }
+
+    private companion object {
+        const val IMDB_ID = "tt-private-history-identity"
+        const val TMDB_ID = 848_484
+        const val ITEM_ID = 424_242
+        const val SEASON = 713
+        const val EPISODE = 927
+        const val VIDEO_NUMBER = 535
+        val LOG_CALL_REGEX = Regex("""\blog\s*\(""")
+        val SKIP_SEGMENT_PATH_FILES = listOf(
+            "com/kino/puber/ui/feature/player/vm/PlayerVM.kt",
+            "com/kino/puber/ui/feature/player/component/PlayerScreen.kt",
+            "com/kino/puber/domain/interactor/player/SkipSegmentInteractor.kt",
+            "com/kino/puber/core/di/DIScope.kt",
+            "com/kino/puber/core/di/ScopeModuleManager.kt",
+            "com/kino/puber/data/repository/SkipSegmentService.kt",
+            "com/kino/puber/data/api/TmdbApiClient.kt",
+            "com/kino/puber/data/api/TheIntroDbApiClient.kt",
+            "com/kino/puber/data/api/IntroDbAppApiClient.kt",
+        )
+    }
+}

--- a/app/src/test/kotlin/com/kino/puber/domain/interactor/history/HistoryInteractorTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/domain/interactor/history/HistoryInteractorTest.kt
@@ -1,0 +1,211 @@
+package com.kino.puber.domain.interactor.history
+
+import com.kino.puber.data.api.KinoPubApiClient
+import com.kino.puber.data.api.models.History
+import com.kino.puber.data.api.models.Item
+import com.kino.puber.data.api.models.ItemType
+import com.kino.puber.data.api.models.PaginatedResponse
+import com.kino.puber.data.api.models.Pagination
+import com.kino.puber.data.api.models.Video
+import com.kino.puber.data.repository.ItemDetailsRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.IOException
+
+class HistoryInteractorTest {
+
+    private val api = mockk<KinoPubApiClient>()
+    private val itemDetailsRepository = mockk<ItemDetailsRepository>(relaxed = true)
+    private val interactor = HistoryInteractor(api, itemDetailsRepository)
+
+    @Test
+    fun getPage_returnsVerifiedPaginatedResponse() = runTest {
+        val expected = PaginatedResponse(
+            items = listOf(movie(recordId = 1, videoId = 11, videoNumber = 2)),
+            pagination = Pagination(current = 2, perpage = 20, total = 3, totalItems = 41),
+        )
+        coEvery { api.getHistoryData(page = 2) } returns Result.success(expected)
+
+        assertEquals(expected, interactor.getPage(page = 2))
+    }
+
+    @Test
+    fun clearExactMediaHistory_invalidatesExactItemOnlyAfterSuccessfulMutation() = runTest {
+        val history = movie(recordId = 1, videoId = 73001, videoNumber = 2)
+        coEvery { api.clearExactMediaHistory(73001) } returns Result.success(Unit)
+
+        interactor.clearExactMediaHistory(
+            mediaId = requireNotNull(history.video).id,
+            itemId = 72001,
+        )
+
+        coVerifyOrder {
+            api.clearExactMediaHistory(73001)
+            itemDetailsRepository.invalidate(72001)
+        }
+        verify(exactly = 1) { itemDetailsRepository.invalidate(72001) }
+    }
+
+    @Test
+    fun clearExactMediaHistory_doesNotInvalidateItemWhenMutationFails() = runTest {
+        coEvery { api.clearExactMediaHistory(73001) } returns
+            Result.failure(IOException("delete failure"))
+
+        val failure = runCatching {
+            interactor.clearExactMediaHistory(mediaId = 73001, itemId = 72001)
+        }.exceptionOrNull()
+
+        assertTrue(failure is IOException)
+        coVerify(exactly = 1) { api.clearExactMediaHistory(73001) }
+        verify(exactly = 0) { itemDetailsRepository.invalidate(any()) }
+    }
+
+    @Test
+    fun invalidateItemDetails_invalidatesSelectedItemCacheEntry() {
+        interactor.invalidateItemDetails(itemId = 72001)
+
+        verify(exactly = 1) { itemDetailsRepository.invalidate(72001) }
+    }
+
+    @Test
+    fun filterFirstOccurrences_preservesFirstOccurrenceWithinAndAcrossPages() {
+        val traversal = HistoryTraversal()
+        val firstMovie = movie(recordId = 1, videoId = 11, videoNumber = 2)
+        val duplicateMovie = movie(recordId = 2, videoId = 12, videoNumber = 2)
+        val firstEpisode = episode(recordId = 3, videoId = 13, season = 1, episode = 4)
+        val secondEpisode = episode(recordId = 4, videoId = 14, season = 1, episode = 5)
+
+        val firstPage = traversal.filterFirstOccurrences(
+            listOf(firstMovie, duplicateMovie, firstEpisode, secondEpisode),
+        )
+        val laterPage = traversal.filterFirstOccurrences(
+            listOf(
+                movie(recordId = 5, videoId = 15, videoNumber = 2),
+                episode(recordId = 6, videoId = 16, season = 1, episode = 4),
+                movie(recordId = 7, videoId = 17, videoNumber = 3),
+            ),
+        )
+
+        assertEquals(listOf(firstMovie, firstEpisode, secondEpisode), firstPage)
+        assertEquals(listOf(movie(recordId = 7, videoId = 17, videoNumber = 3)), laterPage)
+    }
+
+    @Test
+    fun newTraversal_allowsAuthoritativePageOneToRebuildIdentity() {
+        val history = movie(recordId = 1, videoId = 11, videoNumber = 2)
+        val firstTraversal = HistoryTraversal()
+        assertEquals(listOf(history), firstTraversal.filterFirstOccurrences(listOf(history)))
+        assertEquals(emptyList<History>(), firstTraversal.filterFirstOccurrences(listOf(history)))
+
+        val refreshedTraversal = HistoryTraversal()
+
+        assertEquals(listOf(history), refreshedTraversal.filterFirstOccurrences(listOf(history)))
+    }
+
+    @Test
+    fun seededTraversal_rebuildsSeenKeysFromStableContent() {
+        val seededMovie = movie(recordId = 1, videoId = 11, videoNumber = 2)
+        val seededEpisode = episode(recordId = 2, videoId = 12, season = 2, episode = 3)
+        val traversal = HistoryTraversal(listOf(seededMovie, seededEpisode))
+
+        val filtered = traversal.filterFirstOccurrences(
+            listOf(
+                movie(recordId = 3, videoId = 13, videoNumber = 2),
+                episode(recordId = 4, videoId = 14, season = 2, episode = 3),
+                episode(recordId = 5, videoId = 15, season = 2, episode = 4),
+            ),
+        )
+
+        assertEquals(listOf(episode(recordId = 5, videoId = 15, season = 2, episode = 4)), filtered)
+    }
+
+    @Test
+    fun filterFirstOccurrences_keepsIncompleteSeriesByDeletionMediaIdentityForDetailsFallback() {
+        val traversal = HistoryTraversal()
+        val first = episode(recordId = null, videoId = 11, season = null, episode = 3)
+        val second = episode(recordId = null, videoId = 12, season = null, episode = 3)
+
+        assertEquals(listOf(first, second), traversal.filterFirstOccurrences(listOf(first, second)))
+        assertEquals(null, first.semanticKeyOrNull())
+        assertEquals(HistoryRowKey.DeletionMedia(mediaId = 11), first.rowKeyOrNull())
+    }
+
+    @Test
+    fun filterFirstOccurrences_deduplicatesFallbackRowsByDeletionMediaIdAcrossPages() {
+        val traversal = HistoryTraversal()
+        val first = episode(recordId = null, videoId = 11, season = null, episode = 3)
+        val duplicate = episode(recordId = null, videoId = 11, season = null, episode = 4)
+
+        assertEquals(listOf(first), traversal.filterFirstOccurrences(listOf(first, duplicate)))
+        assertEquals(emptyList<History>(), traversal.filterFirstOccurrences(listOf(duplicate)))
+    }
+
+    @Test
+    fun filterFirstOccurrences_filtersUnsupportedOrUnusableRows() {
+        val traversal = HistoryTraversal()
+        val unsupported = movie(
+            recordId = 1,
+            videoId = 11,
+            videoNumber = 2,
+            type = ItemType.UNKNOWN_VALUE,
+        )
+        val missingMovieNumber = movie(recordId = 2, videoId = 12, videoNumber = null)
+        val missingMedia = movie(recordId = 3, videoId = null, videoNumber = null)
+
+        assertEquals(
+            emptyList<History>(),
+            traversal.filterFirstOccurrences(listOf(unsupported, missingMovieNumber, missingMedia)),
+        )
+    }
+
+    private fun movie(
+        recordId: Int?,
+        videoId: Int?,
+        videoNumber: Int?,
+        type: ItemType = ItemType.MOVIE,
+    ): History {
+        return history(
+            recordId = recordId,
+            videoId = videoId,
+            videoNumber = videoNumber,
+            type = type,
+        )
+    }
+
+    private fun episode(
+        recordId: Int?,
+        videoId: Int,
+        season: Int?,
+        episode: Int?,
+    ): History {
+        return history(
+            recordId = recordId,
+            videoId = videoId,
+            videoNumber = episode,
+            type = ItemType.SERIAL,
+            season = season,
+        )
+    }
+
+    private fun history(
+        recordId: Int?,
+        videoId: Int?,
+        videoNumber: Int?,
+        type: ItemType,
+        season: Int? = null,
+    ): History {
+        return History(
+            recordId = recordId,
+            item = Item(id = 100, title = "Synthetic", type = type),
+            video = videoId?.let { Video(id = it, number = videoNumber) },
+            season = season,
+        )
+    }
+}

--- a/app/src/test/kotlin/com/kino/puber/domain/interactor/player/PlayerInteractorTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/domain/interactor/player/PlayerInteractorTest.kt
@@ -5,8 +5,10 @@ import com.kino.puber.data.api.models.Episode
 import com.kino.puber.data.api.models.Item
 import com.kino.puber.data.api.models.ItemType
 import com.kino.puber.data.api.models.Season
+import com.kino.puber.data.api.models.Video
 import com.kino.puber.data.api.models.VideoFile
 import com.kino.puber.data.api.models.VideoUrl
+import com.kino.puber.data.api.models.WatchingInfo
 import com.kino.puber.data.api.models.WatchingStatus
 import com.kino.puber.data.api.models.WatchingToggleResponse
 import com.kino.puber.data.repository.ItemDetailsRepository
@@ -52,10 +54,21 @@ class PlayerInteractorTest {
         seasons = listOf(season1, season2),
     )
 
+    private val movieVideo1 = Video(
+        id = 101,
+        number = 1,
+        files = listOf(VideoFile(url = VideoUrl(hls = "hls://movie-1.m3u8"))),
+    )
+    private val movieVideo2 = Video(
+        id = 102,
+        number = 2,
+        files = listOf(VideoFile(url = VideoUrl(hls = "hls://movie-2.m3u8"))),
+    )
     private val movieItem = Item(
         id = 10,
         title = "Test Movie",
         type = ItemType.MOVIE,
+        videos = listOf(movieVideo1, movieVideo2),
     )
 
     // endregion
@@ -278,8 +291,94 @@ class PlayerInteractorTest {
     }
 
     @Test
-    fun resolveMedia_movie_setsWatchedStateFromItem() {
+    fun resolveMedia_movieWithoutExplicitNumber_selectsFirstVideo() {
+        val result = interactor.resolveMedia(
+            item = movieItem,
+            seasonNumber = null,
+            episodeNumber = null,
+            videoNumber = null,
+        )
+
+        assertEquals(movieVideo1.number, result.videoNumber)
+        assertEquals(movieVideo1.files, result.files)
+    }
+
+    @Test
+    fun resolveMedia_movieWithExplicitNumber_selectsExactVideo() {
+        val result = interactor.resolveMedia(
+            item = movieItem,
+            seasonNumber = null,
+            episodeNumber = null,
+            videoNumber = 2,
+        )
+
+        assertEquals(movieVideo2.number, result.videoNumber)
+        assertEquals(movieVideo2.files, result.files)
+    }
+
+    @Test
+    fun resolveMedia_movieWithMissingExplicitNumber_doesNotFallback() {
+        val result = interactor.resolveMedia(
+            item = movieItem,
+            seasonNumber = null,
+            episodeNumber = null,
+            videoNumber = 99,
+        )
+
+        assertNull(result.videoNumber)
+        assertNull(result.files)
+        assertNull(result.audios)
+        assertNull(result.subtitles)
+    }
+
+    @Test
+    fun resolveMedia_series_ignoresMovieVideoNumber() {
+        val result = interactor.resolveMedia(
+            item = serialItem,
+            seasonNumber = 1,
+            episodeNumber = 2,
+            videoNumber = 99,
+        )
+
+        assertEquals(episode2.number, result.videoNumber)
+        assertEquals(1, result.seasonNumber)
+        assertEquals(2, result.episodeNumber)
+    }
+
+    @Test
+    fun resolveMedia_movieFallsBackToItemWatchedStateWhenSelectedVideoHasNoStatus() {
         val result = interactor.resolveMedia(movieItem.copy(watched = 1), seasonNumber = null, episodeNumber = null)
+        assertTrue(result.isCurrentMediaWatched)
+    }
+
+    @Test
+    fun resolveMedia_movieUsesSelectedVideoWatchedState() {
+        val item = movieItem.copy(
+            watched = 1,
+            videos = listOf(
+                movieVideo1.copy(watched = 0),
+                movieVideo2.copy(watched = 1),
+            ),
+        )
+
+        val first = interactor.resolveMedia(item, seasonNumber = null, episodeNumber = null, videoNumber = 1)
+        val second = interactor.resolveMedia(item, seasonNumber = null, episodeNumber = null, videoNumber = 2)
+
+        assertFalse(first.isCurrentMediaWatched)
+        assertTrue(second.isCurrentMediaWatched)
+    }
+
+    @Test
+    fun resolveMedia_movieUsesSelectedVideoWatchingStatus() {
+        val item = movieItem.copy(
+            videos = listOf(
+                movieVideo1.copy(watching = WatchingInfo(status = 1)),
+                movieVideo2,
+            ),
+        )
+
+        val result = interactor.resolveMedia(item, seasonNumber = null, episodeNumber = null, videoNumber = 1)
+
         assertTrue(result.isCurrentMediaWatched)
     }
 
@@ -331,19 +430,21 @@ class PlayerInteractorTest {
     }
 
     @Test
-    fun markCurrentAsWatched_movieMarksAndRefreshesItem() = runTest {
-        val refreshed = movieItem.copy(watched = 1)
+    fun markCurrentAsWatched_movieUsesExactVideoAndRefreshesItem() = runTest {
+        val refreshed = movieItem.copy(
+            videos = listOf(movieVideo1, movieVideo2.copy(watched = 1)),
+        )
         coEvery {
-            api.toggleWatchingStatus(id = 10, status = 1, season = null, video = null)
+            api.toggleWatchingStatus(id = 10, status = 1, season = null, video = 2)
         } returns Result.success(WatchingToggleResponse(status = 1, watched = 1))
         every { itemDetailsRepository.invalidate(10) } returns Unit
         coEvery { itemDetailsRepository.getItemDetails(10) } returns refreshed
 
-        val result = interactor.markCurrentAsWatched(id = 10)
+        val result = interactor.markCurrentAsWatched(id = 10, videoNumber = 2)
 
         assertEquals(refreshed, result)
         coVerify(exactly = 1) {
-            api.toggleWatchingStatus(id = 10, status = 1, season = null, video = null)
+            api.toggleWatchingStatus(id = 10, status = 1, season = null, video = 2)
         }
         verify(exactly = 1) { itemDetailsRepository.invalidate(10) }
         coVerify(exactly = 1) { itemDetailsRepository.getItemDetails(10) }
@@ -358,7 +459,7 @@ class PlayerInteractorTest {
         every { itemDetailsRepository.invalidate(42) } returns Unit
         coEvery { itemDetailsRepository.getItemDetails(42) } returns refreshed
 
-        val result = interactor.markCurrentAsWatched(id = 42, season = 1, episode = 1)
+        val result = interactor.markCurrentAsWatched(id = 42, season = 1, videoNumber = 1)
 
         assertEquals(refreshed, result)
         coVerify(exactly = 1) {
@@ -377,7 +478,7 @@ class PlayerInteractorTest {
         coEvery { itemDetailsRepository.getItemDetails(42) } throws IllegalStateException("refresh failed")
 
         val failure = runCatching {
-            interactor.markCurrentAsWatched(id = 42, season = 1, episode = 1)
+            interactor.markCurrentAsWatched(id = 42, season = 1, videoNumber = 1)
         }.exceptionOrNull()
 
         assertTrue(failure is WatchedDetailsRefreshException)

--- a/app/src/test/kotlin/com/kino/puber/ui/feature/auth/vm/AuthVMTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/ui/feature/auth/vm/AuthVMTest.kt
@@ -1,8 +1,11 @@
 package com.kino.puber.ui.feature.auth.vm
 
+import com.kino.puber.R
+import com.kino.puber.core.error.DefaultErrorHandler
 import com.kino.puber.core.error.ErrorEntity
 import com.kino.puber.core.error.ErrorHandler
 import com.kino.puber.core.ui.navigation.AppRouter
+import com.kino.puber.core.ui.uikit.model.SnackbarMessage
 import com.kino.puber.domain.interactor.api.ApiDomainAutoResolveResult
 import com.kino.puber.domain.interactor.api.ApiDomainInteractor
 import com.kino.puber.domain.interactor.api.ApiDomainState
@@ -39,7 +42,9 @@ class AuthVMTest {
     private val deviceInfoInteractor = mockk<IDeviceInfoInteractor>(relaxed = true)
     private val apiDomainInteractor = mockk<ApiDomainInteractor>(relaxed = true)
 
-    private fun createVM(): AuthVM {
+    private fun createVM(
+        authErrorHandler: ErrorHandler = errorHandler,
+    ): AuthVM {
         every { apiDomainInteractor.getState() } returns ApiDomainState(
             domain = "api.example.com",
             customDomain = null,
@@ -49,7 +54,7 @@ class AuthVMTest {
             deviceInfoInteractor = deviceInfoInteractor,
             apiDomainInteractor = apiDomainInteractor,
             resources = FakeResourceProvider(),
-            errorHandler = errorHandler,
+            errorHandler = authErrorHandler,
             router = router,
         )
     }
@@ -108,5 +113,21 @@ class AuthVMTest {
 
         verify(exactly = 1) { errorHandler.proceedInvoke(any(), any()) }
         coVerify(exactly = 0) { apiDomainInteractor.detectAndSaveAlternativeBuiltInDomain() }
+    }
+
+    @Test
+    fun transportFailure_displaysResourceBackedCopyWithoutRawExceptionMessage() {
+        val transportDetails = "OAuth response decoding failed: HTTP 502 error response"
+        every { authInteractor.isAuthenticated() } returns false
+        every { authInteractor.getAuthState() } returns flow {
+            throw IllegalStateException(transportDetails)
+        }
+        val vm = createVM(DefaultErrorHandler(FakeResourceProvider()))
+
+        vm.testOnStart()
+
+        val message = vm.testMessageValue as SnackbarMessage.Short
+        assertEquals("string_${R.string.error_generic}", message.message)
+        assertTrue(message.message.contains(transportDetails).not())
     }
 }

--- a/app/src/test/kotlin/com/kino/puber/ui/feature/details/component/DetailsScreenKeyTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/ui/feature/details/component/DetailsScreenKeyTest.kt
@@ -1,0 +1,28 @@
+package com.kino.puber.ui.feature.details.component
+
+import com.kino.puber.ui.feature.details.model.DetailsEpisodeTarget
+import com.kino.puber.ui.feature.details.model.DetailsScreenParams
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+
+internal class DetailsScreenKeyTest {
+
+    @Test
+    fun initialEpisodeUsesStableDistinctLifecycleKey() {
+        val plain = DetailsScreen(DetailsScreenParams(itemId = 42))
+        val episode = DetailsScreen(
+            DetailsScreenParams(
+                itemId = 42,
+                initialEpisode = DetailsEpisodeTarget(
+                    seasonNumber = 3,
+                    episodeNumber = 4,
+                ),
+            ),
+        )
+
+        assertEquals("DetailsScreen_42", plain.key)
+        assertEquals("DetailsScreen_42_s3_e4", episode.key)
+        assertNotEquals(plain.key, episode.key)
+    }
+}

--- a/app/src/test/kotlin/com/kino/puber/ui/feature/details/model/DetailsScreenUIMapperTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/ui/feature/details/model/DetailsScreenUIMapperTest.kt
@@ -81,6 +81,38 @@ class DetailsScreenUIMapperTest {
         assertEquals("2", state.audioTracksRowValue())
     }
 
+    @Test
+    fun map_initialEpisodeSelectsExactEpisodeForPanelFocus() {
+        val state = mapper.map(
+            item = series(
+                trailer = null,
+                seasons = listOf(
+                    Season(
+                        id = 1,
+                        number = 1,
+                        episodes = listOf(Episode(id = 101, number = 1)),
+                    ),
+                    Season(
+                        id = 2,
+                        number = 2,
+                        episodes = listOf(
+                            Episode(id = 201, number = 1),
+                            Episode(id = 204, number = 4),
+                        ),
+                    ),
+                ),
+            ),
+            isInWatchlist = false,
+            initialEpisode = DetailsEpisodeTarget(
+                seasonNumber = 2,
+                episodeNumber = 4,
+            ),
+        )
+
+        assertEquals(204, state.currentEpisode?.id)
+        assertEquals(204, state.initialEpisodeFocusId)
+    }
+
     private inline fun <reified T : DetailsButtonUIState> List<DetailsButtonUIState>.count(
         action: DetailsAction,
     ): Int {

--- a/app/src/test/kotlin/com/kino/puber/ui/feature/details/vm/DetailsVMTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/ui/feature/details/vm/DetailsVMTest.kt
@@ -20,6 +20,7 @@ import com.kino.puber.domain.interactor.details.MovieBookmarkUpdate
 import com.kino.puber.domain.interactor.details.MovieWatchedUpdate
 import com.kino.puber.domain.interactor.details.WatchedUpdate
 import com.kino.puber.ui.feature.details.model.DetailsAction
+import com.kino.puber.ui.feature.details.model.DetailsEpisodeTarget
 import com.kino.puber.ui.feature.details.model.DetailsInfoUIState
 import com.kino.puber.ui.feature.details.model.DetailsScreenParams
 import com.kino.puber.ui.feature.details.model.DetailsScreenState
@@ -142,6 +143,33 @@ class DetailsVMTest {
         verify {
             router.navigateForResult<ContentChangeSet>(detailsScreen, RESULT_CONTENT_CHANGED, any())
         }
+    }
+
+    @Test
+    fun historyEpisodeParamsOpenPanelWithExactEpisodeFocusTarget() {
+        val target = DetailsEpisodeTarget(seasonNumber = 1, episodeNumber = 2)
+        val mapped = content().copy(
+            currentEpisode = videoItem(id = 101, seasonNumber = 1, episodeNumber = 2),
+            initialEpisodeFocusId = 101,
+        )
+        every {
+            mapper.map(
+                item = testItem,
+                isInWatchlist = false,
+                initialEpisode = target,
+            )
+        } returns mapped
+        val vm = startedVM(
+            DetailsScreenParams(
+                itemId = 42,
+                initialEpisode = target,
+            ),
+        )
+
+        val content = vm.testStateValue as DetailsScreenState.Content
+        assertTrue(content.seasonsPanelVisible)
+        assertEquals(101, content.currentEpisode?.id)
+        assertEquals(101, content.initialEpisodeFocusId)
     }
 
     @Test
@@ -581,9 +609,13 @@ class DetailsVMTest {
         verifyContentChangeBack(itemId = 42, ContentChangeType.Watched)
     }
 
-    private fun startedVM(): DetailsVM = createVM().also { it.testOnStart() }
+    private fun startedVM(
+        params: DetailsScreenParams = this.params,
+    ): DetailsVM = createVM(params).also { it.testOnStart() }
 
-    private fun createVM() = DetailsVM(
+    private fun createVM(
+        params: DetailsScreenParams = this.params,
+    ) = DetailsVM(
         router = router,
         params = params,
         mapper = mapper,

--- a/app/src/test/kotlin/com/kino/puber/ui/feature/history/component/HistoryContextMenuTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/ui/feature/history/component/HistoryContextMenuTest.kt
@@ -1,0 +1,114 @@
+package com.kino.puber.ui.feature.history.component
+
+import com.kino.puber.R
+import com.kino.puber.core.ui.uikit.component.moviesList.VideoItemUIState
+import com.kino.puber.domain.interactor.history.HistoryRowKey
+import com.kino.puber.domain.interactor.history.HistorySemanticKey
+import com.kino.puber.ui.feature.history.model.HistoryItemUIState
+import com.kino.puber.ui.feature.history.model.HistoryPlaybackTarget
+import com.kino.puber.ui.feature.player.model.PlayerStartMode
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class HistoryContextMenuTest {
+
+    @Test
+    fun playbackActionTitleUsesContinueForUnfinishedProgress() {
+        val action = historyPlaybackMenuAction(
+            historyItem(progressPercent = 0.42F, isWatched = false),
+        )
+        assertEquals(R.string.history_context_continue, action?.titleRes)
+        assertEquals(PlayerStartMode.ResumeIfAvailable, action?.startMode)
+    }
+
+    @Test
+    fun playbackActionTitleUsesStartOverWithoutResumableProgress() {
+        listOf(
+            historyItem(progressPercent = null, isWatched = false),
+            historyItem(progressPercent = 0F, isWatched = false),
+            historyItem(progressPercent = 0.42F, isWatched = true),
+        ).forEach { item ->
+            val action = historyPlaybackMenuAction(item)
+            assertEquals(R.string.history_context_play, action?.titleRes)
+            assertEquals(PlayerStartMode.StartFromBeginning, action?.startMode)
+        }
+    }
+
+    @Test
+    fun fallbackDetailsRowHasNoPlaybackMenuIntent() {
+        assertNull(
+            historyPlaybackMenuAction(
+                historyItem(
+                    progressPercent = 0.42F,
+                    isWatched = false,
+                    playbackTarget = HistoryPlaybackTarget.Details,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun localizedPlaybackLabelsMatchApprovedCopy() {
+        val strings = String(
+            Files.readAllBytes(resolveStringsResource()),
+            StandardCharsets.UTF_8,
+        )
+
+        assertTrue(
+            strings.contains(
+                """<string name="history_context_continue">Продолжить просмотр</string>""",
+            ),
+        )
+        assertTrue(
+            strings.contains(
+                """<string name="history_context_play">Смотреть сначала</string>""",
+            ),
+        )
+    }
+
+    private fun historyItem(
+        progressPercent: Float?,
+        isWatched: Boolean,
+        playbackTarget: HistoryPlaybackTarget = HistoryPlaybackTarget.Movie(videoNumber = 1),
+    ): HistoryItemUIState {
+        val semanticKey = if (playbackTarget == HistoryPlaybackTarget.Details) {
+            null
+        } else {
+            HistorySemanticKey.Movie(itemId = 42, videoNumber = 1)
+        }
+        return HistoryItemUIState(
+            itemId = 42,
+            deletionMediaId = 2,
+            rowKey = semanticKey?.let(HistoryRowKey::Media) ?: HistoryRowKey.DeletionMedia(2),
+            semanticKey = semanticKey,
+            videoNumber = semanticKey?.videoNumber,
+            seasonNumber = null,
+            episodeNumber = null,
+            progressPercent = progressPercent,
+            isWatched = isWatched,
+            lastViewedAt = null,
+            playbackTarget = playbackTarget,
+            card = VideoItemUIState(
+                id = 42,
+                title = "Synthetic title",
+                imageUrl = "",
+                bigImageUrl = "",
+            ),
+        )
+    }
+
+    private fun resolveStringsResource(): Path {
+        val workingDirectory = Path.of(System.getProperty("user.dir"))
+        val candidates = listOf(
+            workingDirectory.resolve("src/main/res/values/strings.xml"),
+            workingDirectory.resolve("app/src/main/res/values/strings.xml"),
+        )
+        return candidates.firstOrNull(Files::exists)
+            ?: error("Unable to locate values/strings.xml")
+    }
+}

--- a/app/src/test/kotlin/com/kino/puber/ui/feature/history/model/HistoryUIMapperTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/ui/feature/history/model/HistoryUIMapperTest.kt
@@ -1,0 +1,307 @@
+package com.kino.puber.ui.feature.history.model
+
+import com.kino.puber.core.ui.model.VideoItemUIMapper
+import com.kino.puber.data.api.models.History
+import com.kino.puber.data.api.models.Item
+import com.kino.puber.data.api.models.ItemType
+import com.kino.puber.data.api.models.Posters
+import com.kino.puber.data.api.models.Video
+import com.kino.puber.data.api.models.WatchingInfo
+import com.kino.puber.data.repository.PlayerPreferencesRepository
+import com.kino.puber.domain.interactor.history.HistoryRowKey
+import com.kino.puber.domain.interactor.history.HistorySemanticKey
+import com.kino.puber.util.FakeResourceProvider
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import io.mockk.every
+import io.mockk.mockk
+
+class HistoryUIMapperTest {
+
+    private val mapper = HistoryUIMapper(VideoItemUIMapper(FakeResourceProvider()))
+
+    @Test
+    fun mapMovie_keepsItemPlaybackAndDeletionIdentityWithoutInventingRecordIdentity() {
+        val state = requireNotNull(
+            mapper.map(
+                movie(
+                    recordId = null,
+                    itemId = 72001,
+                    videoId = 73001,
+                    videoNumber = 2,
+                    watching = WatchingInfo(time = 1_200, duration = 4_800, status = 0),
+                    watched = 0,
+                    updated = "2100-01-01T00:00:00Z",
+                ),
+            ),
+        )
+
+        assertEquals(72001, state.itemId)
+        assertEquals(73001, state.deletionMediaId)
+        assertEquals(
+            HistoryRowKey.Media(
+                HistorySemanticKey.Movie(itemId = 72001, videoNumber = 2),
+            ),
+            state.rowKey,
+        )
+        assertEquals(HistorySemanticKey.Movie(itemId = 72001, videoNumber = 2), state.semanticKey)
+        assertEquals(2, state.videoNumber)
+        assertNull(state.seasonNumber)
+        assertNull(state.episodeNumber)
+        assertEquals(HistoryPlaybackTarget.Movie(videoNumber = 2), state.playbackTarget)
+        assertEquals(0.25F, state.progressPercent)
+        assertFalse(state.isWatched)
+        assertEquals("2100-01-01T00:00:00Z", state.lastViewedAt)
+        assertEquals(72001, state.card.id)
+        assertEquals("https://assets.example.test/wide.jpg", state.card.wideImageUrl)
+        assertEquals(state.progressPercent, state.card.progressPercent)
+        assertEquals(state.isWatched, state.card.isWatched)
+        assertTrue(state.card.ratings.isEmpty())
+        assertNull(state.card.unwatchedCount)
+    }
+
+    @Test
+    fun mapSeries_preservesExactSeasonAndEpisodeIdentity() {
+        val state = requireNotNull(
+            mapper.map(
+                episode(
+                    recordId = null,
+                    itemId = 82001,
+                    videoId = 83001,
+                    season = 4,
+                    episode = 9,
+                ),
+            ),
+        )
+
+        assertEquals(
+            HistorySemanticKey.Episode(itemId = 82001, seasonNumber = 4, episodeNumber = 9),
+            state.semanticKey,
+        )
+        assertNull(state.videoNumber)
+        assertEquals(4, state.seasonNumber)
+        assertEquals(9, state.episodeNumber)
+        assertEquals(
+            HistoryPlaybackTarget.Episode(seasonNumber = 4, episodeNumber = 9),
+            state.playbackTarget,
+        )
+        assertEquals(4, state.card.seasonNumber)
+        assertEquals(9, state.card.episodeNumber)
+    }
+
+    @Test
+    fun mapSeries_routesIncompleteCoordinatesToDetails() {
+        val history = episode(
+            recordId = null,
+            itemId = 82001,
+            videoId = 83001,
+            season = null,
+            episode = 9,
+        )
+
+        val state = requireNotNull(mapper.map(history))
+
+        assertEquals(HistoryRowKey.DeletionMedia(mediaId = 83001), state.rowKey)
+        assertNull(state.semanticKey)
+        assertEquals(HistoryPlaybackTarget.Details, state.playbackTarget)
+        assertNull(state.videoNumber)
+        assertNull(state.seasonNumber)
+        assertNull(state.episodeNumber)
+    }
+
+    @Test
+    fun map_usesNestedWatchingDurationAndHidesProgressWhenItIsMissing() {
+        val state = requireNotNull(
+            mapper.map(
+                movie(
+                    recordId = null,
+                    itemId = 2,
+                    videoId = 3,
+                    videoNumber = 1,
+                    watching = WatchingInfo(time = 600, duration = 0, status = 0),
+                    videoDuration = 2_400,
+                ),
+            ),
+        )
+
+        assertNull(state.progressPercent)
+        assertNull(state.card.progressPercent)
+    }
+
+    @Test
+    fun map_prefersMediaWatchedFlagAndFallsBackToWatchingStatusOnlyWhenAbsent() {
+        val explicitNotWatched = requireNotNull(
+            mapper.map(
+                movie(
+                    recordId = null,
+                    itemId = 2,
+                    videoId = 3,
+                    videoNumber = 1,
+                    watching = WatchingInfo(status = 1),
+                    watched = 0,
+                ),
+            ),
+        )
+        val fallbackWatched = requireNotNull(
+            mapper.map(
+                movie(
+                    recordId = null,
+                    itemId = 2,
+                    videoId = 4,
+                    videoNumber = 2,
+                    watching = WatchingInfo(status = 1),
+                    watched = null,
+                ),
+            ),
+        )
+
+        assertFalse(explicitNotWatched.isWatched)
+        assertTrue(fallbackWatched.isWatched)
+    }
+
+    @Test
+    fun map_retainsCompletedEntries() {
+        val completed = movie(
+            recordId = null,
+            itemId = 2,
+            videoId = 3,
+            videoNumber = 1,
+            watching = WatchingInfo(time = 2_400, duration = 2_400, status = 1),
+            watched = 1,
+        )
+
+        val states = mapper.map(listOf(completed))
+
+        assertEquals(1, states.size)
+        assertTrue(states.single().isWatched)
+    }
+
+    @Test
+    fun map_completedEntryForcesWatchedIndicatorWhenSharedPreferenceIsOff() {
+        val preferences = mockk<PlayerPreferencesRepository>()
+        every { preferences.watchedIndicatorsEnabled } returns false
+        val historyMapper = HistoryUIMapper(
+            VideoItemUIMapper(
+                resources = FakeResourceProvider(),
+                playerPreferencesRepository = preferences,
+            ),
+        )
+        val completed = movie(
+            recordId = null,
+            itemId = 2,
+            videoId = 3,
+            videoNumber = 1,
+            watching = WatchingInfo(time = 2_400, duration = 2_400, status = 1),
+            watched = 1,
+        )
+
+        val state = requireNotNull(historyMapper.map(completed))
+
+        assertTrue(state.isWatched)
+        assertTrue(state.card.isWatched)
+        assertTrue(state.card.showWatchedIndicator)
+    }
+
+    @Test
+    fun map_keepsDifferentEpisodesOfOneSeriesDistinct() {
+        val states = mapper.map(
+            listOf(
+                episode(recordId = null, itemId = 2, videoId = 3, season = 1, episode = 4),
+                episode(recordId = null, itemId = 2, videoId = 4, season = 1, episode = 5),
+            ),
+        )
+
+        assertEquals(
+            listOf(
+                HistorySemanticKey.Episode(itemId = 2, seasonNumber = 1, episodeNumber = 4),
+                HistorySemanticKey.Episode(itemId = 2, seasonNumber = 1, episodeNumber = 5),
+            ),
+            states.map(HistoryItemUIState::semanticKey),
+        )
+    }
+
+    @Test
+    fun map_filtersUnsupportedOrUnusableRows() {
+        val unsupported = movie(
+            recordId = null,
+            itemId = 2,
+            videoId = 3,
+            videoNumber = 1,
+            type = ItemType.UNKNOWN_VALUE,
+        )
+        val missingMovieNumber = movie(
+            recordId = null,
+            itemId = 2,
+            videoId = 4,
+            videoNumber = null,
+        )
+        val missingMedia = History(
+            recordId = 3,
+            item = item(id = 2, type = ItemType.MOVIE),
+            video = null,
+        )
+
+        assertEquals(
+            emptyList<HistoryItemUIState>(),
+            mapper.map(listOf(unsupported, missingMovieNumber, missingMedia)),
+        )
+    }
+
+    private fun movie(
+        recordId: Int?,
+        itemId: Int,
+        videoId: Int,
+        videoNumber: Int?,
+        watching: WatchingInfo? = null,
+        watched: Int? = null,
+        updated: String? = null,
+        videoDuration: Int? = null,
+        type: ItemType = ItemType.MOVIE,
+    ): History {
+        return History(
+            recordId = recordId,
+            item = item(id = itemId, type = type),
+            video = Video(
+                id = videoId,
+                number = videoNumber,
+                duration = videoDuration,
+                watched = watched,
+                watching = watching,
+            ),
+            updated = updated,
+        )
+    }
+
+    private fun episode(
+        recordId: Int?,
+        itemId: Int,
+        videoId: Int,
+        season: Int?,
+        episode: Int?,
+    ): History {
+        return History(
+            recordId = recordId,
+            item = item(id = itemId, type = ItemType.SERIAL),
+            video = Video(id = videoId, number = episode),
+            season = season,
+        )
+    }
+
+    private fun item(id: Int, type: ItemType): Item {
+        return Item(
+            id = id,
+            title = "Synthetic title",
+            type = type,
+            posters = Posters(
+                medium = "https://assets.example.test/medium.jpg",
+                big = "https://assets.example.test/big.jpg",
+                wide = "https://assets.example.test/wide.jpg",
+            ),
+            new = 3,
+            kinopoiskRating = "7.2",
+        )
+    }
+}

--- a/app/src/test/kotlin/com/kino/puber/ui/feature/history/vm/HistoryRuntimeStoreTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/ui/feature/history/vm/HistoryRuntimeStoreTest.kt
@@ -1,0 +1,136 @@
+package com.kino.puber.ui.feature.history.vm
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import kotlin.concurrent.thread
+
+class HistoryRuntimeStoreTest {
+
+    @Test
+    fun update_serializesConcurrentMultiFieldTransitionsWithoutLostRevisions() {
+        val store = HistoryRuntimeStore()
+        val start = CountDownLatch(1)
+        val workers = List(WORKER_COUNT) {
+            thread(start = true) {
+                start.await()
+                repeat(UPDATES_PER_WORKER) {
+                    store.update { state ->
+                        state.copy(
+                            currentPage = state.currentPage + 1,
+                            pageAttemptRevision = state.pageAttemptRevision + 1L,
+                        )
+                    }
+                }
+            }
+        }
+
+        start.countDown()
+        workers.forEach(Thread::join)
+
+        val finalState = store.snapshot()
+        val expected = WORKER_COUNT * UPDATES_PER_WORKER
+        assertEquals(expected, finalState.currentPage)
+        assertEquals(expected.toLong(), finalState.pageAttemptRevision)
+    }
+
+    @Test
+    fun prepareContentPublication_keepsOperationGatedUntilUiCommit() {
+        val rowKey = com.kino.puber.domain.interactor.history.HistoryRowKey.DeletionMedia(1)
+        val publication = HistoryOperation.AwaitingPublication(
+            operationId = 7L,
+            kind = HistoryPublicationKind.FIRST_PAGE,
+        )
+        val store = HistoryRuntimeStore(
+            HistoryRuntimeState(
+                operation = publication,
+                requestedFocusKey = rowKey,
+            ),
+        )
+
+        val prepared = store.prepareContentPublication(
+            availableKeys = setOf(rowKey),
+            paginatorFocusKey = null,
+        )
+
+        assertEquals(publication, prepared.operation)
+        assertEquals(rowKey, prepared.requestedFocusKey)
+        assertEquals(publication, store.snapshot().operation)
+    }
+
+    @Test
+    fun authoritativeEmptyPublicationClearsDeferredRefresh() {
+        val store = HistoryRuntimeStore(
+            HistoryRuntimeState(
+                operation = HistoryOperation.AwaitingPublication(
+                    operationId = 7L,
+                    kind = HistoryPublicationKind.FIRST_PAGE,
+                ),
+                refreshAfterPendingOperation = true,
+            ),
+        )
+
+        assertEquals(true, store.completeEmptyPublication())
+        assertFalse(store.snapshot().refreshAfterPendingOperation)
+    }
+
+    @Test
+    fun duplicateRestartIsRejectedBeforeFirstPageSideEffectStarts() {
+        val store = HistoryRuntimeStore()
+
+        assertTrue(store.beginRestart())
+        assertFalse(store.beginRestart())
+        assertTrue(store.beginFirstPage() != null)
+        assertNull(store.beginFirstPage())
+    }
+
+    @Test
+    fun deferredRefreshReservationBlocksNextPageThenReservesAtomically() {
+        val store = HistoryRuntimeStore(
+            HistoryRuntimeState(
+                currentPage = 1,
+                refreshAfterPendingOperation = true,
+            ),
+        )
+
+        assertFalse(store.beginNextPage())
+        assertTrue(store.beginDeferredRefresh())
+        val reserved = store.snapshot()
+        assertFalse(reserved.refreshAfterPendingOperation)
+        assertTrue(reserved.operation is HistoryOperation.RefreshRequested)
+    }
+
+    @Test
+    fun authoritativeEmptyPublicationDropsStaleQueuedDeletionAndFocus() {
+        val queuedKey = com.kino.puber.domain.interactor.history.HistoryRowKey.DeletionMedia(9)
+        val store = HistoryRuntimeStore(
+            HistoryRuntimeState(
+                operation = HistoryOperation.AwaitingPublication(
+                    operationId = 7L,
+                    kind = HistoryPublicationKind.FIRST_PAGE,
+                ),
+                queuedDeletion = HistoryQueuedDeletion(
+                    rowKey = queuedKey,
+                ),
+                focusedKey = queuedKey,
+                requestedFocusKey = queuedKey,
+                openMenuKey = queuedKey,
+            ),
+        )
+
+        assertTrue(store.completeEmptyPublication())
+        val empty = store.snapshot()
+        assertNull(empty.queuedDeletion)
+        assertNull(empty.focusedKey)
+        assertNull(empty.requestedFocusKey)
+        assertNull(empty.openMenuKey)
+    }
+
+    private companion object {
+        const val WORKER_COUNT = 8
+        const val UPDATES_PER_WORKER = 250
+    }
+}

--- a/app/src/test/kotlin/com/kino/puber/ui/feature/history/vm/HistoryVMContentPublicationTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/ui/feature/history/vm/HistoryVMContentPublicationTest.kt
@@ -1,0 +1,297 @@
+package com.kino.puber.ui.feature.history.vm
+
+import com.kino.puber.core.error.ErrorEntity
+import com.kino.puber.core.error.ErrorHandler
+import com.kino.puber.core.paginator.Paginator
+import com.kino.puber.core.ui.model.VideoItemUIMapper
+import com.kino.puber.core.ui.navigation.AppRouter
+import com.kino.puber.core.ui.navigation.Screens
+import com.kino.puber.core.ui.uikit.model.CommonAction
+import com.kino.puber.data.api.KinoPubApiClient
+import com.kino.puber.data.api.models.History
+import com.kino.puber.data.api.models.Item
+import com.kino.puber.data.api.models.ItemType
+import com.kino.puber.data.api.models.PaginatedResponse
+import com.kino.puber.data.api.models.Pagination
+import com.kino.puber.data.api.models.Video
+import com.kino.puber.data.api.models.WatchingInfo
+import com.kino.puber.data.repository.ItemDetailsRepository
+import com.kino.puber.domain.interactor.history.HistoryInteractor
+import com.kino.puber.ui.feature.history.model.HistoryAction
+import com.kino.puber.ui.feature.history.model.HistoryItemUIState
+import com.kino.puber.ui.feature.history.model.HistoryUIMapper
+import com.kino.puber.ui.feature.history.model.HistoryViewState
+import com.kino.puber.util.FakeResourceProvider
+import com.kino.puber.util.MainDispatcherExtension
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.api.fail
+
+class HistoryVMContentPublicationTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val mainDispatcher = MainDispatcherExtension()
+
+        private const val AWAIT_TIMEOUT_MILLIS = 4_000L
+        private const val AWAIT_POLL_MILLIS = 10L
+        private const val REFRESHED_VIDEO_ID = 110
+    }
+
+    private lateinit var api: KinoPubApiClient
+    private lateinit var router: AppRouter
+
+    @BeforeEach
+    fun setUp() {
+        api = mockk()
+        router = mockk(relaxed = true)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun concurrentMenuTransitionWinsOverContentPublicationAndKeepsRuntimeAligned() {
+        val pageCalls = AtomicInteger()
+        val publicationEntered = CountDownLatch(1)
+        val releasePublication = CountDownLatch(1)
+        val menuCompleted = CountDownLatch(1)
+        val mapper = spyk(HistoryUIMapper(VideoItemUIMapper(FakeResourceProvider())))
+        every { mapper.map(any<List<History>>()) } answers {
+            val history = firstArg<List<History>>()
+            if (history.firstOrNull()?.video?.id == REFRESHED_VIDEO_ID) {
+                publicationEntered.countDown()
+                check(releasePublication.await(2, TimeUnit.SECONDS))
+            }
+            callOriginal()
+        }
+        coEvery { api.getHistoryData(1) } coAnswers {
+            if (pageCalls.incrementAndGet() == 1) {
+                Result.success(page(listOf(movie(1), movie(2))))
+            } else {
+                Result.success(
+                    page(
+                        listOf(
+                            movie(itemId = 1, videoId = REFRESHED_VIDEO_ID),
+                            movie(2),
+                        ),
+                    ),
+                )
+            }
+        }
+        val vm = createVm(mapper)
+        vm.testOnStart()
+        val menuItem = awaitContent(vm).items.last()
+
+        vm.onAction(CommonAction.Refresh)
+
+        assertTrue(publicationEntered.await(2, TimeUnit.SECONDS))
+        val menuThread = thread {
+            vm.onAction(CommonAction.ItemFocused(menuItem))
+            vm.onAction(HistoryAction.OpenContextMenu(menuItem))
+            menuCompleted.countDown()
+        }
+        assertFalse(menuCompleted.await(100, TimeUnit.MILLISECONDS))
+
+        releasePublication.countDown()
+        assertTrue(menuCompleted.await(2, TimeUnit.SECONDS))
+        menuThread.join(2_000)
+        val published = awaitContent(vm) {
+            it.items.first().deletionMediaId == REFRESHED_VIDEO_ID &&
+                it.focusKey == menuItem.rowKey &&
+                it.openMenuKey == menuItem.rowKey
+        }
+        val runtime = vm.testRuntimeState
+
+        assertEquals(menuItem.rowKey, published.focusKey)
+        assertEquals(menuItem.rowKey, published.openMenuKey)
+        assertEquals(published.focusKey, runtime.focusedKey)
+        assertEquals(published.openMenuKey, runtime.openMenuKey)
+    }
+
+    @Test
+    fun concurrentMenuTransitionWaitsForAvailabilityPublicationAndPreservesLatestContent() {
+        val availabilityRead = CountDownLatch(1)
+        val releaseAvailabilityWrite = CountDownLatch(1)
+        val paginationEntered = CountDownLatch(1)
+        val releasePagination = CountDownLatch(1)
+        val menuWorkerAtLockAcquire = CountDownLatch(1)
+        val menuCompleted = CountDownLatch(1)
+        coEvery { api.getHistoryData(1) } returns Result.success(
+            page(
+                items = listOf(movie(1), movie(2)),
+                current = 1,
+                total = 2,
+            ),
+        )
+        coEvery { api.getHistoryData(2) } coAnswers {
+            paginationEntered.countDown()
+            check(releasePagination.await(2, TimeUnit.SECONDS))
+            Result.success(
+                page(
+                    items = listOf(movie(3)),
+                    current = 2,
+                    total = 2,
+                ),
+            )
+        }
+        val vm = createVm(HistoryUIMapper(VideoItemUIMapper(FakeResourceProvider())))
+        vm.testOnStart()
+        val menuItem = awaitContent(vm).items.last()
+        vm.testAfterDeleteAvailabilityRead = {
+            vm.testAfterDeleteAvailabilityRead = null
+            availabilityRead.countDown()
+            check(releaseAvailabilityWrite.await(2, TimeUnit.SECONDS))
+        }
+        vm.testBeforeFocusPublicationLockAcquire = {
+            vm.testBeforeFocusPublicationLockAcquire = null
+            menuWorkerAtLockAcquire.countDown()
+        }
+
+        val paginationThread = thread {
+            vm.onAction(CommonAction.LoadMore)
+        }
+
+        assertTrue(availabilityRead.await(2, TimeUnit.SECONDS))
+        val menuThread = thread {
+            vm.onAction(CommonAction.ItemFocused(menuItem))
+            vm.onAction(HistoryAction.OpenContextMenu(menuItem))
+            menuCompleted.countDown()
+        }
+        assertTrue(menuWorkerAtLockAcquire.await(2, TimeUnit.SECONDS))
+        assertTrue(
+            awaitBlockedBeforeCompletion(menuThread, menuCompleted),
+            "Focus/menu worker completed instead of blocking on contentPublicationLock",
+        )
+        assertEquals(1L, menuCompleted.count)
+
+        releaseAvailabilityWrite.countDown()
+        assertTrue(menuCompleted.await(2, TimeUnit.SECONDS))
+        assertTrue(paginationEntered.await(2, TimeUnit.SECONDS))
+        val loadingMore = awaitContent(vm) {
+            it.isLoadingMore &&
+                it.items.map(HistoryItemUIState::itemId) == listOf(1, 2) &&
+                it.focusKey == menuItem.rowKey &&
+                it.openMenuKey == menuItem.rowKey
+        }
+        assertFalse(loadingMore.isDeleteExactMediaAvailable)
+
+        releasePagination.countDown()
+        paginationThread.join(2_000)
+        menuThread.join(2_000)
+        val published = awaitContent(vm) {
+            !it.isLoadingMore &&
+                it.items.map(HistoryItemUIState::itemId) == listOf(1, 2, 3) &&
+                it.focusKey == menuItem.rowKey &&
+                it.openMenuKey == menuItem.rowKey
+        }
+        val runtime = vm.testRuntimeState
+
+        assertTrue(published.isDeleteExactMediaAvailable)
+        assertEquals(menuItem.rowKey, published.focusKey)
+        assertEquals(menuItem.rowKey, published.openMenuKey)
+        assertEquals(published.focusKey, runtime.focusedKey)
+        assertEquals(published.openMenuKey, runtime.openMenuKey)
+    }
+
+    private fun awaitBlockedBeforeCompletion(
+        worker: Thread,
+        completed: CountDownLatch,
+    ): Boolean {
+        val deadline = System.nanoTime() + AWAIT_TIMEOUT_MILLIS * 1_000_000
+        while (System.nanoTime() < deadline) {
+            if (worker.state == Thread.State.BLOCKED) return true
+            if (completed.count == 0L) return false
+            Thread.sleep(AWAIT_POLL_MILLIS)
+        }
+        fail("Timed out waiting for worker contention; state=${worker.state}")
+    }
+
+    private fun createVm(mapper: HistoryUIMapper): HistoryVM {
+        val screens = mockk<Screens>(relaxed = true)
+        val errorHandler = mockk<ErrorHandler>(relaxed = true)
+        every { router.screens } returns screens
+        every { errorHandler.map(any()) } answers {
+            val error = firstArg<Throwable>()
+            ErrorEntity(message = error.message.orEmpty(), code = "test")
+        }
+        return HistoryVM(
+            paginator = Paginator.Store(comparator = HistoryRowComparator),
+            interactor = spyk(
+                HistoryInteractor(
+                    api = api,
+                    itemDetailsRepository = mockk<ItemDetailsRepository>(relaxed = true),
+                ),
+            ),
+            mapper = mapper,
+            router = router,
+            errorHandler = errorHandler,
+        )
+    }
+
+    private fun awaitContent(
+        vm: HistoryVM,
+        predicate: (HistoryViewState.Content) -> Boolean = { true },
+    ): HistoryViewState.Content {
+        val deadline = System.nanoTime() + AWAIT_TIMEOUT_MILLIS * 1_000_000
+        while (System.nanoTime() < deadline) {
+            val state = vm.testStateValue
+            if (state is HistoryViewState.Content && predicate(state)) {
+                return state
+            }
+            Thread.sleep(AWAIT_POLL_MILLIS)
+        }
+        fail("Timed out waiting for History state; last=${vm.testStateValue}")
+    }
+
+    private fun page(
+        items: List<History>,
+        current: Int = 1,
+        total: Int = 1,
+    ): PaginatedResponse<History> {
+        return PaginatedResponse(
+            items = items,
+            pagination = Pagination(
+                current = current,
+                perpage = 20,
+                total = total,
+                totalItems = items.size,
+            ),
+        )
+    }
+
+    private fun movie(
+        itemId: Int,
+        videoId: Int = itemId * 100,
+    ): History {
+        return History(
+            item = Item(
+                id = itemId,
+                title = "Synthetic movie $itemId",
+                type = ItemType.MOVIE,
+            ),
+            video = Video(
+                id = videoId,
+                number = itemId,
+                watching = WatchingInfo(time = 120, duration = 600),
+            ),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/kino/puber/ui/feature/history/vm/HistoryVMDeletionInputGuardTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/ui/feature/history/vm/HistoryVMDeletionInputGuardTest.kt
@@ -1,0 +1,209 @@
+package com.kino.puber.ui.feature.history.vm
+
+import com.kino.puber.core.error.ErrorEntity
+import com.kino.puber.core.error.ErrorHandler
+import com.kino.puber.core.paginator.Paginator
+import com.kino.puber.core.ui.model.VideoItemUIMapper
+import com.kino.puber.core.ui.navigation.AppRouter
+import com.kino.puber.core.ui.navigation.PuberScreen
+import com.kino.puber.core.ui.navigation.Screens
+import com.kino.puber.core.ui.uikit.model.CommonAction
+import com.kino.puber.data.api.KinoPubApiClient
+import com.kino.puber.data.api.models.History
+import com.kino.puber.data.api.models.Item
+import com.kino.puber.data.api.models.ItemType
+import com.kino.puber.data.api.models.PaginatedResponse
+import com.kino.puber.data.api.models.Pagination
+import com.kino.puber.data.api.models.Video
+import com.kino.puber.data.api.models.WatchingInfo
+import com.kino.puber.data.repository.ItemDetailsRepository
+import com.kino.puber.domain.interactor.history.HistoryInteractor
+import com.kino.puber.ui.feature.history.model.HistoryAction
+import com.kino.puber.ui.feature.history.model.HistoryItemUIState
+import com.kino.puber.ui.feature.history.model.HistoryUIMapper
+import com.kino.puber.ui.feature.history.model.HistoryViewState
+import com.kino.puber.ui.feature.player.model.PlayerStartMode
+import com.kino.puber.util.FakeResourceProvider
+import com.kino.puber.util.MainDispatcherExtension
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.api.fail
+
+class HistoryVMDeletionInputGuardTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val mainDispatcher = MainDispatcherExtension()
+
+        private const val AWAIT_TIMEOUT_MILLIS = 4_000L
+        private const val AWAIT_POLL_MILLIS = 10L
+    }
+
+    private lateinit var api: KinoPubApiClient
+    private lateinit var router: AppRouter
+    private lateinit var screens: Screens
+    private lateinit var vm: HistoryVM
+
+    @BeforeEach
+    fun setUp() {
+        api = mockk()
+        router = mockk(relaxed = true)
+        screens = mockk(relaxed = true)
+        val errorHandler = mockk<ErrorHandler>(relaxed = true)
+        every { router.screens } returns screens
+        every { errorHandler.map(any()) } answers {
+            val error = firstArg<Throwable>()
+            ErrorEntity(message = error.message.orEmpty(), code = "test")
+        }
+        vm = HistoryVM(
+            paginator = Paginator.Store(comparator = HistoryRowComparator),
+            interactor = spyk(
+                HistoryInteractor(
+                    api = api,
+                    itemDetailsRepository = mockk<ItemDetailsRepository>(relaxed = true),
+                ),
+            ),
+            mapper = HistoryUIMapper(VideoItemUIMapper(FakeResourceProvider())),
+            router = router,
+            errorHandler = errorHandler,
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun deletionAndReconciliationRejectNavigationAndMenuActionsUntilSettled() {
+        val historyCalls = AtomicInteger()
+        val mutationEntered = CountDownLatch(1)
+        val releaseMutation = CountDownLatch(1)
+        val reconciliationEntered = CountDownLatch(1)
+        val releaseReconciliation = CountDownLatch(1)
+        coEvery { api.getHistoryData(1) } coAnswers {
+            if (historyCalls.incrementAndGet() == 1) {
+                Result.success(page(listOf(movie(1), movie(2))))
+            } else {
+                reconciliationEntered.countDown()
+                check(releaseReconciliation.await(2, TimeUnit.SECONDS))
+                Result.success(page(listOf(movie(2))))
+            }
+        }
+        coEvery { api.clearExactMediaHistory(any()) } coAnswers {
+            mutationEntered.countDown()
+            check(releaseMutation.await(2, TimeUnit.SECONDS))
+            Result.success(Unit)
+        }
+        val destination = mockk<PuberScreen>()
+        every { screens.details(2) } returns destination
+        vm.testOnStart()
+        val initial = awaitContent()
+        val deletingItem = initial.items.first()
+        val retainedItem = initial.items.last()
+
+        val deletionThread = thread {
+            vm.onAction(HistoryAction.DeleteExactMedia(deletingItem))
+        }
+        assertTrue(mutationEntered.await(2, TimeUnit.SECONDS))
+        dispatchNavigationAndMenuActions(deletingItem, retainedItem)
+        assertNavigationAndMenuWereRejected()
+
+        releaseMutation.countDown()
+        assertTrue(reconciliationEntered.await(2, TimeUnit.SECONDS))
+        dispatchNavigationAndMenuActions(deletingItem, retainedItem)
+        assertNavigationAndMenuWereRejected()
+
+        releaseReconciliation.countDown()
+        deletionThread.join(2_000)
+        val settled = awaitContent {
+            it.itemIds() == listOf(2) && !it.isRefreshing && it.deletingKeys.isEmpty()
+        }
+        vm.onAction(CommonAction.ItemSelected(settled.items.single()))
+
+        verify(exactly = 1) { router.navigateTo(destination) }
+        coVerify(exactly = 1) { api.clearExactMediaHistory(deletingItem.deletionMediaId) }
+    }
+
+    private fun dispatchNavigationAndMenuActions(
+        deletingItem: HistoryItemUIState,
+        retainedItem: HistoryItemUIState,
+    ) {
+        vm.onAction(CommonAction.ItemSelected(retainedItem))
+        vm.onAction(HistoryAction.OpenContextMenu(retainedItem))
+        vm.onAction(
+            HistoryAction.Play(
+                item = retainedItem,
+                startMode = PlayerStartMode.ResumeIfAvailable,
+            ),
+        )
+        vm.onAction(HistoryAction.OpenDetails(retainedItem))
+        vm.onAction(HistoryAction.DeleteExactMedia(deletingItem))
+    }
+
+    private fun assertNavigationAndMenuWereRejected() {
+        verify(exactly = 0) { router.navigateTo(any()) }
+        assertEquals(null, awaitContent().openMenuKey)
+    }
+
+    private fun awaitContent(
+        predicate: (HistoryViewState.Content) -> Boolean = { true },
+    ): HistoryViewState.Content {
+        val deadline = System.nanoTime() + AWAIT_TIMEOUT_MILLIS * 1_000_000
+        while (System.nanoTime() < deadline) {
+            val state = vm.testStateValue
+            if (state is HistoryViewState.Content && predicate(state)) {
+                return state
+            }
+            Thread.sleep(AWAIT_POLL_MILLIS)
+        }
+        fail("Timed out waiting for History state; last=${vm.testStateValue}")
+    }
+
+    private fun HistoryViewState.Content.itemIds(): List<Int> {
+        return items.map(HistoryItemUIState::itemId)
+    }
+
+    private fun page(items: List<History>): PaginatedResponse<History> {
+        return PaginatedResponse(
+            items = items,
+            pagination = Pagination(
+                current = 1,
+                perpage = 20,
+                total = 1,
+                totalItems = items.size,
+            ),
+        )
+    }
+
+    private fun movie(itemId: Int): History {
+        return History(
+            item = Item(
+                id = itemId,
+                title = "Synthetic movie $itemId",
+                type = ItemType.MOVIE,
+            ),
+            video = Video(
+                id = itemId * 100,
+                number = itemId,
+                watching = WatchingInfo(time = 120, duration = 600),
+            ),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/kino/puber/ui/feature/history/vm/HistoryVMDeletionSchedulingTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/ui/feature/history/vm/HistoryVMDeletionSchedulingTest.kt
@@ -1,0 +1,542 @@
+package com.kino.puber.ui.feature.history.vm
+
+import com.kino.puber.core.error.ErrorEntity
+import com.kino.puber.core.error.ErrorHandler
+import com.kino.puber.core.paginator.Paginator
+import com.kino.puber.core.ui.model.VideoItemUIMapper
+import com.kino.puber.core.ui.navigation.AppRouter
+import com.kino.puber.core.ui.navigation.Screens
+import com.kino.puber.core.ui.uikit.model.CommonAction
+import com.kino.puber.data.api.KinoPubApiClient
+import com.kino.puber.data.api.models.History
+import com.kino.puber.data.api.models.Item
+import com.kino.puber.data.api.models.ItemType
+import com.kino.puber.data.api.models.PaginatedResponse
+import com.kino.puber.data.api.models.Pagination
+import com.kino.puber.data.api.models.Video
+import com.kino.puber.data.api.models.WatchingInfo
+import com.kino.puber.data.repository.ItemDetailsRepository
+import com.kino.puber.domain.interactor.history.HistoryInteractor
+import com.kino.puber.ui.feature.history.model.HistoryAction
+import com.kino.puber.ui.feature.history.model.HistoryItemUIState
+import com.kino.puber.ui.feature.history.model.HistoryUIMapper
+import com.kino.puber.ui.feature.history.model.HistoryViewState
+import com.kino.puber.util.FakeResourceProvider
+import com.kino.puber.util.MainDispatcherExtension
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.api.fail
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
+
+class HistoryVMDeletionSchedulingTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val mainDispatcher = MainDispatcherExtension()
+
+        private const val AWAIT_TIMEOUT_MILLIS = 4_000L
+        private const val AWAIT_POLL_MILLIS = 10L
+    }
+
+    private lateinit var api: KinoPubApiClient
+    private lateinit var itemDetailsRepository: ItemDetailsRepository
+    private lateinit var router: AppRouter
+    private lateinit var errorHandler: ErrorHandler
+    private lateinit var vm: HistoryVM
+
+    @BeforeEach
+    fun setUp() {
+        api = mockk()
+        itemDetailsRepository = mockk(relaxed = true)
+        router = mockk(relaxed = true)
+        errorHandler = mockk(relaxed = true)
+        every { router.screens } returns mockk<Screens>(relaxed = true)
+        every { errorHandler.map(any()) } answers {
+            val error = firstArg<Throwable>()
+            ErrorEntity(message = error.message.orEmpty(), code = "test")
+        }
+        vm = HistoryVM(
+            paginator = Paginator.Store(comparator = HistoryRowComparator),
+            interactor = spyk(HistoryInteractor(api, itemDetailsRepository)),
+            mapper = HistoryUIMapper(VideoItemUIMapper(FakeResourceProvider())),
+            router = router,
+            errorHandler = errorHandler,
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun deleteSelectionDuringRefresh_isQueuedOnceAndRetainsSemanticFocus() {
+        val pageOneCalls = AtomicInteger()
+        val refreshEntered = CountDownLatch(1)
+        val releaseRefresh = CountDownLatch(1)
+        coEvery { api.getHistoryData(1) } coAnswers {
+            when (pageOneCalls.incrementAndGet()) {
+                1 -> Result.success(page(listOf(movie(1), movie(2))))
+                2 -> {
+                    refreshEntered.countDown()
+                    check(releaseRefresh.await(2, TimeUnit.SECONDS))
+                    Result.success(page(listOf(movie(1), movie(2))))
+                }
+                else -> Result.success(page(listOf(movie(2))))
+            }
+        }
+        coEvery { api.clearExactMediaHistory(any()) } returns Result.success(Unit)
+        vm.testOnStart()
+        val deleted = awaitContent().items.first()
+        vm.onAction(HistoryAction.OpenContextMenu(deleted))
+
+        vm.onAction(CommonAction.Refresh)
+
+        assertTrue(refreshEntered.await(2, TimeUnit.SECONDS))
+        val refreshing = awaitContent { it.isRefreshing }
+        assertFalse(refreshing.isDeleteExactMediaAvailable)
+        vm.onAction(HistoryAction.DeleteExactMedia(deleted))
+        val queued = awaitContent {
+            it.openMenuKey == null && it.focusKey == deleted.rowKey
+        }
+        assertFalse(queued.isDeleteExactMediaAvailable)
+        coVerify(exactly = 0) { api.clearExactMediaHistory(any()) }
+
+        releaseRefresh.countDown()
+
+        val reconciled = awaitContent { it.itemIds() == listOf(2) }
+        assertEquals(2, reconciled.focusedItemId())
+        assertTrue(reconciled.isDeleteExactMediaAvailable)
+        assertEquals(3, pageOneCalls.get())
+        coVerify(exactly = 1) { api.clearExactMediaHistory(deleted.deletionMediaId) }
+        verify(exactly = 1) { itemDetailsRepository.invalidate(deleted.itemId) }
+    }
+
+    @Test
+    fun queuedDeletionAfterRefresh_usesCurrentDeletionMediaIdForSurvivingRow() {
+        val pageOneCalls = AtomicInteger()
+        val refreshEntered = CountDownLatch(1)
+        val releaseRefresh = CountDownLatch(1)
+        coEvery { api.getHistoryData(1) } coAnswers {
+            when (pageOneCalls.incrementAndGet()) {
+                1 -> Result.success(page(listOf(movie(itemId = 1, videoId = 100))))
+                2 -> {
+                    refreshEntered.countDown()
+                    check(releaseRefresh.await(2, TimeUnit.SECONDS))
+                    Result.success(page(listOf(movie(itemId = 1, videoId = 120))))
+                }
+                else -> Result.success(page(emptyList()))
+            }
+        }
+        coEvery { api.clearExactMediaHistory(any()) } returns Result.success(Unit)
+        vm.testOnStart()
+        val staleItem = awaitContent().items.single()
+
+        vm.onAction(CommonAction.Refresh)
+
+        assertTrue(refreshEntered.await(2, TimeUnit.SECONDS))
+        vm.onAction(HistoryAction.DeleteExactMedia(staleItem))
+        releaseRefresh.countDown()
+
+        awaitState { it == HistoryViewState.Empty }
+        assertEquals(3, pageOneCalls.get())
+        coVerify(exactly = 0) { api.clearExactMediaHistory(100) }
+        coVerify(exactly = 1) { api.clearExactMediaHistory(120) }
+        verify(exactly = 1) { itemDetailsRepository.invalidate(1) }
+    }
+
+    @Test
+    fun deletionDuringAuthoritativeContentPublication_waitsAndUsesPublishedMediaId() {
+        val pageOneCalls = AtomicInteger()
+        val publicationEntered = CountDownLatch(1)
+        val releasePublication = CountDownLatch(1)
+        val blockingMapper = spyk(
+            HistoryUIMapper(VideoItemUIMapper(FakeResourceProvider())),
+        )
+        every { blockingMapper.map(any<List<History>>()) } answers {
+            val history = firstArg<List<History>>()
+            if (history.singleOrNull()?.video?.id == 120) {
+                publicationEntered.countDown()
+                check(releasePublication.await(2, TimeUnit.SECONDS))
+            }
+            callOriginal()
+        }
+        vm = HistoryVM(
+            paginator = Paginator.Store(comparator = HistoryRowComparator),
+            interactor = spyk(HistoryInteractor(api, itemDetailsRepository)),
+            mapper = blockingMapper,
+            router = router,
+            errorHandler = errorHandler,
+        )
+        coEvery { api.getHistoryData(1) } coAnswers {
+            when (pageOneCalls.incrementAndGet()) {
+                1 -> Result.success(page(listOf(movie(itemId = 1, videoId = 100))))
+                2 -> Result.success(page(listOf(movie(itemId = 1, videoId = 120))))
+                else -> Result.success(page(emptyList()))
+            }
+        }
+        coEvery { api.clearExactMediaHistory(any()) } returns Result.success(Unit)
+        vm.testOnStart()
+        val staleMenuItem = awaitContent().items.single()
+
+        vm.onAction(CommonAction.Refresh)
+
+        assertTrue(publicationEntered.await(2, TimeUnit.SECONDS))
+        val deletionThread = thread {
+            vm.onAction(HistoryAction.DeleteExactMedia(staleMenuItem))
+        }
+        awaitRuntime { it.queuedDeletion?.rowKey == staleMenuItem.rowKey }
+        coVerify(exactly = 0) { api.clearExactMediaHistory(any()) }
+
+        releasePublication.countDown()
+        deletionThread.join(2_000)
+
+        awaitState { it == HistoryViewState.Empty }
+        assertEquals(3, pageOneCalls.get())
+        coVerify(exactly = 0) { api.clearExactMediaHistory(100) }
+        coVerify(exactly = 1) { api.clearExactMediaHistory(120) }
+        verify(exactly = 1) { itemDetailsRepository.invalidate(1) }
+    }
+
+    @Test
+    fun staleMenuActionAfterPublication_resolvesCurrentPublishedMediaId() {
+        val pageOneCalls = AtomicInteger()
+        coEvery { api.getHistoryData(1) } coAnswers {
+            when (pageOneCalls.incrementAndGet()) {
+                1 -> Result.success(page(listOf(movie(itemId = 1, videoId = 100))))
+                2 -> Result.success(page(listOf(movie(itemId = 1, videoId = 120))))
+                else -> Result.success(page(emptyList()))
+            }
+        }
+        coEvery { api.clearExactMediaHistory(any()) } returns Result.success(Unit)
+        vm.testOnStart()
+        val staleMenuItem = awaitContent().items.single()
+
+        vm.onAction(CommonAction.Refresh)
+        awaitContent {
+            pageOneCalls.get() == 2 &&
+                it.items.single().deletionMediaId == 120 &&
+                it.isDeleteExactMediaAvailable
+        }
+
+        vm.onAction(HistoryAction.DeleteExactMedia(staleMenuItem))
+
+        awaitState { it == HistoryViewState.Empty }
+        coVerify(exactly = 0) { api.clearExactMediaHistory(100) }
+        coVerify(exactly = 1) { api.clearExactMediaHistory(120) }
+        verify(exactly = 1) { itemDetailsRepository.invalidate(1) }
+    }
+
+    @Test
+    fun refreshToEmptyDropsQueuedDeletionWithoutIssuingStaleMutation() {
+        val pageOneCalls = AtomicInteger()
+        val refreshEntered = CountDownLatch(1)
+        val releaseRefresh = CountDownLatch(1)
+        coEvery { api.getHistoryData(1) } coAnswers {
+            if (pageOneCalls.incrementAndGet() == 1) {
+                Result.success(page(listOf(movie(1))))
+            } else {
+                refreshEntered.countDown()
+                check(releaseRefresh.await(2, TimeUnit.SECONDS))
+                Result.success(page(emptyList()))
+            }
+        }
+        coEvery { api.clearExactMediaHistory(any()) } returns
+            Result.failure(IllegalStateException("stale mutation must not run"))
+        vm.testOnStart()
+        val staleItem = awaitContent().items.single()
+
+        vm.onAction(CommonAction.Refresh)
+
+        assertTrue(refreshEntered.await(2, TimeUnit.SECONDS))
+        vm.onAction(HistoryAction.DeleteExactMedia(staleItem))
+        releaseRefresh.countDown()
+
+        awaitState { it == HistoryViewState.Empty }
+        coVerify(exactly = 0) { api.clearExactMediaHistory(any()) }
+        verify(exactly = 0) { itemDetailsRepository.invalidate(any()) }
+    }
+
+    @Test
+    fun refreshWithoutQueuedRowDropsDeletionWithoutMutatingAnotherRow() {
+        val pageOneCalls = AtomicInteger()
+        val refreshEntered = CountDownLatch(1)
+        val releaseRefresh = CountDownLatch(1)
+        coEvery { api.getHistoryData(1) } coAnswers {
+            if (pageOneCalls.incrementAndGet() == 1) {
+                Result.success(page(listOf(movie(1), movie(2))))
+            } else {
+                refreshEntered.countDown()
+                check(releaseRefresh.await(2, TimeUnit.SECONDS))
+                Result.success(page(listOf(movie(2))))
+            }
+        }
+        coEvery { api.clearExactMediaHistory(any()) } returns
+            Result.failure(IllegalStateException("missing queued row must not mutate"))
+        vm.testOnStart()
+        val staleItem = awaitContent().items.first()
+
+        vm.onAction(CommonAction.Refresh)
+
+        assertTrue(refreshEntered.await(2, TimeUnit.SECONDS))
+        vm.onAction(HistoryAction.DeleteExactMedia(staleItem))
+        releaseRefresh.countDown()
+
+        val refreshed = awaitContent {
+            it.itemIds() == listOf(2) &&
+                !it.isRefreshing &&
+                it.isDeleteExactMediaAvailable
+        }
+        assertTrue(refreshed.isDeleteExactMediaAvailable)
+        coVerify(exactly = 0) { api.clearExactMediaHistory(any()) }
+        verify(exactly = 0) { itemDetailsRepository.invalidate(any()) }
+    }
+
+    @Test
+    fun deleteSelectionDuringAutomaticPagination_isQueuedOnceAndRetainsSemanticFocus() {
+        val pageOneCalls = AtomicInteger()
+        val pageTwoCalls = AtomicInteger()
+        val paginationEntered = CountDownLatch(1)
+        val releasePagination = CountDownLatch(1)
+        coEvery { api.getHistoryData(1) } coAnswers {
+            if (pageOneCalls.incrementAndGet() == 1) {
+                Result.success(page(listOf(movie(1), movie(2)), current = 1, total = 2))
+            } else {
+                Result.success(page(listOf(movie(1), movie(3)), current = 1, total = 2))
+            }
+        }
+        coEvery { api.getHistoryData(2) } coAnswers {
+            if (pageTwoCalls.incrementAndGet() == 1) {
+                paginationEntered.countDown()
+                check(releasePagination.await(2, TimeUnit.SECONDS))
+                Result.success(page(listOf(movie(3), movie(4)), current = 2, total = 2))
+            } else {
+                Result.success(page(listOf(movie(4)), current = 2, total = 2))
+            }
+        }
+        coEvery { api.clearExactMediaHistory(any()) } returns Result.success(Unit)
+        vm.testOnStart()
+        val deleted = awaitContent().items[1]
+        vm.onAction(HistoryAction.OpenContextMenu(deleted))
+
+        vm.onAction(CommonAction.LoadMore)
+
+        assertTrue(paginationEntered.await(2, TimeUnit.SECONDS))
+        val paginating = awaitContent { it.isLoadingMore }
+        assertFalse(paginating.isDeleteExactMediaAvailable)
+        vm.onAction(HistoryAction.DeleteExactMedia(deleted))
+        val queued = awaitContent {
+            it.openMenuKey == null && it.focusKey == deleted.rowKey
+        }
+        assertFalse(queued.isDeleteExactMediaAvailable)
+        coVerify(exactly = 0) { api.clearExactMediaHistory(any()) }
+
+        releasePagination.countDown()
+
+        val reconciled = awaitContent { it.itemIds() == listOf(1, 3, 4) }
+        assertEquals(3, reconciled.focusedItemId())
+        assertTrue(reconciled.isDeleteExactMediaAvailable)
+        assertEquals(2, pageOneCalls.get())
+        assertEquals(2, pageTwoCalls.get())
+        coVerify(exactly = 1) { api.clearExactMediaHistory(deleted.deletionMediaId) }
+        verify(exactly = 1) { itemDetailsRepository.invalidate(deleted.itemId) }
+    }
+
+    @Test
+    fun deletingLastRenderedRow_keepsReconcilingStateUntilReflowedRowLoads() {
+        val pageOneCalls = AtomicInteger()
+        val reconciliationEntered = CountDownLatch(1)
+        val releaseReconciliation = CountDownLatch(1)
+        coEvery { api.getHistoryData(1) } coAnswers {
+            when (pageOneCalls.incrementAndGet()) {
+                1 -> Result.success(page(listOf(movie(1))))
+                else -> {
+                    reconciliationEntered.countDown()
+                    check(releaseReconciliation.await(2, TimeUnit.SECONDS))
+                    Result.success(page(listOf(movie(2))))
+                }
+            }
+        }
+        coEvery { api.clearExactMediaHistory(any()) } returns Result.success(Unit)
+        vm.testOnStart()
+        val deleted = awaitContent().items.single()
+
+        val actionThread = thread {
+            vm.onAction(HistoryAction.DeleteExactMedia(deleted))
+        }
+        assertTrue(reconciliationEntered.await(2, TimeUnit.SECONDS))
+        val reconciling = awaitContent {
+            it.items.isEmpty() && it.isRefreshing && it.reloadErrorMessage == null
+        }
+        assertFalse(reconciling.isDeleteExactMediaAvailable)
+        assertFalse(vm.testStateValue is HistoryViewState.Empty)
+
+        releaseReconciliation.countDown()
+        actionThread.join(2_000)
+
+        val reconciled = awaitContent { it.itemIds() == listOf(2) && !it.isRefreshing }
+        assertEquals(2, reconciled.focusedItemId())
+        assertEquals(2, pageOneCalls.get())
+    }
+
+    @Test
+    fun deletingLastRenderedRow_reconciliationFailureKeepsRetryableNonEmptyState() {
+        val pageOneCalls = AtomicInteger()
+        coEvery { api.getHistoryData(1) } coAnswers {
+            when (pageOneCalls.incrementAndGet()) {
+                1 -> Result.success(page(listOf(movie(1))))
+                2 -> Result.failure(IllegalStateException("reconcile failure"))
+                else -> Result.success(page(listOf(movie(2))))
+            }
+        }
+        coEvery { api.clearExactMediaHistory(any()) } returns Result.success(Unit)
+        vm.testOnStart()
+        val deleted = awaitContent().items.single()
+
+        vm.onAction(HistoryAction.DeleteExactMedia(deleted))
+
+        val failed = awaitContent {
+            it.items.isEmpty() &&
+                !it.isRefreshing &&
+                it.reloadErrorMessage == "reconcile failure"
+        }
+        assertFalse(failed.isDeleteExactMediaAvailable)
+        assertFalse(vm.testStateValue is HistoryViewState.Empty)
+
+        vm.onAction(HistoryAction.RetryReconciliation)
+
+        val reconciled = awaitContent { it.itemIds() == listOf(2) && !it.isRefreshing }
+        assertEquals(2, reconciled.focusedItemId())
+        assertEquals(null, reconciled.reloadErrorMessage)
+        assertEquals(3, pageOneCalls.get())
+    }
+
+    @Test
+    fun unchangedReconciliationResponseSettlesWithoutPaginatorPublication() {
+        val pageOneCalls = AtomicInteger()
+        coEvery { api.getHistoryData(1) } coAnswers {
+            pageOneCalls.incrementAndGet()
+            Result.success(page(listOf(movie(1), movie(2))))
+        }
+        coEvery { api.clearExactMediaHistory(any()) } returns Result.success(Unit)
+        vm.testOnStart()
+        val initial = awaitContent()
+        val deleted = initial.items.first()
+        vm.onAction(CommonAction.ItemFocused(initial.items.last()))
+
+        vm.onAction(CommonAction.Refresh)
+
+        awaitContent {
+            pageOneCalls.get() == 2 &&
+                !it.isRefreshing &&
+                it.focusedItemId() == 2
+        }
+
+        vm.onAction(HistoryAction.DeleteExactMedia(deleted))
+
+        val reconciled = awaitContent {
+            pageOneCalls.get() == 3 &&
+                it.itemIds() == listOf(1, 2) &&
+                !it.isRefreshing
+        }
+        assertTrue(reconciled.isDeleteExactMediaAvailable)
+        assertEquals(2, reconciled.focusedItemId())
+        coVerify(exactly = 1) { api.clearExactMediaHistory(deleted.deletionMediaId) }
+    }
+
+    private fun awaitContent(
+        predicate: (HistoryViewState.Content) -> Boolean = { true },
+    ): HistoryViewState.Content {
+        val deadline = System.nanoTime() + AWAIT_TIMEOUT_MILLIS * 1_000_000
+        while (System.nanoTime() < deadline) {
+            val state = vm.testStateValue
+            if (state is HistoryViewState.Content && predicate(state)) {
+                return state
+            }
+            Thread.sleep(AWAIT_POLL_MILLIS)
+        }
+        fail("Timed out waiting for History state; last=${vm.testStateValue}")
+    }
+
+    private fun awaitState(
+        predicate: (HistoryViewState) -> Boolean,
+    ): HistoryViewState {
+        val deadline = System.nanoTime() + AWAIT_TIMEOUT_MILLIS * 1_000_000
+        while (System.nanoTime() < deadline) {
+            val state = vm.testStateValue
+            if (predicate(state)) return state
+            Thread.sleep(AWAIT_POLL_MILLIS)
+        }
+        fail("Timed out waiting for History state; last=${vm.testStateValue}")
+    }
+
+    private fun awaitRuntime(
+        predicate: (HistoryRuntimeState) -> Boolean,
+    ): HistoryRuntimeState {
+        val deadline = System.nanoTime() + AWAIT_TIMEOUT_MILLIS * 1_000_000
+        while (System.nanoTime() < deadline) {
+            val state = vm.testRuntimeState
+            if (predicate(state)) return state
+            Thread.sleep(AWAIT_POLL_MILLIS)
+        }
+        fail("Timed out waiting for History runtime; last=${vm.testRuntimeState}")
+    }
+
+    private fun HistoryViewState.Content.itemIds(): List<Int> {
+        return items.map(HistoryItemUIState::itemId)
+    }
+
+    private fun HistoryViewState.Content.focusedItemId(): Int? {
+        return items.firstOrNull { it.rowKey == focusKey }?.itemId
+    }
+
+    private fun page(
+        items: List<History>,
+        current: Int = 1,
+        total: Int = 1,
+    ): PaginatedResponse<History> {
+        return PaginatedResponse(
+            items = items,
+            pagination = Pagination(
+                current = current,
+                perpage = 20,
+                total = total,
+                totalItems = items.size,
+            ),
+        )
+    }
+
+    private fun movie(
+        itemId: Int,
+        videoId: Int = itemId * 100,
+    ): History {
+        return History(
+            item = Item(
+                id = itemId,
+                title = "Synthetic movie $itemId",
+                type = ItemType.MOVIE,
+            ),
+            video = Video(
+                id = videoId,
+                number = itemId,
+                watching = WatchingInfo(time = 120, duration = 600),
+            ),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/kino/puber/ui/feature/history/vm/HistoryVMFilteredEmptyPageTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/ui/feature/history/vm/HistoryVMFilteredEmptyPageTest.kt
@@ -1,0 +1,172 @@
+package com.kino.puber.ui.feature.history.vm
+
+import com.kino.puber.core.error.ErrorEntity
+import com.kino.puber.core.error.ErrorHandler
+import com.kino.puber.core.paginator.Paginator
+import com.kino.puber.core.ui.model.VideoItemUIMapper
+import com.kino.puber.core.ui.navigation.AppRouter
+import com.kino.puber.data.api.KinoPubApiClient
+import com.kino.puber.data.api.models.History
+import com.kino.puber.data.api.models.Item
+import com.kino.puber.data.api.models.ItemType
+import com.kino.puber.data.api.models.PaginatedResponse
+import com.kino.puber.data.api.models.Pagination
+import com.kino.puber.data.api.models.Video
+import com.kino.puber.data.repository.ItemDetailsRepository
+import com.kino.puber.domain.interactor.history.HistoryInteractor
+import com.kino.puber.ui.feature.history.model.HistoryAction
+import com.kino.puber.ui.feature.history.model.HistoryViewState
+import com.kino.puber.ui.feature.history.model.HistoryUIMapper
+import com.kino.puber.util.FakeResourceProvider
+import com.kino.puber.util.MainDispatcherExtension
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
+import org.junit.jupiter.api.extension.RegisterExtension
+import java.util.concurrent.atomic.AtomicInteger
+
+class HistoryVMFilteredEmptyPageTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val mainDispatcher = MainDispatcherExtension()
+
+        private const val AWAIT_TIMEOUT_MILLIS = 4_000L
+        private const val AWAIT_POLL_MILLIS = 10L
+    }
+
+    private lateinit var api: KinoPubApiClient
+    private lateinit var itemDetailsRepository: ItemDetailsRepository
+    private lateinit var interactor: HistoryInteractor
+    private lateinit var mapper: HistoryUIMapper
+    private lateinit var router: AppRouter
+    private lateinit var errorHandler: ErrorHandler
+
+    @BeforeEach
+    fun setUp() {
+        api = mockk()
+        itemDetailsRepository = mockk(relaxed = true)
+        interactor = HistoryInteractor(api, itemDetailsRepository)
+        mapper = HistoryUIMapper(VideoItemUIMapper(FakeResourceProvider()))
+        router = mockk(relaxed = true)
+        errorHandler = mockk(relaxed = true)
+        every { errorHandler.map(any()) } answers {
+            val error = firstArg<Throwable>()
+            ErrorEntity(message = error.message.orEmpty(), code = "test")
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun initialLoad_continuesPastFilteredEmptyPageUntilRenderableRow() {
+        coEvery { api.getHistoryData(1) } returns Result.success(
+            page(emptyList(), current = 1, total = 2),
+        )
+        coEvery { api.getHistoryData(2) } returns Result.success(
+            page(listOf(movie(2)), current = 2, total = 2),
+        )
+
+        val content = awaitContent(createVM().also(HistoryVM::testOnStart))
+
+        assertEquals(listOf(2), content.items.map { it.itemId })
+        assertFalse(content.hasMorePages)
+        coVerify(exactly = 1) { api.getHistoryData(1) }
+        coVerify(exactly = 1) { api.getHistoryData(2) }
+    }
+
+    @Test
+    fun deletionReconciliation_continuesPastFilteredEmptyPageUntilRenderableRow() {
+        val pageOneCalls = AtomicInteger()
+        coEvery { api.getHistoryData(1) } coAnswers {
+            if (pageOneCalls.incrementAndGet() == 1) {
+                Result.success(page(listOf(movie(1)), current = 1, total = 2))
+            } else {
+                Result.success(page(emptyList(), current = 1, total = 2))
+            }
+        }
+        coEvery { api.getHistoryData(2) } returns Result.success(
+            page(listOf(movie(2)), current = 2, total = 2),
+        )
+        coEvery { api.clearExactMediaHistory(any()) } returns Result.success(Unit)
+        val vm = createVM().also(HistoryVM::testOnStart)
+        val deleted = awaitContent(vm).items.single()
+
+        vm.onAction(HistoryAction.DeleteExactMedia(deleted))
+
+        val reconciled = awaitContent(vm) { content ->
+            content.items.map { it.itemId } == listOf(2)
+        }
+        assertEquals(listOf(2), reconciled.items.map { it.itemId })
+        assertFalse(reconciled.hasMorePages)
+        assertEquals(2, pageOneCalls.get())
+        coVerify(exactly = 1) { api.getHistoryData(2) }
+    }
+
+    private fun createVM(): HistoryVM {
+        return HistoryVM(
+            paginator = Paginator.Store(comparator = HistoryRowComparator),
+            interactor = interactor,
+            mapper = mapper,
+            router = router,
+            errorHandler = errorHandler,
+        )
+    }
+
+    private fun awaitContent(
+        vm: HistoryVM,
+        predicate: (HistoryViewState.Content) -> Boolean = { true },
+    ): HistoryViewState.Content {
+        val deadline = System.nanoTime() + AWAIT_TIMEOUT_MILLIS * 1_000_000
+        while (System.nanoTime() < deadline) {
+            val state = vm.testStateValue
+            if (state is HistoryViewState.Content && predicate(state)) {
+                return state
+            }
+            Thread.sleep(AWAIT_POLL_MILLIS)
+        }
+        fail("Timed out waiting for History content; last=${vm.testStateValue}")
+    }
+
+    private fun page(
+        items: List<History>,
+        current: Int,
+        total: Int,
+    ): PaginatedResponse<History> {
+        return PaginatedResponse(
+            items = items,
+            pagination = Pagination(
+                current = current,
+                perpage = 20,
+                total = total,
+                totalItems = items.size,
+            ),
+        )
+    }
+
+    private fun movie(itemId: Int): History {
+        return History(
+            item = Item(
+                id = itemId,
+                title = "Synthetic movie $itemId",
+                type = ItemType.MOVIE,
+            ),
+            video = Video(
+                id = itemId * 100,
+                number = itemId,
+            ),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/kino/puber/ui/feature/history/vm/HistoryVMLifecycleTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/ui/feature/history/vm/HistoryVMLifecycleTest.kt
@@ -1,0 +1,177 @@
+package com.kino.puber.ui.feature.history.vm
+
+import com.kino.puber.core.error.ErrorEntity
+import com.kino.puber.core.error.ErrorHandler
+import com.kino.puber.core.paginator.Paginator
+import com.kino.puber.core.ui.model.VideoItemUIMapper
+import com.kino.puber.core.ui.navigation.AppRouter
+import com.kino.puber.core.ui.uikit.model.CommonAction
+import com.kino.puber.data.api.KinoPubApiClient
+import com.kino.puber.data.api.models.History
+import com.kino.puber.data.api.models.Item
+import com.kino.puber.data.api.models.ItemType
+import com.kino.puber.data.api.models.PaginatedResponse
+import com.kino.puber.data.api.models.Pagination
+import com.kino.puber.data.api.models.Video
+import com.kino.puber.data.api.models.WatchingInfo
+import com.kino.puber.data.repository.ItemDetailsRepository
+import com.kino.puber.domain.interactor.history.HistoryInteractor
+import com.kino.puber.ui.feature.history.model.HistoryItemUIState
+import com.kino.puber.ui.feature.history.model.HistoryUIMapper
+import com.kino.puber.ui.feature.history.model.HistoryViewState
+import com.kino.puber.util.FakeResourceProvider
+import com.kino.puber.util.MainDispatcherExtension
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import java.io.IOException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.api.fail
+
+internal class HistoryVMLifecycleTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val mainDispatcher = MainDispatcherExtension()
+
+        private const val AWAIT_TIMEOUT_MILLIS = 4_000L
+        private const val AWAIT_POLL_MILLIS = 10L
+    }
+
+    private lateinit var api: KinoPubApiClient
+    private lateinit var vm: HistoryVM
+
+    @BeforeEach
+    fun setUp() {
+        api = mockk()
+        val errorHandler = mockk<ErrorHandler>(relaxed = true)
+        every { errorHandler.map(any()) } answers {
+            val error = firstArg<Throwable>()
+            ErrorEntity(message = error.message.orEmpty(), code = "test")
+        }
+        vm = HistoryVM(
+            paginator = Paginator.Store(comparator = HistoryRowComparator),
+            interactor = HistoryInteractor(
+                api = api,
+                itemDetailsRepository = mockk<ItemDetailsRepository>(relaxed = true),
+            ),
+            mapper = HistoryUIMapper(VideoItemUIMapper(FakeResourceProvider())),
+            router = mockk<AppRouter>(relaxed = true),
+            errorHandler = errorHandler,
+        )
+    }
+
+    @Test
+    fun onResumeFromEmpty_reloadsPageOne() {
+        val pageOneCalls = AtomicInteger()
+        coEvery { api.getHistoryData(1) } coAnswers {
+            if (pageOneCalls.incrementAndGet() == 1) {
+                Result.success(page(emptyList()))
+            } else {
+                Result.success(page(listOf(movie(1))))
+            }
+        }
+        vm.testOnStart()
+        awaitState { pageOneCalls.get() == 1 && it == HistoryViewState.Empty }
+
+        vm.onAction(CommonAction.OnResume)
+
+        assertEquals(listOf(1), awaitContent().items.map(HistoryItemUIState::itemId))
+        assertEquals(2, pageOneCalls.get())
+        coVerify(exactly = 2) { api.getHistoryData(1) }
+    }
+
+    @Test
+    fun onResumeFromInitialError_reloadsPageOne() {
+        val pageOneCalls = AtomicInteger()
+        coEvery { api.getHistoryData(1) } coAnswers {
+            if (pageOneCalls.incrementAndGet() == 1) {
+                Result.failure(IOException("initial failure"))
+            } else {
+                Result.success(page(listOf(movie(1))))
+            }
+        }
+        vm.testOnStart()
+        awaitState { it is HistoryViewState.Error }
+
+        vm.onAction(CommonAction.OnResume)
+
+        assertEquals(listOf(1), awaitContent().items.map(HistoryItemUIState::itemId))
+        assertEquals(2, pageOneCalls.get())
+        coVerify(exactly = 2) { api.getHistoryData(1) }
+    }
+
+    @Test
+    fun onResumeDuringInitialLoading_doesNotDuplicatePageOneRequest() {
+        val pageOneCalls = AtomicInteger()
+        val requestEntered = CountDownLatch(1)
+        val releaseRequest = CountDownLatch(1)
+        coEvery { api.getHistoryData(1) } coAnswers {
+            pageOneCalls.incrementAndGet()
+            requestEntered.countDown()
+            check(releaseRequest.await(2, TimeUnit.SECONDS))
+            Result.success(page(listOf(movie(1))))
+        }
+        vm.testOnStart()
+        assertTrue(requestEntered.await(2, TimeUnit.SECONDS))
+        assertEquals(HistoryViewState.Loading, vm.testStateValue)
+
+        vm.onAction(CommonAction.OnResume)
+        Thread.sleep(40)
+
+        assertEquals(1, pageOneCalls.get())
+        releaseRequest.countDown()
+        assertEquals(listOf(1), awaitContent().items.map(HistoryItemUIState::itemId))
+        coVerify(exactly = 1) { api.getHistoryData(1) }
+    }
+
+    private fun awaitContent(): HistoryViewState.Content {
+        return awaitState { it is HistoryViewState.Content } as HistoryViewState.Content
+    }
+
+    private fun awaitState(predicate: (HistoryViewState) -> Boolean): HistoryViewState {
+        val deadline = System.nanoTime() + AWAIT_TIMEOUT_MILLIS * 1_000_000
+        while (System.nanoTime() < deadline) {
+            val state = vm.testStateValue
+            if (predicate(state)) return state
+            Thread.sleep(AWAIT_POLL_MILLIS)
+        }
+        fail("Timed out waiting for History state; last=${vm.testStateValue}")
+    }
+
+    private fun page(items: List<History>): PaginatedResponse<History> {
+        return PaginatedResponse(
+            items = items,
+            pagination = Pagination(
+                current = 1,
+                perpage = 20,
+                total = 1,
+                totalItems = items.size,
+            ),
+        )
+    }
+
+    private fun movie(itemId: Int): History {
+        return History(
+            item = Item(
+                id = itemId,
+                title = "Synthetic movie $itemId",
+                type = ItemType.MOVIE,
+            ),
+            video = Video(
+                id = itemId * 100,
+                number = itemId,
+                watching = WatchingInfo(time = 120, duration = 600),
+            ),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/kino/puber/ui/feature/history/vm/HistoryVMPlaybackTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/ui/feature/history/vm/HistoryVMPlaybackTest.kt
@@ -1,0 +1,246 @@
+package com.kino.puber.ui.feature.history.vm
+
+import com.kino.puber.core.error.ErrorEntity
+import com.kino.puber.core.error.ErrorHandler
+import com.kino.puber.core.paginator.Paginator
+import com.kino.puber.core.ui.model.VideoItemUIMapper
+import com.kino.puber.core.ui.navigation.AppRouter
+import com.kino.puber.core.ui.navigation.PuberScreen
+import com.kino.puber.core.ui.navigation.Screens
+import com.kino.puber.core.ui.uikit.model.CommonAction
+import com.kino.puber.data.api.KinoPubApiClient
+import com.kino.puber.data.api.models.History
+import com.kino.puber.data.api.models.Item
+import com.kino.puber.data.api.models.ItemType
+import com.kino.puber.data.api.models.PaginatedResponse
+import com.kino.puber.data.api.models.Pagination
+import com.kino.puber.data.api.models.Video
+import com.kino.puber.data.api.models.WatchingInfo
+import com.kino.puber.data.repository.ItemDetailsRepository
+import com.kino.puber.domain.interactor.history.HistoryInteractor
+import com.kino.puber.ui.feature.details.model.DetailsEpisodeTarget
+import com.kino.puber.ui.feature.history.model.HistoryAction
+import com.kino.puber.ui.feature.history.model.HistoryUIMapper
+import com.kino.puber.ui.feature.history.model.HistoryViewState
+import com.kino.puber.ui.feature.player.model.PlayerStartMode
+import com.kino.puber.util.FakeResourceProvider
+import com.kino.puber.util.MainDispatcherExtension
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.api.fail
+
+class HistoryVMPlaybackTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val mainDispatcher = MainDispatcherExtension()
+
+        private const val AWAIT_TIMEOUT_MILLIS = 4_000L
+        private const val AWAIT_POLL_MILLIS = 10L
+    }
+
+    private lateinit var api: KinoPubApiClient
+    private lateinit var itemDetailsRepository: ItemDetailsRepository
+    private lateinit var screens: Screens
+    private lateinit var router: AppRouter
+    private lateinit var vm: HistoryVM
+
+    @BeforeEach
+    fun setUp() {
+        api = mockk()
+        itemDetailsRepository = mockk(relaxed = true)
+        screens = mockk(relaxed = true)
+        router = mockk(relaxed = true)
+        val errorHandler = mockk<ErrorHandler>(relaxed = true)
+        every { router.screens } returns screens
+        every { errorHandler.map(any()) } answers {
+            val error = firstArg<Throwable>()
+            ErrorEntity(message = error.message.orEmpty(), code = "test")
+        }
+        vm = HistoryVM(
+            paginator = Paginator.Store(comparator = HistoryRowComparator),
+            interactor = spyk(HistoryInteractor(api, itemDetailsRepository)),
+            mapper = HistoryUIMapper(VideoItemUIMapper(FakeResourceProvider())),
+            router = router,
+            errorHandler = errorHandler,
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun selection_opensMovieAndExactEpisodeDetailsWithoutStartingPlayback() {
+        startWith(
+            movie(itemId = 10, videoNumber = 2),
+            episode(itemId = 20, season = 3, episode = 4),
+            episode(itemId = 30, season = null, episode = 5),
+        )
+        val movieDetails = mockk<PuberScreen>()
+        val episodeDetails = mockk<PuberScreen>()
+        val fallbackDetails = mockk<PuberScreen>()
+        every { screens.details(10) } returns movieDetails
+        every {
+            screens.details(
+                itemId = 20,
+                initialEpisode = DetailsEpisodeTarget(
+                    seasonNumber = 3,
+                    episodeNumber = 4,
+                ),
+            )
+        } returns episodeDetails
+        every { screens.details(30) } returns fallbackDetails
+
+        awaitContent().items.forEach { vm.onAction(CommonAction.ItemSelected(it)) }
+
+        verify(exactly = 0) { screens.player(any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { itemDetailsRepository.invalidate(any()) }
+        verify { router.navigateTo(movieDetails) }
+        verify { router.navigateTo(episodeDetails) }
+        verify { router.navigateTo(fallbackDetails) }
+    }
+
+    @Test
+    fun contextMenu_openAndDismissPreserveSourceFocus() {
+        startWith(movie(itemId = 1, videoNumber = 1))
+        val item = awaitContent().items.single()
+
+        vm.onAction(HistoryAction.OpenContextMenu(item))
+        val open = awaitContent { it.openMenuKey == item.rowKey }
+        assertEquals(item.rowKey, open.focusKey)
+
+        vm.onAction(HistoryAction.DismissContextMenu)
+        val dismissed = awaitContent { it.openMenuKey == null }
+        assertEquals(item.rowKey, dismissed.focusKey)
+    }
+
+    @Test
+    fun play_opensExactMovieVideoAfterInvalidatingItemDetails() {
+        startWith(movie(itemId = 10, videoNumber = 7))
+        val item = awaitContent().items.single()
+        val player = mockk<PuberScreen>()
+        every {
+            screens.player(
+                itemId = 10,
+                seasonNumber = null,
+                episodeNumber = null,
+                videoNumber = 7,
+                startMode = PlayerStartMode.StartFromBeginning,
+            )
+        } returns player
+
+        vm.onAction(HistoryAction.Play(item, PlayerStartMode.StartFromBeginning))
+
+        verifyOrder {
+            itemDetailsRepository.invalidate(10)
+            screens.player(
+                itemId = 10,
+                seasonNumber = null,
+                episodeNumber = null,
+                videoNumber = 7,
+                startMode = PlayerStartMode.StartFromBeginning,
+            )
+            router.navigateTo(player)
+        }
+        verify(exactly = 0) { screens.details(any()) }
+    }
+
+    @Test
+    fun play_opensExactSeriesEpisodeAfterInvalidatingItemDetails() {
+        startWith(episode(itemId = 20, season = 8, episode = 4))
+        val item = awaitContent().items.single()
+        val player = mockk<PuberScreen>()
+        every {
+            screens.player(
+                itemId = 20,
+                seasonNumber = 8,
+                episodeNumber = 4,
+                videoNumber = null,
+                startMode = PlayerStartMode.ResumeIfAvailable,
+            )
+        } returns player
+
+        vm.onAction(HistoryAction.Play(item, PlayerStartMode.ResumeIfAvailable))
+
+        verifyOrder {
+            itemDetailsRepository.invalidate(20)
+            screens.player(
+                itemId = 20,
+                seasonNumber = 8,
+                episodeNumber = 4,
+                videoNumber = null,
+                startMode = PlayerStartMode.ResumeIfAvailable,
+            )
+            router.navigateTo(player)
+        }
+        verify(exactly = 0) { screens.details(any()) }
+    }
+
+    private fun startWith(vararg items: History) {
+        coEvery { api.getHistoryData(1) } returns Result.success(page(items.toList()))
+        vm.testOnStart()
+    }
+
+    private fun awaitContent(
+        predicate: (HistoryViewState.Content) -> Boolean = { true },
+    ): HistoryViewState.Content {
+        val deadline = System.nanoTime() + AWAIT_TIMEOUT_MILLIS * 1_000_000
+        while (System.nanoTime() < deadline) {
+            val state = vm.testStateValue
+            if (state is HistoryViewState.Content && predicate(state)) return state
+            Thread.sleep(AWAIT_POLL_MILLIS)
+        }
+        fail("Timed out waiting for History content; last=${vm.testStateValue}")
+    }
+
+    private fun page(items: List<History>): PaginatedResponse<History> {
+        return PaginatedResponse(
+            items = items,
+            pagination = Pagination(
+                current = 1,
+                perpage = 20,
+                total = 1,
+                totalItems = items.size,
+            ),
+        )
+    }
+
+    private fun movie(
+        itemId: Int,
+        videoNumber: Int,
+    ): History {
+        return History(
+            item = Item(id = itemId, title = "Synthetic movie $itemId", type = ItemType.MOVIE),
+            video = Video(
+                id = itemId * 100,
+                number = videoNumber,
+                watching = WatchingInfo(time = 120, duration = 600),
+            ),
+        )
+    }
+
+    private fun episode(
+        itemId: Int,
+        season: Int?,
+        episode: Int,
+    ): History {
+        return History(
+            item = Item(id = itemId, title = "Synthetic series $itemId", type = ItemType.SERIAL),
+            video = Video(id = itemId * 100, number = episode),
+            season = season,
+        )
+    }
+}

--- a/app/src/test/kotlin/com/kino/puber/ui/feature/history/vm/HistoryVMQueuedDeletionInputGuardTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/ui/feature/history/vm/HistoryVMQueuedDeletionInputGuardTest.kt
@@ -1,0 +1,361 @@
+package com.kino.puber.ui.feature.history.vm
+
+import com.kino.puber.core.error.ErrorEntity
+import com.kino.puber.core.error.ErrorHandler
+import com.kino.puber.core.paginator.Paginator
+import com.kino.puber.core.ui.model.VideoItemUIMapper
+import com.kino.puber.core.ui.navigation.AppRouter
+import com.kino.puber.core.ui.navigation.Screens
+import com.kino.puber.core.ui.uikit.model.CommonAction
+import com.kino.puber.data.api.KinoPubApiClient
+import com.kino.puber.data.api.models.History
+import com.kino.puber.data.api.models.Item
+import com.kino.puber.data.api.models.ItemType
+import com.kino.puber.data.api.models.PaginatedResponse
+import com.kino.puber.data.api.models.Pagination
+import com.kino.puber.data.api.models.Video
+import com.kino.puber.data.api.models.WatchingInfo
+import com.kino.puber.data.repository.ItemDetailsRepository
+import com.kino.puber.domain.interactor.history.HistoryInteractor
+import com.kino.puber.ui.feature.history.model.HistoryAction
+import com.kino.puber.ui.feature.history.model.HistoryItemUIState
+import com.kino.puber.ui.feature.history.model.HistoryUIMapper
+import com.kino.puber.ui.feature.history.model.HistoryViewState
+import com.kino.puber.ui.feature.player.model.PlayerStartMode
+import com.kino.puber.util.FakeResourceProvider
+import com.kino.puber.util.MainDispatcherExtension
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.api.fail
+
+class HistoryVMQueuedDeletionInputGuardTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val mainDispatcher = MainDispatcherExtension()
+
+        private const val AWAIT_TIMEOUT_MILLIS = 4_000L
+        private const val AWAIT_POLL_MILLIS = 10L
+        private const val REFRESHED_VIDEO_ID = 120
+    }
+
+    private lateinit var api: KinoPubApiClient
+    private lateinit var router: AppRouter
+    private lateinit var vm: HistoryVM
+
+    @BeforeEach
+    fun setUp() {
+        api = mockk()
+        router = mockk(relaxed = true)
+        vm = createVm()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun queuedDeletionDuringRefreshRejectsInputUntilReconciliationSettles() {
+        val pageOneCalls = AtomicInteger()
+        val busy = BusyDeletionLatches()
+        coEvery { api.getHistoryData(1) } coAnswers {
+            when (pageOneCalls.incrementAndGet()) {
+                1 -> Result.success(page(listOf(movie(1), movie(2))))
+                2 -> {
+                    busy.operationEntered.countDown()
+                    awaitLatch(busy.releaseOperation)
+                    Result.success(page(listOf(movie(1), movie(2))))
+                }
+                else -> {
+                    busy.reconciliationEntered.countDown()
+                    awaitLatch(busy.releaseReconciliation)
+                    Result.success(page(listOf(movie(2))))
+                }
+            }
+        }
+        stubBlockingDeletion(busy)
+        vm.testOnStart()
+        val initial = awaitContent()
+
+        vm.onAction(CommonAction.Refresh)
+
+        exerciseQueuedDeletionGuard(
+            busy = busy,
+            deleted = initial.items.first(),
+            retainedItemId = 2,
+            expectedBusyOperation = { it is HistoryOperation.LoadingFirstPage },
+        )
+    }
+
+    @Test
+    fun queuedDeletionDuringPaginationRejectsInputUntilReconciliationSettles() {
+        val pageOneCalls = AtomicInteger()
+        val pageTwoCalls = AtomicInteger()
+        val busy = BusyDeletionLatches()
+        coEvery { api.getHistoryData(1) } coAnswers {
+            if (pageOneCalls.incrementAndGet() == 1) {
+                Result.success(page(listOf(movie(1), movie(2)), current = 1, total = 2))
+            } else {
+                busy.reconciliationEntered.countDown()
+                awaitLatch(busy.releaseReconciliation)
+                Result.success(page(listOf(movie(2)), current = 1, total = 2))
+            }
+        }
+        coEvery { api.getHistoryData(2) } coAnswers {
+            if (pageTwoCalls.incrementAndGet() == 1) {
+                busy.operationEntered.countDown()
+                awaitLatch(busy.releaseOperation)
+            }
+            Result.success(page(listOf(movie(3)), current = 2, total = 2))
+        }
+        stubBlockingDeletion(busy)
+        vm.testOnStart()
+        val initial = awaitContent()
+
+        vm.onAction(CommonAction.LoadMore)
+
+        exerciseQueuedDeletionGuard(
+            busy = busy,
+            deleted = initial.items.first(),
+            retainedItemId = 2,
+            settledIds = listOf(2, 3),
+            expectedBusyOperation = { it is HistoryOperation.LoadingNextPage },
+        )
+    }
+
+    @Test
+    fun queuedDeletionDuringPublicationRejectsInputUntilReconciliationSettles() {
+        val pageOneCalls = AtomicInteger()
+        val busy = BusyDeletionLatches()
+        val blockingMapper = spyk(HistoryUIMapper(VideoItemUIMapper(FakeResourceProvider())))
+        every { blockingMapper.map(any<List<History>>()) } answers {
+            val history = firstArg<List<History>>()
+            if (history.firstOrNull()?.video?.id == REFRESHED_VIDEO_ID) {
+                busy.operationEntered.countDown()
+                awaitLatch(busy.releaseOperation)
+            }
+            callOriginal()
+        }
+        vm = createVm(blockingMapper)
+        coEvery { api.getHistoryData(1) } coAnswers {
+            when (pageOneCalls.incrementAndGet()) {
+                1 -> Result.success(page(listOf(movie(1), movie(2))))
+                2 -> Result.success(
+                    page(
+                        listOf(
+                            movie(itemId = 1, videoId = REFRESHED_VIDEO_ID),
+                            movie(2),
+                        ),
+                    ),
+                )
+                else -> {
+                    busy.reconciliationEntered.countDown()
+                    awaitLatch(busy.releaseReconciliation)
+                    Result.success(page(listOf(movie(2))))
+                }
+            }
+        }
+        stubBlockingDeletion(busy)
+        vm.testOnStart()
+        val initial = awaitContent()
+
+        vm.onAction(CommonAction.Refresh)
+
+        exerciseQueuedDeletionGuard(
+            busy = busy,
+            deleted = initial.items.first(),
+            retainedItemId = 2,
+            expectedDeletionMediaId = REFRESHED_VIDEO_ID,
+            expectedBusyOperation = { it is HistoryOperation.AwaitingPublication },
+        )
+    }
+
+    private fun exerciseQueuedDeletionGuard(
+        busy: BusyDeletionLatches,
+        deleted: HistoryItemUIState,
+        retainedItemId: Int,
+        settledIds: List<Int> = listOf(retainedItemId),
+        expectedDeletionMediaId: Int = deleted.deletionMediaId,
+        expectedBusyOperation: (HistoryOperation) -> Boolean,
+    ) {
+        assertTrue(busy.operationEntered.await(2, TimeUnit.SECONDS))
+        assertTrue(expectedBusyOperation(vm.testRuntimeState.operation))
+        val retained = awaitContent().items.first { it.itemId == retainedItemId }
+        val queueThread = thread {
+            vm.onAction(HistoryAction.DeleteExactMedia(deleted))
+        }
+        val queued = awaitRuntime { it.queuedDeletion?.rowKey == deleted.rowKey }
+        assertTrue(expectedBusyOperation(queued.operation))
+        assertTrue(queued.isDeletionFlowActive())
+        dispatchBlockedActions(deleted, retained)
+        assertInputRejected()
+
+        busy.releaseOperation.countDown()
+        assertTrue(busy.mutationEntered.await(2, TimeUnit.SECONDS))
+        dispatchBlockedActions(deleted, retained)
+        assertInputRejected()
+
+        busy.releaseMutation.countDown()
+        assertTrue(busy.reconciliationEntered.await(2, TimeUnit.SECONDS))
+        dispatchBlockedActions(deleted, retained)
+        assertInputRejected()
+
+        busy.releaseReconciliation.countDown()
+        queueThread.join(2_000)
+        val settled = awaitContent {
+            it.items.map(HistoryItemUIState::itemId) == settledIds &&
+                !it.isRefreshing &&
+                it.deletingKeys.isEmpty()
+        }
+        vm.onAction(CommonAction.ItemSelected(settled.items.first { it.itemId == retainedItemId }))
+
+        verify(exactly = 1) { router.navigateTo(any()) }
+        coVerify(exactly = 1) { api.clearExactMediaHistory(expectedDeletionMediaId) }
+    }
+
+    private fun dispatchBlockedActions(
+        deleted: HistoryItemUIState,
+        retained: HistoryItemUIState,
+    ) {
+        vm.onAction(CommonAction.ItemSelected(retained))
+        vm.onAction(HistoryAction.OpenContextMenu(retained))
+        vm.onAction(
+            HistoryAction.Play(
+                item = retained,
+                startMode = PlayerStartMode.ResumeIfAvailable,
+            ),
+        )
+        vm.onAction(HistoryAction.OpenDetails(retained))
+        vm.onAction(HistoryAction.DeleteExactMedia(deleted))
+    }
+
+    private fun assertInputRejected() {
+        verify(exactly = 0) { router.navigateTo(any()) }
+        assertNull(vm.testRuntimeState.openMenuKey)
+        assertNull(awaitContent().openMenuKey)
+    }
+
+    private fun stubBlockingDeletion(busy: BusyDeletionLatches) {
+        coEvery { api.clearExactMediaHistory(any()) } coAnswers {
+            busy.mutationEntered.countDown()
+            awaitLatch(busy.releaseMutation)
+            Result.success(Unit)
+        }
+    }
+
+    private fun createVm(
+        mapper: HistoryUIMapper = HistoryUIMapper(VideoItemUIMapper(FakeResourceProvider())),
+    ): HistoryVM {
+        val screens = mockk<Screens>(relaxed = true)
+        val errorHandler = mockk<ErrorHandler>(relaxed = true)
+        every { router.screens } returns screens
+        every { errorHandler.map(any()) } answers {
+            val error = firstArg<Throwable>()
+            ErrorEntity(message = error.message.orEmpty(), code = "test")
+        }
+        return HistoryVM(
+            paginator = Paginator.Store(comparator = HistoryRowComparator),
+            interactor = spyk(
+                HistoryInteractor(
+                    api = api,
+                    itemDetailsRepository = mockk<ItemDetailsRepository>(relaxed = true),
+                ),
+            ),
+            mapper = mapper,
+            router = router,
+            errorHandler = errorHandler,
+        )
+    }
+
+    private fun awaitContent(
+        predicate: (HistoryViewState.Content) -> Boolean = { true },
+    ): HistoryViewState.Content {
+        val deadline = System.nanoTime() + AWAIT_TIMEOUT_MILLIS * 1_000_000
+        while (System.nanoTime() < deadline) {
+            val state = vm.testStateValue
+            if (state is HistoryViewState.Content && predicate(state)) {
+                return state
+            }
+            Thread.sleep(AWAIT_POLL_MILLIS)
+        }
+        fail("Timed out waiting for History state; last=${vm.testStateValue}")
+    }
+
+    private fun awaitRuntime(
+        predicate: (HistoryRuntimeState) -> Boolean,
+    ): HistoryRuntimeState {
+        val deadline = System.nanoTime() + AWAIT_TIMEOUT_MILLIS * 1_000_000
+        while (System.nanoTime() < deadline) {
+            val state = vm.testRuntimeState
+            if (predicate(state)) return state
+            Thread.sleep(AWAIT_POLL_MILLIS)
+        }
+        fail("Timed out waiting for History runtime; last=${vm.testRuntimeState}")
+    }
+
+    private fun page(
+        items: List<History>,
+        current: Int = 1,
+        total: Int = 1,
+    ): PaginatedResponse<History> {
+        return PaginatedResponse(
+            items = items,
+            pagination = Pagination(
+                current = current,
+                perpage = 20,
+                total = total,
+                totalItems = items.size,
+            ),
+        )
+    }
+
+    private fun movie(
+        itemId: Int,
+        videoId: Int = itemId * 100,
+    ): History {
+        return History(
+            item = Item(
+                id = itemId,
+                title = "Synthetic movie $itemId",
+                type = ItemType.MOVIE,
+            ),
+            video = Video(
+                id = videoId,
+                number = itemId,
+                watching = WatchingInfo(time = 120, duration = 600),
+            ),
+        )
+    }
+
+    private fun awaitLatch(latch: CountDownLatch) {
+        check(latch.await(2, TimeUnit.SECONDS))
+    }
+
+    private class BusyDeletionLatches {
+        val operationEntered = CountDownLatch(1)
+        val releaseOperation = CountDownLatch(1)
+        val mutationEntered = CountDownLatch(1)
+        val releaseMutation = CountDownLatch(1)
+        val reconciliationEntered = CountDownLatch(1)
+        val releaseReconciliation = CountDownLatch(1)
+    }
+
+}

--- a/app/src/test/kotlin/com/kino/puber/ui/feature/history/vm/HistoryVMRefreshDepthTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/ui/feature/history/vm/HistoryVMRefreshDepthTest.kt
@@ -1,0 +1,404 @@
+package com.kino.puber.ui.feature.history.vm
+
+import com.kino.puber.core.error.ErrorEntity
+import com.kino.puber.core.error.ErrorHandler
+import com.kino.puber.core.paginator.Paginator
+import com.kino.puber.core.ui.model.VideoItemUIMapper
+import com.kino.puber.core.ui.navigation.AppRouter
+import com.kino.puber.core.ui.navigation.PuberScreen
+import com.kino.puber.core.ui.navigation.Screens
+import com.kino.puber.core.ui.uikit.model.CommonAction
+import com.kino.puber.data.api.KinoPubApiClient
+import com.kino.puber.data.api.models.History
+import com.kino.puber.data.api.models.Item
+import com.kino.puber.data.api.models.ItemType
+import com.kino.puber.data.api.models.PaginatedResponse
+import com.kino.puber.data.api.models.Pagination
+import com.kino.puber.data.api.models.Video
+import com.kino.puber.data.api.models.WatchingInfo
+import com.kino.puber.data.repository.ItemDetailsRepository
+import com.kino.puber.domain.interactor.history.HistoryInteractor
+import com.kino.puber.ui.feature.history.model.HistoryAction
+import com.kino.puber.ui.feature.history.model.HistoryItemUIState
+import com.kino.puber.ui.feature.history.model.HistoryUIMapper
+import com.kino.puber.ui.feature.history.model.HistoryViewState
+import com.kino.puber.ui.feature.player.model.PlayerStartMode
+import com.kino.puber.util.FakeResourceProvider
+import com.kino.puber.util.MainDispatcherExtension
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.io.IOException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.api.fail
+
+internal class HistoryVMRefreshDepthTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val mainDispatcher = MainDispatcherExtension()
+
+        private const val AWAIT_TIMEOUT_MILLIS = 4_000L
+        private const val AWAIT_POLL_MILLIS = 10L
+    }
+
+    private lateinit var api: KinoPubApiClient
+    private lateinit var itemDetailsRepository: ItemDetailsRepository
+    private lateinit var screens: Screens
+    private lateinit var router: AppRouter
+    private lateinit var errorHandler: ErrorHandler
+
+    @BeforeEach
+    fun setUp() {
+        api = mockk()
+        itemDetailsRepository = mockk(relaxed = true)
+        screens = mockk(relaxed = true)
+        router = mockk(relaxed = true)
+        errorHandler = mockk(relaxed = true)
+        every { router.screens } returns screens
+        every { errorHandler.map(any()) } answers {
+            val error = firstArg<Throwable>()
+            ErrorEntity(message = error.message.orEmpty(), code = "test")
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun onResumeDuringLoadMore_runsDeferredRefreshAndKeepsLaterPageAvailable() {
+        val pageOneCalls = AtomicInteger()
+        val pageTwoCalls = AtomicInteger()
+        val releasePageTwo = CountDownLatch(1)
+        coEvery { api.getHistoryData(1) } coAnswers {
+            val call = pageOneCalls.incrementAndGet()
+            val deletionMediaId = if (call == 1) 100 else 120
+            Result.success(
+                page(
+                    listOf(movie(itemId = 1, videoId = deletionMediaId)),
+                    current = 1,
+                    total = 2,
+                ),
+            )
+        }
+        coEvery { api.getHistoryData(2) } coAnswers {
+            if (pageTwoCalls.incrementAndGet() == 1) {
+                check(releasePageTwo.await(2, TimeUnit.SECONDS))
+            }
+            Result.success(page(listOf(movie(2)), current = 2, total = 3))
+        }
+        coEvery { api.getHistoryData(3) } returns Result.success(
+            page(listOf(movie(3)), current = 3, total = 3),
+        )
+        val vm = createVM().also(HistoryVM::testOnStart)
+        awaitContent(vm)
+
+        val loadThread = thread { vm.onAction(CommonAction.LoadMore) }
+        awaitContent(vm) { it.isLoadingMore }
+        vm.onAction(CommonAction.OnResume)
+        releasePageTwo.countDown()
+        loadThread.join(2_000)
+
+        val refreshed = awaitContent(vm) {
+            pageOneCalls.get() == 2 && it.items.first().deletionMediaId == 120
+        }
+        assertFalse(refreshed.isRefreshing)
+        assertEquals(listOf(1, 2), refreshed.itemIds())
+        assertTrue(refreshed.hasMorePages)
+        coVerify(exactly = 2) { api.getHistoryData(1) }
+        coVerify(exactly = 2) { api.getHistoryData(2) }
+
+        vm.onAction(CommonAction.LoadMore)
+
+        val completed = awaitContent(vm) { it.itemIds() == listOf(1, 2, 3) }
+        assertFalse(completed.hasMorePages)
+        coVerify(exactly = 1) { api.getHistoryData(3) }
+    }
+
+    @Test
+    fun onResumeRefresh_refetchesLoadedDepthAndPreservesFocusedLaterPageItem() {
+        val pageOneCalls = AtomicInteger()
+        val pageTwoCalls = AtomicInteger()
+        val refreshedPageTwoEntered = CountDownLatch(1)
+        val releaseRefreshedPageTwo = CountDownLatch(1)
+        coEvery { api.getHistoryData(1) } coAnswers {
+            if (pageOneCalls.incrementAndGet() == 1) {
+                Result.success(page(listOf(movie(1)), current = 1, total = 2))
+            } else {
+                Result.success(page(listOf(movie(3), movie(1)), current = 1, total = 2))
+            }
+        }
+        coEvery { api.getHistoryData(2) } coAnswers {
+            val call = pageTwoCalls.incrementAndGet()
+            if (call == 2) {
+                refreshedPageTwoEntered.countDown()
+                check(releaseRefreshedPageTwo.await(2, TimeUnit.SECONDS))
+            }
+            Result.success(
+                page(
+                    listOf(
+                        movie(itemId = 1, videoId = 120),
+                        movie(itemId = 2, videoId = if (call == 1) 200 else 220),
+                    ),
+                    current = 2,
+                    total = 2,
+                ),
+            )
+        }
+        val vm = createVM().also(HistoryVM::testOnStart)
+        awaitContent(vm)
+        vm.onAction(CommonAction.LoadMore)
+        val loaded = awaitContent(vm) { it.itemIds() == listOf(1, 2) }
+        vm.onAction(CommonAction.ItemFocused(loaded.items.last()))
+
+        val refreshThread = thread { vm.onAction(CommonAction.OnResume) }
+        assertTrue(refreshedPageTwoEntered.await(2, TimeUnit.SECONDS))
+        val refreshing = awaitContent(vm) {
+            it.isRefreshing && it.itemIds() == listOf(1, 2)
+        }
+        assertEquals(2, refreshing.focusedItemId())
+        releaseRefreshedPageTwo.countDown()
+        refreshThread.join(2_000)
+
+        val refreshed = awaitContent(vm) {
+            it.itemIds() == listOf(3, 1, 2) &&
+                it.items.last().deletionMediaId == 220 &&
+                !it.isRefreshing
+        }
+        assertEquals(2, refreshed.focusedItemId())
+        assertEquals(2, pageOneCalls.get())
+        assertEquals(2, pageTwoCalls.get())
+    }
+
+    @Test
+    fun refreshFailureOnLaterPage_restoresEntireStableWindowAndFocus() {
+        val pageOneCalls = AtomicInteger()
+        val pageTwoCalls = AtomicInteger()
+        coEvery { api.getHistoryData(1) } coAnswers {
+            if (pageOneCalls.incrementAndGet() == 1) {
+                Result.success(page(listOf(movie(1)), current = 1, total = 2))
+            } else {
+                Result.success(page(listOf(movie(3)), current = 1, total = 2))
+            }
+        }
+        coEvery { api.getHistoryData(2) } coAnswers {
+            if (pageTwoCalls.incrementAndGet() == 1) {
+                Result.success(page(listOf(movie(2)), current = 2, total = 2))
+            } else {
+                Result.failure(IOException("page two refresh failure"))
+            }
+        }
+        val vm = createVM().also(HistoryVM::testOnStart)
+        awaitContent(vm)
+        vm.onAction(CommonAction.LoadMore)
+        val loaded = awaitContent(vm) { it.itemIds() == listOf(1, 2) }
+        vm.onAction(CommonAction.ItemFocused(loaded.items.last()))
+
+        vm.onAction(CommonAction.Refresh)
+
+        val restored = awaitContent(vm) {
+            !it.isRefreshing &&
+                it.itemIds() == listOf(1, 2) &&
+                pageTwoCalls.get() == 2
+        }
+        assertEquals(2, restored.focusedItemId())
+        assertEquals(2, pageOneCalls.get())
+        assertEquals(2, pageTwoCalls.get())
+        verify { errorHandler.map(match { it.message == "page two refresh failure" }) }
+    }
+
+    @Test
+    fun refreshPageMismatch_restoresStableWindowInsteadOfPublishingTruncatedData() {
+        val pageOneCalls = AtomicInteger()
+        val pageTwoCalls = AtomicInteger()
+        coEvery { api.getHistoryData(1) } coAnswers {
+            val itemId = if (pageOneCalls.incrementAndGet() == 1) 1 else 3
+            Result.success(page(listOf(movie(itemId)), current = 1, total = 2))
+        }
+        coEvery { api.getHistoryData(2) } coAnswers {
+            if (pageTwoCalls.incrementAndGet() == 1) {
+                Result.success(page(listOf(movie(2)), current = 2, total = 2))
+            } else {
+                Result.success(page(listOf(movie(3)), current = 1, total = 2))
+            }
+        }
+        val vm = createVM().also(HistoryVM::testOnStart)
+        awaitContent(vm)
+        vm.onAction(CommonAction.LoadMore)
+        val loaded = awaitContent(vm) { it.itemIds() == listOf(1, 2) }
+        vm.onAction(CommonAction.ItemFocused(loaded.items.last()))
+
+        vm.onAction(CommonAction.Refresh)
+
+        val restored = awaitContent(vm) {
+            !it.isRefreshing &&
+                it.itemIds() == listOf(1, 2) &&
+                pageTwoCalls.get() == 2
+        }
+        assertEquals(2, restored.focusedItemId())
+        verify {
+            errorHandler.map(
+                match { it.message == "History pagination did not match the requested page" },
+            )
+        }
+    }
+
+    @Test
+    fun refreshWhenPageCountShrinks_stopsAtNewBoundAndDropsOldTail() {
+        val pageOneCalls = AtomicInteger()
+        val pageTwoCalls = AtomicInteger()
+        coEvery { api.getHistoryData(1) } coAnswers {
+            if (pageOneCalls.incrementAndGet() == 1) {
+                Result.success(page(listOf(movie(1)), current = 1, total = 2))
+            } else {
+                Result.success(page(listOf(movie(3)), current = 1, total = 1))
+            }
+        }
+        coEvery { api.getHistoryData(2) } coAnswers {
+            pageTwoCalls.incrementAndGet()
+            Result.success(page(listOf(movie(2)), current = 2, total = 2))
+        }
+        val vm = createVM().also(HistoryVM::testOnStart)
+        awaitContent(vm)
+        vm.onAction(CommonAction.LoadMore)
+        awaitContent(vm) { it.itemIds() == listOf(1, 2) }
+
+        vm.onAction(CommonAction.Refresh)
+
+        val refreshed = awaitContent(vm) {
+            !it.isRefreshing && it.itemIds() == listOf(3)
+        }
+        assertFalse(refreshed.hasMorePages)
+        assertEquals(2, pageOneCalls.get())
+        assertEquals(1, pageTwoCalls.get())
+    }
+
+    @Test
+    fun nextPageMismatchKeepsCurrentWindowRetryableInsteadOfSkippingPages() {
+        coEvery { api.getHistoryData(1) } returns Result.success(
+            page(listOf(movie(1)), current = 1, total = 3),
+        )
+        coEvery { api.getHistoryData(2) } returns Result.success(
+            page(listOf(movie(3)), current = 3, total = 3),
+        )
+        val vm = createVM().also(HistoryVM::testOnStart)
+        val firstPage = awaitContent(vm)
+
+        vm.onAction(CommonAction.LoadMore)
+
+        val failed = awaitContent(vm) {
+            !it.isLoadingMore &&
+                it.itemIds() == listOf(1) &&
+                it.nextPageErrorMessage ==
+                    "History pagination did not match the requested next page"
+        }
+        assertEquals(firstPage.focusKey, failed.focusKey)
+        assertTrue(failed.hasMorePages)
+        coVerify(exactly = 1) { api.getHistoryData(2) }
+    }
+
+    @Test
+    fun contextMenuStartOver_routesExplicitPlayerStartMode() {
+        coEvery { api.getHistoryData(1) } returns Result.success(page(listOf(movie(1))))
+        val vm = createVM().also(HistoryVM::testOnStart)
+        val item = awaitContent(vm).items.single()
+        val playerScreen = mockk<PuberScreen>()
+        every {
+            screens.player(
+                itemId = item.itemId,
+                seasonNumber = null,
+                episodeNumber = null,
+                videoNumber = item.videoNumber,
+                startMode = PlayerStartMode.StartFromBeginning,
+            )
+        } returns playerScreen
+
+        vm.onAction(HistoryAction.Play(item, PlayerStartMode.StartFromBeginning))
+
+        verify { router.navigateTo(playerScreen) }
+        verify { itemDetailsRepository.invalidate(item.itemId) }
+    }
+
+    private fun createVM(): HistoryVM {
+        return HistoryVM(
+            paginator = Paginator.Store(comparator = HistoryRowComparator),
+            interactor = HistoryInteractor(api, itemDetailsRepository),
+            mapper = HistoryUIMapper(VideoItemUIMapper(FakeResourceProvider())),
+            router = router,
+            errorHandler = errorHandler,
+        )
+    }
+
+    private fun awaitContent(
+        vm: HistoryVM,
+        predicate: (HistoryViewState.Content) -> Boolean = { true },
+    ): HistoryViewState.Content {
+        val deadline = System.nanoTime() + AWAIT_TIMEOUT_MILLIS * 1_000_000
+        while (System.nanoTime() < deadline) {
+            val state = vm.testStateValue
+            if (state is HistoryViewState.Content && predicate(state)) {
+                return state
+            }
+            Thread.sleep(AWAIT_POLL_MILLIS)
+        }
+        fail("Timed out waiting for History state; last=${vm.testStateValue}")
+    }
+
+    private fun HistoryViewState.Content.itemIds(): List<Int> {
+        return items.map(HistoryItemUIState::itemId)
+    }
+
+    private fun HistoryViewState.Content.focusedItemId(): Int? {
+        return items.firstOrNull { it.rowKey == focusKey }?.itemId
+    }
+
+    private fun page(
+        items: List<History>,
+        current: Int = 1,
+        total: Int = 1,
+    ): PaginatedResponse<History> {
+        return PaginatedResponse(
+            items = items,
+            pagination = Pagination(
+                current = current,
+                perpage = 20,
+                total = total,
+                totalItems = items.size,
+            ),
+        )
+    }
+
+    private fun movie(
+        itemId: Int,
+        videoId: Int = itemId * 100,
+    ): History {
+        return History(
+            item = Item(
+                id = itemId,
+                title = "Synthetic movie $itemId",
+                type = ItemType.MOVIE,
+            ),
+            video = Video(
+                id = videoId,
+                number = itemId,
+                watching = WatchingInfo(time = 120, duration = 600),
+            ),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/kino/puber/ui/feature/history/vm/HistoryVMRestartTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/ui/feature/history/vm/HistoryVMRestartTest.kt
@@ -1,0 +1,135 @@
+package com.kino.puber.ui.feature.history.vm
+
+import com.kino.puber.core.error.ErrorEntity
+import com.kino.puber.core.error.ErrorHandler
+import com.kino.puber.core.paginator.Paginator
+import com.kino.puber.core.ui.model.VideoItemUIMapper
+import com.kino.puber.core.ui.navigation.AppRouter
+import com.kino.puber.core.ui.uikit.model.CommonAction
+import com.kino.puber.data.api.KinoPubApiClient
+import com.kino.puber.data.api.models.History
+import com.kino.puber.data.api.models.Item
+import com.kino.puber.data.api.models.ItemType
+import com.kino.puber.data.api.models.PaginatedResponse
+import com.kino.puber.data.api.models.Pagination
+import com.kino.puber.data.api.models.Video
+import com.kino.puber.data.repository.ItemDetailsRepository
+import com.kino.puber.domain.interactor.history.HistoryInteractor
+import com.kino.puber.ui.feature.history.model.HistoryItemUIState
+import com.kino.puber.ui.feature.history.model.HistoryUIMapper
+import com.kino.puber.ui.feature.history.model.HistoryViewState
+import com.kino.puber.util.FakeResourceProvider
+import com.kino.puber.util.MainDispatcherExtension
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import java.io.IOException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.api.fail
+
+internal class HistoryVMRestartTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val mainDispatcher = MainDispatcherExtension()
+
+        private const val AWAIT_TIMEOUT_MILLIS = 4_000L
+        private const val AWAIT_POLL_MILLIS = 10L
+    }
+
+    @Test
+    fun doubleRetryAcceptsOneCompleteOrderedRestart() {
+        val api = mockk<KinoPubApiClient>()
+        val pageOneCalls = AtomicInteger()
+        val retryEntered = CountDownLatch(1)
+        val releaseRetry = CountDownLatch(1)
+        coEvery { api.getHistoryData(1) } coAnswers {
+            when (pageOneCalls.incrementAndGet()) {
+                1 -> Result.failure(IOException("initial failure"))
+                2 -> {
+                    retryEntered.countDown()
+                    check(releaseRetry.await(2, TimeUnit.SECONDS))
+                    Result.success(page(listOf(movie(1), movie(2))))
+                }
+                else -> Result.success(page(emptyList()))
+            }
+        }
+        val errorHandler = mockk<ErrorHandler>(relaxed = true)
+        every { errorHandler.map(any()) } answers {
+            val error = firstArg<Throwable>()
+            ErrorEntity(message = error.message.orEmpty(), code = "test")
+        }
+        val vm = HistoryVM(
+            paginator = Paginator.Store(comparator = HistoryRowComparator),
+            interactor = HistoryInteractor(
+                api = api,
+                itemDetailsRepository = mockk<ItemDetailsRepository>(relaxed = true),
+            ),
+            mapper = HistoryUIMapper(VideoItemUIMapper(FakeResourceProvider())),
+            router = mockk<AppRouter>(relaxed = true),
+            errorHandler = errorHandler,
+        ).also(HistoryVM::testOnStart)
+        awaitState(vm) { it is HistoryViewState.Error }
+
+        vm.onAction(CommonAction.RetryClicked)
+        assertTrue(retryEntered.await(2, TimeUnit.SECONDS))
+        vm.onAction(CommonAction.RetryClicked)
+        Thread.sleep(100)
+        releaseRetry.countDown()
+
+        val content = awaitState(vm) {
+            it is HistoryViewState.Content &&
+                it.items.map(HistoryItemUIState::itemId) == listOf(1, 2)
+        } as HistoryViewState.Content
+        assertEquals(listOf(1, 2), content.items.map(HistoryItemUIState::itemId))
+        assertEquals(2, pageOneCalls.get())
+        coVerify(exactly = 2) { api.getHistoryData(1) }
+    }
+
+    private fun awaitState(
+        vm: HistoryVM,
+        predicate: (HistoryViewState) -> Boolean,
+    ): HistoryViewState {
+        val deadline = System.nanoTime() + AWAIT_TIMEOUT_MILLIS * 1_000_000
+        while (System.nanoTime() < deadline) {
+            val state = vm.testStateValue
+            if (predicate(state)) return state
+            Thread.sleep(AWAIT_POLL_MILLIS)
+        }
+        fail("Timed out waiting for History state; last=${vm.testStateValue}")
+    }
+
+    private fun page(items: List<History>): PaginatedResponse<History> {
+        return PaginatedResponse(
+            items = items,
+            pagination = Pagination(
+                current = 1,
+                perpage = 20,
+                total = 1,
+                totalItems = items.size,
+            ),
+        )
+    }
+
+    private fun movie(itemId: Int): History {
+        return History(
+            item = Item(
+                id = itemId,
+                title = "Synthetic movie $itemId",
+                type = ItemType.MOVIE,
+            ),
+            video = Video(
+                id = itemId * 100,
+                number = itemId,
+            ),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/kino/puber/ui/feature/history/vm/HistoryVMTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/ui/feature/history/vm/HistoryVMTest.kt
@@ -1,0 +1,641 @@
+package com.kino.puber.ui.feature.history.vm
+
+import com.kino.puber.core.error.ErrorEntity
+import com.kino.puber.core.error.ErrorHandler
+import com.kino.puber.core.paginator.Paginator
+import com.kino.puber.core.ui.model.VideoItemUIMapper
+import com.kino.puber.core.ui.navigation.AppRouter
+import com.kino.puber.core.ui.navigation.Screens
+import com.kino.puber.core.ui.uikit.model.CommonAction
+import com.kino.puber.data.api.KinoPubApiClient
+import com.kino.puber.data.api.models.History
+import com.kino.puber.data.api.models.Item
+import com.kino.puber.data.api.models.ItemType
+import com.kino.puber.data.api.models.PaginatedResponse
+import com.kino.puber.data.api.models.Pagination
+import com.kino.puber.data.api.models.Video
+import com.kino.puber.data.api.models.WatchingInfo
+import com.kino.puber.data.repository.ItemDetailsRepository
+import com.kino.puber.domain.interactor.history.HistoryInteractor
+import com.kino.puber.ui.feature.history.model.HistoryAction
+import com.kino.puber.ui.feature.history.model.HistoryItemUIState
+import com.kino.puber.ui.feature.history.model.HistoryUIMapper
+import com.kino.puber.ui.feature.history.model.HistoryViewState
+import com.kino.puber.util.FakeResourceProvider
+import com.kino.puber.util.MainDispatcherExtension
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import kotlinx.coroutines.delay
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
+import org.junit.jupiter.api.extension.RegisterExtension
+import java.io.IOException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
+
+class HistoryVMTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val mainDispatcher = MainDispatcherExtension()
+
+        private const val AWAIT_TIMEOUT_MILLIS = 4_000L
+        private const val AWAIT_POLL_MILLIS = 10L
+    }
+
+    private lateinit var api: KinoPubApiClient
+    private lateinit var itemDetailsRepository: ItemDetailsRepository
+    private lateinit var interactor: HistoryInteractor
+    private lateinit var mapper: HistoryUIMapper
+    private lateinit var screens: Screens
+    private lateinit var router: AppRouter
+    private lateinit var errorHandler: ErrorHandler
+
+    @BeforeEach
+    fun setUp() {
+        api = mockk()
+        itemDetailsRepository = mockk(relaxed = true)
+        interactor = spyk(HistoryInteractor(api, itemDetailsRepository))
+        mapper = HistoryUIMapper(VideoItemUIMapper(FakeResourceProvider()))
+        screens = mockk(relaxed = true)
+        router = mockk(relaxed = true)
+        errorHandler = mockk(relaxed = true)
+
+        every { router.screens } returns screens
+        every { errorHandler.map(any()) } answers {
+            val error = firstArg<Throwable>()
+            ErrorEntity(message = error.message.orEmpty(), code = "test")
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun initialLoad_mapsContentAndEmptyAndErrorStates() {
+        val contentVM = startWith(page(listOf(movie(1))))
+        assertEquals(listOf(1), awaitContent(contentVM).itemIds())
+
+        val emptyVM = startWith(page(emptyList()))
+        awaitState(emptyVM) { it == HistoryViewState.Empty }
+
+        coEvery { api.getHistoryData(1) } returns Result.failure(IOException("initial failure"))
+        val errorVM = createVM().also(HistoryVM::testOnStart)
+        val error = awaitState(errorVM) { it is HistoryViewState.Error } as HistoryViewState.Error
+        assertEquals("initial failure", error.message)
+    }
+
+    @Test
+    fun loadMore_isSerializedAndAppendsTheNextPage() {
+        coEvery { api.getHistoryData(1) } returns Result.success(
+            page(listOf(movie(1)), current = 1, total = 2),
+        )
+        coEvery { api.getHistoryData(2) } coAnswers {
+            delay(150)
+            Result.success(page(listOf(movie(2)), current = 2, total = 2))
+        }
+        val vm = createVM().also(HistoryVM::testOnStart)
+        awaitContent(vm) { it.itemIds() == listOf(1) }
+
+        vm.onAction(CommonAction.LoadMore)
+        vm.onAction(CommonAction.LoadMore)
+
+        awaitContent(vm) { it.isLoadingMore }
+        assertEquals(listOf(1, 2), awaitContent(vm) { it.itemIds() == listOf(1, 2) }.itemIds())
+        coVerify(exactly = 1) { api.getHistoryData(2) }
+    }
+
+    @Test
+    fun nextPageFailure_keepsLoadedContent() {
+        coEvery { api.getHistoryData(1) } returns Result.success(
+            page(listOf(movie(1)), current = 1, total = 2),
+        )
+        coEvery { api.getHistoryData(2) } coAnswers {
+            delay(100)
+            Result.failure(IOException("page failure"))
+        }
+        val vm = createVM().also(HistoryVM::testOnStart)
+        awaitContent(vm)
+
+        vm.onAction(CommonAction.LoadMore)
+
+        awaitContent(vm) { it.isLoadingMore }
+        val content = awaitContent(vm) { !it.isLoadingMore }
+        assertEquals(listOf(1), content.itemIds())
+        assertEquals("page failure", content.nextPageErrorMessage)
+        verify { errorHandler.map(match { it.message == "page failure" }) }
+    }
+
+    @Test
+    fun duplicateOnlyPage_automaticallyContinuesToRenderableLaterPageWithoutDuplicatesOrFocusLoss() {
+        coEvery { api.getHistoryData(1) } returns Result.success(
+            page(listOf(movie(1)), current = 1, total = 3),
+        )
+        coEvery { api.getHistoryData(2) } returns Result.success(
+            page(
+                listOf(movie(itemId = 1, recordId = 11)),
+                current = 2,
+                total = 3,
+            ),
+        )
+        coEvery { api.getHistoryData(3) } returns Result.success(
+            page(listOf(movie(2)), current = 3, total = 3),
+        )
+        val vm = createVM().also(HistoryVM::testOnStart)
+        val first = awaitContent(vm).items.single()
+        vm.onAction(CommonAction.ItemFocused(first))
+
+        vm.onAction(CommonAction.LoadMore)
+
+        val content = awaitContent(vm) { it.itemIds() == listOf(1, 2) }
+        assertEquals(listOf(1, 2), content.itemIds())
+        assertEquals(1, content.focusedItemId())
+        assertFalse(content.hasMorePages)
+        coVerify(exactly = 1) { api.getHistoryData(2) }
+        coVerify(exactly = 1) { api.getHistoryData(3) }
+    }
+
+    @Test
+    fun failedNextPage_explicitRetryAtSameThresholdDoesNotDuplicateRequestsRowsOrLoseFocus() {
+        val pageTwoCalls = AtomicInteger()
+        coEvery { api.getHistoryData(1) } returns Result.success(
+            page(listOf(movie(1)), current = 1, total = 2),
+        )
+        coEvery { api.getHistoryData(2) } coAnswers {
+            if (pageTwoCalls.incrementAndGet() == 1) {
+                Result.failure(IOException("page failure"))
+            } else {
+                Result.success(
+                    page(
+                        listOf(movie(itemId = 1, recordId = 11), movie(2)),
+                        current = 2,
+                        total = 2,
+                    ),
+                )
+            }
+        }
+        val vm = createVM().also(HistoryVM::testOnStart)
+        val first = awaitContent(vm).items.single()
+        vm.onAction(CommonAction.ItemFocused(first))
+
+        vm.onAction(CommonAction.LoadMore)
+
+        val failed = awaitContent(vm) { it.nextPageErrorMessage == "page failure" }
+        assertEquals(listOf(1), failed.itemIds())
+        assertEquals(1, failed.focusedItemId())
+        assertEquals(1, pageTwoCalls.get())
+
+        vm.onAction(CommonAction.ReloadNextPage)
+
+        val retried = awaitContent(vm) { it.itemIds() == listOf(1, 2) }
+        assertEquals(listOf(1, 2), retried.itemIds())
+        assertEquals(1, retried.focusedItemId())
+        assertEquals(null, retried.nextPageErrorMessage)
+        assertEquals(2, pageTwoCalls.get())
+        coVerify(exactly = 2) { api.getHistoryData(2) }
+    }
+
+    @Test
+    fun refreshAfterPageError_keepsContentVisible() {
+        val pageOneCalls = AtomicInteger()
+        coEvery { api.getHistoryData(1) } coAnswers {
+            if (pageOneCalls.incrementAndGet() == 1) {
+                Result.success(page(listOf(movie(1)), current = 1, total = 2))
+            } else {
+                delay(150)
+                Result.success(page(listOf(movie(itemId = 1, videoId = 112))))
+            }
+        }
+        coEvery { api.getHistoryData(2) } coAnswers {
+            delay(100)
+            Result.failure(IOException("page failure"))
+        }
+        val vm = createVM().also(HistoryVM::testOnStart)
+        awaitContent(vm)
+        vm.onAction(CommonAction.LoadMore)
+        awaitContent(vm) { it.isLoadingMore }
+        awaitContent(vm) { !it.isLoadingMore }
+
+        vm.onAction(CommonAction.Refresh)
+
+        val refreshing = awaitContent(vm) { it.isRefreshing }
+        assertEquals(100, refreshing.items.single().deletionMediaId)
+        assertEquals(
+            112,
+            awaitContent(vm) { it.items.single().deletionMediaId == 112 }
+                .items.single().deletionMediaId,
+        )
+    }
+
+    @Test
+    fun refresh_keepsContentVisibleAndResetsTraversalForAuthoritativePageOne() {
+        val calls = AtomicInteger()
+        val first = movie(itemId = 1, videoId = 111)
+        val refreshed = movie(itemId = 1, videoId = 112)
+        coEvery { api.getHistoryData(1) } coAnswers {
+            if (calls.incrementAndGet() == 1) {
+                Result.success(page(listOf(first)))
+            } else {
+                delay(150)
+                Result.success(page(listOf(refreshed)))
+            }
+        }
+        val vm = createVM().also(HistoryVM::testOnStart)
+        awaitContent(vm) { it.items.single().deletionMediaId == 111 }
+
+        vm.onAction(CommonAction.Refresh)
+
+        val refreshing = awaitContent(vm) { it.isRefreshing }
+        assertEquals(111, refreshing.items.single().deletionMediaId)
+        assertEquals(
+            112,
+            awaitContent(vm) { it.items.single().deletionMediaId == 112 }
+                .items.single().deletionMediaId,
+        )
+    }
+
+    @Test
+    fun failedRetainedRefresh_restoresDataSeedsTraversalAndBlocksInterleavedLoadMore() {
+        val pageOneCalls = AtomicInteger()
+        coEvery { api.getHistoryData(1) } coAnswers {
+            if (pageOneCalls.incrementAndGet() == 1) {
+                Result.success(page(listOf(movie(1)), current = 1, total = 2))
+            } else {
+                delay(150)
+                Result.failure(IOException("refresh failure"))
+            }
+        }
+        coEvery { api.getHistoryData(2) } returns Result.success(
+            page(listOf(movie(2)), current = 2, total = 2),
+        )
+        val vm = createVM().also(HistoryVM::testOnStart)
+        awaitContent(vm)
+
+        vm.onAction(CommonAction.Refresh)
+        awaitContent(vm) { it.isRefreshing }
+        vm.onAction(CommonAction.LoadMore)
+        Thread.sleep(40)
+        coVerify(exactly = 0) { api.getHistoryData(2) }
+
+        val restored = awaitContent(vm) { !it.isRefreshing && pageOneCalls.get() == 2 }
+        assertEquals(listOf(1), restored.itemIds())
+
+        vm.onAction(CommonAction.LoadMore)
+        assertEquals(listOf(1, 2), awaitContent(vm) { it.itemIds() == listOf(1, 2) }.itemIds())
+        coVerify(exactly = 1) { api.getHistoryData(2) }
+    }
+
+    @Test
+    fun retryAfterInitialError_restartsPageOneAndTraversal() {
+        val calls = AtomicInteger()
+        coEvery { api.getHistoryData(1) } coAnswers {
+            if (calls.incrementAndGet() == 1) {
+                Result.failure(IOException("initial failure"))
+            } else {
+                Result.success(page(listOf(movie(1))))
+            }
+        }
+        val vm = createVM().also(HistoryVM::testOnStart)
+        awaitState(vm) { it is HistoryViewState.Error }
+
+        vm.onAction(CommonAction.RetryClicked)
+
+        assertEquals(listOf(1), awaitContent(vm).itemIds())
+    }
+
+    @Test
+    fun deletionFailure_keepsCardSerializesMutationAndSuspendsLoadMore() {
+        val mutationEntered = CountDownLatch(1)
+        val releaseMutation = CountDownLatch(1)
+        coEvery { api.getHistoryData(1) } returns Result.success(
+            page(listOf(movie(1)), current = 1, total = 2),
+        )
+        coEvery { api.getHistoryData(2) } returns Result.success(
+            page(listOf(movie(2)), current = 2, total = 2),
+        )
+        coEvery { api.clearExactMediaHistory(any()) } coAnswers {
+            mutationEntered.countDown()
+            check(releaseMutation.await(2, TimeUnit.SECONDS))
+            Result.failure(IOException("delete failure"))
+        }
+        val vm = createVM().also(HistoryVM::testOnStart)
+        val item = awaitContent(vm).items.single()
+
+        val actionThread = thread {
+            vm.onAction(HistoryAction.DeleteExactMedia(item))
+        }
+        assertTrue(mutationEntered.await(2, TimeUnit.SECONDS))
+        vm.onAction(HistoryAction.DeleteExactMedia(item))
+        vm.onAction(CommonAction.LoadMore)
+
+        assertTrue(awaitContent(vm) { item.rowKey in it.deletingKeys }.deletingKeys.isNotEmpty())
+        releaseMutation.countDown()
+        actionThread.join(2_000)
+        val restored = awaitContent(vm) { it.deletingKeys.isEmpty() }
+        assertEquals(listOf(1), restored.itemIds())
+        coVerify(exactly = 1) { api.clearExactMediaHistory(item.deletionMediaId) }
+        verify(exactly = 0) { itemDetailsRepository.invalidate(item.itemId) }
+        coVerify(exactly = 0) { api.getHistoryData(2) }
+    }
+
+    @Test
+    fun deletingFirstItemAcrossLoadedPages_focusesOldNext() {
+        verifyDeletionFocus(
+            deleteIndex = 0,
+            reconciledPageOne = listOf(movie(2), movie(3)),
+            reconciledPageTwo = listOf(movie(4)),
+            reconciledTotal = 2,
+            expectedIds = listOf(2, 3, 4),
+            expectedFocusItemId = 2,
+            expectedPageTwoCalls = 2,
+        )
+    }
+
+    @Test
+    fun deletingMiddleItemAcrossLoadedPages_focusesOldNext() {
+        verifyDeletionFocus(
+            deleteIndex = 1,
+            reconciledPageOne = listOf(movie(1), movie(3)),
+            reconciledPageTwo = listOf(movie(4)),
+            reconciledTotal = 2,
+            expectedIds = listOf(1, 3, 4),
+            expectedFocusItemId = 3,
+            expectedPageTwoCalls = 2,
+        )
+    }
+
+    @Test
+    fun deletingLastItemAcrossLoadedPages_focusesPreviousAndHonorsPageContraction() {
+        verifyDeletionFocus(
+            deleteIndex = 3,
+            reconciledPageOne = listOf(movie(1), movie(2), movie(3)),
+            reconciledPageTwo = null,
+            reconciledTotal = 1,
+            expectedIds = listOf(1, 2, 3),
+            expectedFocusItemId = 3,
+            expectedPageTwoCalls = 1,
+        )
+    }
+
+    @Test
+    fun deletingFinalVisibleItem_transitionsToEmpty() {
+        val pageOneCalls = AtomicInteger()
+        coEvery { api.getHistoryData(1) } coAnswers {
+            if (pageOneCalls.incrementAndGet() == 1) {
+                Result.success(page(listOf(movie(1))))
+            } else {
+                Result.success(page(emptyList(), total = 0))
+            }
+        }
+        coEvery { api.clearExactMediaHistory(any()) } returns Result.success(Unit)
+        val vm = createVM().also(HistoryVM::testOnStart)
+        val item = awaitContent(vm).items.single()
+
+        vm.onAction(HistoryAction.DeleteExactMedia(item))
+
+        awaitState(vm) { it == HistoryViewState.Empty }
+        assertEquals(2, pageOneCalls.get())
+    }
+
+    @Test
+    fun reconciliationFailure_keepsPostDeleteContentAndRetryUsesSameBoundedReload() {
+        val pageOneCalls = AtomicInteger()
+        val pageTwoCalls = AtomicInteger()
+        coEvery { api.getHistoryData(1) } coAnswers {
+            when (pageOneCalls.incrementAndGet()) {
+                1 -> Result.success(page(listOf(movie(1), movie(2)), total = 3))
+                2 -> Result.success(page(listOf(movie(2), movie(3)), total = 3))
+                else -> Result.success(page(listOf(movie(2), movie(3)), total = 3))
+            }
+        }
+        coEvery { api.getHistoryData(2) } coAnswers {
+            when (pageTwoCalls.incrementAndGet()) {
+                1 -> Result.success(page(listOf(movie(3), movie(4)), current = 2, total = 3))
+                2 -> Result.failure(IOException("reconcile failure"))
+                else -> Result.success(page(listOf(movie(4), movie(5)), current = 2, total = 3))
+            }
+        }
+        coEvery { api.clearExactMediaHistory(any()) } returns Result.success(Unit)
+        val vm = createVM().also(HistoryVM::testOnStart)
+        awaitContent(vm)
+        vm.onAction(CommonAction.LoadMore)
+        val loaded = awaitContent(vm) { it.itemIds() == listOf(1, 2, 3, 4) }
+        val deleted = loaded.items.first()
+
+        vm.onAction(HistoryAction.DeleteExactMedia(deleted))
+
+        val retained = awaitContent(vm) {
+            pageOneCalls.get() == 2 &&
+                pageTwoCalls.get() == 2 &&
+                it.itemIds() == listOf(2, 3, 4) &&
+                !it.isRefreshing &&
+                it.reloadErrorMessage == "reconcile failure"
+        }
+        assertEquals(2, retained.focusedItemId())
+        assertEquals("reconcile failure", retained.reloadErrorMessage)
+
+        vm.onAction(CommonAction.LoadMore)
+        vm.onAction(CommonAction.Refresh)
+        vm.onAction(HistoryAction.DeleteExactMedia(retained.items.first()))
+        Thread.sleep(40)
+        assertEquals(2, pageOneCalls.get())
+        assertEquals(2, pageTwoCalls.get())
+        coVerify(exactly = 1) { api.clearExactMediaHistory(deleted.deletionMediaId) }
+
+        vm.onAction(HistoryAction.RetryReconciliation)
+
+        val reconciled = awaitContent(vm) {
+            pageOneCalls.get() == 3 &&
+                pageTwoCalls.get() == 3 &&
+                it.itemIds() == listOf(2, 3, 4, 5) &&
+                !it.isRefreshing
+        }
+        assertEquals(2, reconciled.focusedItemId())
+        assertEquals(null, reconciled.reloadErrorMessage)
+        coVerify(exactly = 0) { api.getHistoryData(3) }
+    }
+
+    @Test
+    fun onResumeDuringPendingReconciliation_runsAfterSuccessfulRetry() {
+        val pageOneCalls = AtomicInteger()
+        val deferredRefreshEntered = CountDownLatch(1)
+        val releaseDeferredRefresh = CountDownLatch(1)
+        coEvery { api.getHistoryData(1) } coAnswers {
+            when (pageOneCalls.incrementAndGet()) {
+                1 -> Result.success(page(listOf(movie(1), movie(2))))
+                2 -> Result.failure(IOException("reconcile failure"))
+                3 -> Result.success(page(listOf(movie(2), movie(3))))
+                else -> {
+                    deferredRefreshEntered.countDown()
+                    check(releaseDeferredRefresh.await(2, TimeUnit.SECONDS))
+                    Result.success(page(listOf(movie(2), movie(4))))
+                }
+            }
+        }
+        coEvery { api.clearExactMediaHistory(any()) } returns Result.success(Unit)
+        val vm = createVM().also(HistoryVM::testOnStart)
+        val deleted = awaitContent(vm).items.first()
+        vm.onAction(HistoryAction.DeleteExactMedia(deleted))
+        awaitContent(vm) { it.reloadErrorMessage == "reconcile failure" }
+
+        vm.onAction(CommonAction.OnResume)
+        vm.onAction(HistoryAction.RetryReconciliation)
+
+        assertTrue(deferredRefreshEntered.await(2, TimeUnit.SECONDS))
+        val refreshing = awaitContent(vm) {
+            it.isRefreshing && it.itemIds() == listOf(2, 3)
+        }
+        assertEquals(listOf(2, 3), refreshing.itemIds())
+        releaseDeferredRefresh.countDown()
+
+        val final = awaitContent(vm) {
+            pageOneCalls.get() == 4 && it.itemIds() == listOf(2, 4) && !it.isRefreshing
+        }
+        assertEquals(listOf(2, 4), final.itemIds())
+    }
+
+    private fun verifyDeletionFocus(
+        deleteIndex: Int,
+        reconciledPageOne: List<History>,
+        reconciledPageTwo: List<History>?,
+        reconciledTotal: Int,
+        expectedIds: List<Int>,
+        expectedFocusItemId: Int,
+        expectedPageTwoCalls: Int,
+    ) {
+        val pageOneCalls = AtomicInteger()
+        val pageTwoCalls = AtomicInteger()
+        coEvery { api.getHistoryData(any()) } coAnswers {
+            when (firstArg<Int>()) {
+                1 -> {
+                    val items = if (pageOneCalls.incrementAndGet() == 1) {
+                        listOf(movie(1), movie(2))
+                    } else {
+                        reconciledPageOne
+                    }
+                    val total = if (pageOneCalls.get() == 1) 2 else reconciledTotal
+                    Result.success(page(items, current = 1, total = total))
+                }
+                2 -> {
+                    val call = pageTwoCalls.incrementAndGet()
+                    val items = if (call == 1) {
+                        listOf(movie(3), movie(4))
+                    } else {
+                        requireNotNull(reconciledPageTwo)
+                    }
+                    Result.success(page(items, current = 2, total = 2))
+                }
+                else -> error("Unexpected page")
+            }
+        }
+        coEvery { api.clearExactMediaHistory(any()) } returns Result.success(Unit)
+        val vm = createVM().also(HistoryVM::testOnStart)
+        awaitContent(vm)
+        vm.onAction(CommonAction.LoadMore)
+        val loaded = awaitContent(vm) { it.itemIds() == listOf(1, 2, 3, 4) }
+        val deleted = loaded.items[deleteIndex]
+
+        vm.onAction(HistoryAction.DeleteExactMedia(deleted))
+
+        val reconciled = awaitContent(vm) {
+            pageOneCalls.get() == 2 &&
+                pageTwoCalls.get() == expectedPageTwoCalls &&
+                it.itemIds() == expectedIds
+        }
+        assertEquals(expectedFocusItemId, reconciled.focusedItemId())
+        coVerify(exactly = 1) { api.clearExactMediaHistory(deleted.deletionMediaId) }
+        assertEquals(expectedPageTwoCalls, pageTwoCalls.get())
+    }
+
+    private fun createVM(): HistoryVM {
+        return HistoryVM(
+            paginator = Paginator.Store(comparator = HistoryRowComparator),
+            interactor = interactor,
+            mapper = mapper,
+            router = router,
+            errorHandler = errorHandler,
+        )
+    }
+
+    private fun startWith(response: PaginatedResponse<History>): HistoryVM {
+        coEvery { api.getHistoryData(1) } returns Result.success(response)
+        return createVM().also(HistoryVM::testOnStart)
+    }
+
+    private fun awaitContent(
+        vm: HistoryVM,
+        predicate: (HistoryViewState.Content) -> Boolean = { true },
+    ): HistoryViewState.Content {
+        return awaitState(vm) { state ->
+            state is HistoryViewState.Content && predicate(state)
+        } as HistoryViewState.Content
+    }
+
+    private fun awaitState(
+        vm: HistoryVM,
+        predicate: (HistoryViewState) -> Boolean,
+    ): HistoryViewState {
+        val deadline = System.nanoTime() + AWAIT_TIMEOUT_MILLIS * 1_000_000
+        while (System.nanoTime() < deadline) {
+            val state = vm.testStateValue
+            if (predicate(state)) return state
+            Thread.sleep(AWAIT_POLL_MILLIS)
+        }
+        fail("Timed out waiting for History state; last=${vm.testStateValue}")
+    }
+
+    private fun HistoryViewState.Content.itemIds(): List<Int> = items.map(HistoryItemUIState::itemId)
+
+    private fun HistoryViewState.Content.focusedItemId(): Int? {
+        return items.firstOrNull { it.rowKey == focusKey }?.itemId
+    }
+
+    private fun page(
+        items: List<History>,
+        current: Int = 1,
+        total: Int = 1,
+    ): PaginatedResponse<History> {
+        return PaginatedResponse(
+            items = items,
+            pagination = Pagination(
+                current = current,
+                perpage = 20,
+                total = total,
+                totalItems = items.size,
+            ),
+        )
+    }
+
+    private fun movie(
+        itemId: Int,
+        recordId: Int? = null,
+        videoId: Int = itemId * 100,
+        videoNumber: Int = itemId,
+    ): History {
+        return History(
+            recordId = recordId,
+            item = Item(id = itemId, title = "Synthetic movie $itemId", type = ItemType.MOVIE),
+            video = Video(
+                id = videoId,
+                number = videoNumber,
+                watching = WatchingInfo(time = 120, duration = 600),
+            ),
+        )
+    }
+
+}

--- a/app/src/test/kotlin/com/kino/puber/ui/feature/main/model/MainUIMapperTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/ui/feature/main/model/MainUIMapperTest.kt
@@ -1,0 +1,183 @@
+package com.kino.puber.ui.feature.main.model
+
+import com.adamglin.PhosphorIcons
+import com.adamglin.phosphoricons.Duotone
+import com.adamglin.phosphoricons.duotone.House
+import com.kino.puber.core.model.NavigationMode
+import com.kino.puber.core.ui.navigation.PuberTab
+import com.kino.puber.core.ui.navigation.Screens
+import com.kino.puber.data.preferences.NavigationPreferencesRepository
+import com.kino.puber.ui.ScreensImpl
+import com.kino.puber.ui.feature.history.component.HistoryScreen
+import com.kino.puber.ui.feature.history.model.HistoryPresentation
+import com.kino.puber.util.FakeResourceProvider
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class MainUIMapperTest {
+
+    private val mapper = MainUIMapper(
+        resources = FakeResourceProvider(),
+        screens = ScreensImpl,
+        navPrefs = mockk<NavigationPreferencesRepository>(relaxed = true),
+    )
+
+    @Test
+    fun historyTab_resolvesToHistoryScreen() {
+        val screens = mockk<Screens>()
+        every { screens.history(any()) } answers { HistoryScreen(firstArg()) }
+        val topTabsMapper = createMapper(
+            navPrefs = mockk(relaxed = true),
+            screens = screens,
+        )
+
+        val tab = topTabsMapper.buildTabContent(
+            type = TabType.History,
+            navigationMode = NavigationMode.TopTabs,
+        )
+
+        assertHistoryTab(tab, HistoryPresentation.TopTabs)
+        verify(exactly = 1) {
+            screens.history(HistoryPresentation.TopTabs)
+        }
+        assertTrue(TabType.History.enabled)
+    }
+
+    @Test
+    fun selectingHistory_opensHistoryContentInTopTabsState() {
+        val home = mainTab(TabType.Home, isSelected = true)
+        val history = mainTab(TabType.History)
+        val selected = mapper.updateSelectedTab(
+            state = MainViewState(
+                tabs = listOf(home, history),
+                selectedTab = TabType.Home,
+            ),
+            tab = history,
+        )
+
+        assertEquals(TabType.History, selected.selectedTab)
+        assertEquals(listOf(false, true), selected.tabs.map(MainTab::isSelected))
+        assertHistoryTab(
+            tab = mapper.buildTabContent(
+                type = selected.selectedTab,
+                navigationMode = NavigationMode.TopTabs,
+            ),
+            presentation = HistoryPresentation.TopTabs,
+        )
+    }
+
+    @Test
+    fun sideDrawerState_resolvesTheSameHistoryScreen() {
+        val navPrefs = mockk<NavigationPreferencesRepository>()
+        every { navPrefs.getNavigationMode() } returns NavigationMode.SideDrawer
+        every {
+            navPrefs.getVisibleTabs(NavigationMode.SideDrawer)
+        } returns listOf(TabType.Favourites, TabType.History, TabType.Movies)
+        val screens = mockk<Screens>()
+        every { screens.history(any()) } answers { HistoryScreen(firstArg()) }
+        val sideDrawerMapper = createMapper(navPrefs, screens)
+
+        val state = sideDrawerMapper.buildViewState()
+
+        assertEquals(NavigationMode.SideDrawer, state.navigationMode)
+        assertEquals(TabType.Favourites, state.selectedTab)
+        assertEquals(
+            listOf(TabType.Favourites, TabType.History, TabType.Movies),
+            state.tabs.map(MainTab::type),
+        )
+        assertEquals(listOf(true, false, false), state.tabs.map(MainTab::isSelected))
+        assertHistoryTab(
+            tab = sideDrawerMapper.buildTabContent(
+                type = TabType.History,
+                navigationMode = state.navigationMode,
+            ),
+            presentation = HistoryPresentation.SideDrawer,
+        )
+        verify(exactly = 1) {
+            screens.history(HistoryPresentation.SideDrawer)
+        }
+    }
+
+    @Test
+    fun historyRefresh_keepsLogicalTabKeyAndAdvancesScreenScopeGeneration() {
+        val initial = mapper.buildTabContent(
+            type = TabType.History,
+            navigationMode = NavigationMode.TopTabs,
+        )
+        val sameInstance = mapper.buildTabContent(
+            type = TabType.History,
+            navigationMode = NavigationMode.TopTabs,
+        )
+        val refreshed = mapper.buildTabContent(
+            type = TabType.History,
+            navigationMode = NavigationMode.TopTabs,
+            refreshVersion = 2,
+        )
+
+        assertEquals(initial.key, sameInstance.key)
+        assertEquals(
+            "Tab:${HistoryScreen(HistoryPresentation.TopTabs).key}",
+            initial.key,
+        )
+        assertEquals(initial.key, refreshed.key)
+        assertNotEquals(initial.contentInstanceKey, refreshed.contentInstanceKey)
+        assertEquals(
+            "Tab:${HistoryScreen(HistoryPresentation.TopTabs).key}:refresh_2",
+            refreshed.contentInstanceKey,
+        )
+        assertEquals(TabType.History, refreshed.tag)
+    }
+
+    @Test
+    fun historyPresentationsUseDistinctTabLifecycleKeys() {
+        val topTabs = mapper.buildTabContent(
+            type = TabType.History,
+            navigationMode = NavigationMode.TopTabs,
+        )
+        val sideDrawer = mapper.buildTabContent(
+            type = TabType.History,
+            navigationMode = NavigationMode.SideDrawer,
+        )
+
+        assertEquals("Tab:HistoryScreen_TopTabs", topTabs.key)
+        assertEquals("Tab:HistoryScreen_SideDrawer", sideDrawer.key)
+        assertNotEquals(topTabs.key, sideDrawer.key)
+        assertNotEquals(topTabs.contentInstanceKey, sideDrawer.contentInstanceKey)
+    }
+
+    private fun assertHistoryTab(
+        tab: PuberTab,
+        presentation: HistoryPresentation,
+    ) {
+        assertEquals("Tab:${HistoryScreen(presentation).key}", tab.key)
+        assertEquals(TabType.History, tab.tag)
+    }
+
+    private fun mainTab(
+        type: TabType,
+        isSelected: Boolean = false,
+    ): MainTab {
+        return MainTab(
+            type = type,
+            label = type.name,
+            icon = PhosphorIcons.Duotone.House,
+            isSelected = isSelected,
+        )
+    }
+
+    private fun createMapper(
+        navPrefs: NavigationPreferencesRepository,
+        screens: Screens = ScreensImpl,
+    ): MainUIMapper {
+        return MainUIMapper(
+            resources = FakeResourceProvider(),
+            screens = screens,
+            navPrefs = navPrefs,
+        )
+    }
+}

--- a/app/src/test/kotlin/com/kino/puber/ui/feature/main/vm/MainVMRefreshLifecycleTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/ui/feature/main/vm/MainVMRefreshLifecycleTest.kt
@@ -1,0 +1,90 @@
+package com.kino.puber.ui.feature.main.vm
+
+import com.adamglin.PhosphorIcons
+import com.adamglin.phosphoricons.Duotone
+import com.adamglin.phosphoricons.duotone.House
+import com.kino.puber.core.ui.navigation.AppRouter
+import com.kino.puber.core.ui.navigation.PuberScreen
+import com.kino.puber.core.ui.navigation.PuberTab
+import com.kino.puber.core.ui.navigation.Screens
+import com.kino.puber.core.ui.navigation.TabRouter
+import com.kino.puber.ui.feature.main.model.MainAction
+import com.kino.puber.ui.feature.main.model.MainTab
+import com.kino.puber.ui.feature.main.model.MainUIMapper
+import com.kino.puber.ui.feature.main.model.TabType
+import com.kino.puber.util.MainDispatcherExtension
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+internal class MainVMRefreshLifecycleTest {
+
+    companion object {
+        private val dispatcher = StandardTestDispatcher()
+
+        @JvmField
+        @RegisterExtension
+        val mainDispatcher = MainDispatcherExtension(dispatcher)
+    }
+
+    @Test
+    fun rapidRefreshKeepsOneLogicalTabAndAdvancesItsContentGeneration() = runTest(dispatcher) {
+        val screens = mockk<Screens>(relaxed = true)
+        val router = mockk<AppRouter>(relaxed = true)
+        val mapper = mockk<MainUIMapper>()
+        val tabRouter = mockk<TabRouter>(relaxed = true)
+        val openedTabs = mutableListOf<PuberTab>()
+        val historyScreen = mockk<PuberScreen>()
+        every { historyScreen.key } returns "HistoryScreen"
+        every { router.screens } returns screens
+        every { tabRouter.openTab(capture(openedTabs)) } returns Unit
+        every {
+            mapper.buildTabContent(
+                type = TabType.History,
+                navigationMode = any(),
+                refreshVersion = any(),
+            )
+        } answers {
+            val version = thirdArg<Int>()
+            PuberTab(
+                screen = historyScreen,
+                tag = TabType.History,
+                instanceKey = version.takeIf { it > 0 }?.let { "refresh_$it" }.orEmpty(),
+            )
+        }
+        every { mapper.updateSelectedTab(any(), any()) } answers { firstArg() }
+        val vm = MainVM(router, mapper, tabRouter)
+        val historyTab = MainTab(
+            type = TabType.History,
+            label = "History",
+            icon = PhosphorIcons.Duotone.House,
+        )
+
+        vm.onAction(MainAction.RefreshTab(historyTab))
+        vm.onAction(MainAction.RefreshTab(historyTab))
+
+        assertEquals(
+            listOf("Tab:HistoryScreen", "Tab:HistoryScreen"),
+            openedTabs.map(PuberTab::key),
+        )
+        assertEquals(
+            listOf("Tab:HistoryScreen:refresh_1", "Tab:HistoryScreen:refresh_2"),
+            openedTabs.map(PuberTab::contentInstanceKey),
+        )
+        assertSame(
+            vm.tabAppRouterHolder.getOrCreate(
+                key = openedTabs.first().key,
+                initialContentInstanceKey = openedTabs.first().contentInstanceKey,
+            ),
+            vm.tabAppRouterHolder.getOrCreate(
+                key = openedTabs.last().key,
+                initialContentInstanceKey = openedTabs.last().contentInstanceKey,
+            ),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/kino/puber/ui/feature/player/vm/PlayerStartModeTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/ui/feature/player/vm/PlayerStartModeTest.kt
@@ -1,0 +1,192 @@
+package com.kino.puber.ui.feature.player.vm
+
+import com.kino.puber.core.error.ErrorHandler
+import com.kino.puber.core.ui.navigation.AppRouter
+import com.kino.puber.data.api.models.Item
+import com.kino.puber.data.api.models.ItemType
+import com.kino.puber.domain.interactor.player.PlayerInteractor
+import com.kino.puber.domain.interactor.player.ResolvedMedia
+import com.kino.puber.domain.interactor.player.SkipSegmentInteractor
+import com.kino.puber.domain.model.SubtitleSize
+import com.kino.puber.ui.ScreensImpl
+import com.kino.puber.ui.feature.player.model.BufferPreset
+import com.kino.puber.ui.feature.player.model.PlayerContentState
+import com.kino.puber.ui.feature.player.model.PlayerScreenParams
+import com.kino.puber.ui.feature.player.model.PlayerStartMode
+import com.kino.puber.ui.feature.player.model.PlayerUIMapper
+import com.kino.puber.ui.feature.player.model.ResumeDialogState
+import com.kino.puber.util.FakeResourceProvider
+import com.kino.puber.util.MainDispatcherExtension
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+internal class PlayerStartModeTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val mainDispatcher = MainDispatcherExtension()
+    }
+
+    private lateinit var router: AppRouter
+    private lateinit var errorHandler: ErrorHandler
+    private lateinit var interactor: PlayerInteractor
+    private lateinit var skipSegmentInteractor: SkipSegmentInteractor
+    private lateinit var mapper: PlayerUIMapper
+    private lateinit var contentStateFactory: ContentStateFactory
+    private lateinit var playbackController: PlaybackControl
+    private lateinit var contentState: PlayerContentState
+
+    private val item = Item(
+        id = 42,
+        title = "Synthetic series",
+        type = ItemType.SERIAL,
+    )
+    private val savedMedia = ResolvedMedia(
+        files = emptyList(),
+        audios = emptyList(),
+        subtitles = emptyList(),
+        watchingTime = 120,
+        duration = 2_400,
+        videoNumber = 1,
+        episodeId = 101,
+        episodeTitle = "Pilot",
+        isCurrentMediaWatched = false,
+        isSeries = true,
+        hasNext = false,
+        hasPrevious = false,
+        seasonNumber = 1,
+        episodeNumber = 1,
+    )
+
+    @BeforeEach
+    fun setUp() {
+        router = mockk(relaxed = true)
+        errorHandler = mockk { every { proceed(any()) } returns { } }
+        interactor = mockk(relaxUnitFun = true)
+        skipSegmentInteractor = mockk()
+        mapper = mockk(relaxUnitFun = true)
+        contentStateFactory = mockk()
+        playbackController = mockk(relaxUnitFun = true) {
+            every { isPlaying } returns true
+            every { currentPosition } returns 0L
+            every { duration } returns 2_400_000L
+            every { bufferedPosition } returns 0L
+        }
+        contentState = mockk(relaxed = true)
+
+        coEvery { interactor.getItemDetails(item.id) } returns item
+        every { interactor.resolveMedia(item, 1, 1, null) } returns savedMedia
+        every {
+            contentStateFactory.build(any(), any(), any(), any(), any(), any())
+        } returns contentState
+        every { interactor.selectStreamUrl(any(), any()) } returns "https://test/v.m3u8"
+        every { interactor.isDebugOverlayEnabled() } returns false
+        every { interactor.getSubtitleSize() } returns SubtitleSize.MEDIUM
+        every { interactor.getBufferPreset() } returns BufferPreset.AUTO
+        every { interactor.isFastDnsEnabled() } returns true
+        coEvery { skipSegmentInteractor.loadSegments(any(), any(), any()) } returns emptyList()
+        every { skipSegmentInteractor.findCreditsSegment(any()) } returns null
+        every { mapper.formatTime(any()) } returns "2:00"
+        every { mapper.buildSubtitle(any(), any(), any(), any()) } returns "S1E1"
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun explicitStartOverSuppressesSavedProgressResumeAndPreparesAtZero() {
+        createVM(PlayerStartMode.StartFromBeginning).testOnStart()
+
+        verify {
+            contentStateFactory.build(
+                item = item,
+                resolved = savedMedia,
+                resumeDialog = null,
+                subtitleSize = SubtitleSize.MEDIUM,
+                savedBufferPreset = BufferPreset.AUTO,
+                fastDnsEnabled = true,
+            )
+        }
+        verify {
+            playbackController.prepare(
+                streamUrl = "https://test/v.m3u8",
+                subtitles = emptyList(),
+                startPosition = 0L,
+                bufferPreset = BufferPreset.AUTO,
+                fastDns = false,
+            )
+        }
+        verify(exactly = 0) { mapper.formatTime(any()) }
+    }
+
+    @Test
+    fun normalStartModeKeepsSavedProgressResumeDialog() {
+        createVM(PlayerStartMode.ResumeIfAvailable).testOnStart()
+
+        verify {
+            contentStateFactory.build(
+                item = item,
+                resolved = savedMedia,
+                resumeDialog = ResumeDialogState(
+                    savedPosition = 120_000L,
+                    formattedTime = "2:00",
+                    episodeInfo = "S1E1",
+                ),
+                subtitleSize = SubtitleSize.MEDIUM,
+                savedBufferPreset = BufferPreset.AUTO,
+                fastDnsEnabled = true,
+            )
+        }
+        verify {
+            playbackController.prepare(
+                streamUrl = "https://test/v.m3u8",
+                subtitles = emptyList(),
+                startPosition = null,
+                bufferPreset = BufferPreset.AUTO,
+                fastDns = false,
+            )
+        }
+    }
+
+    @Test
+    fun playerScreenKeyDistinguishesExplicitStartOver() {
+        assertEquals(
+            "PlayerScreen_42_v7_startOver",
+            ScreensImpl.player(
+                itemId = 42,
+                videoNumber = 7,
+                startMode = PlayerStartMode.StartFromBeginning,
+            ).key,
+        )
+    }
+
+    private fun createVM(startMode: PlayerStartMode): PlayerVM {
+        return PlayerVM(
+            router = router,
+            errorHandler = errorHandler,
+            params = PlayerScreenParams(
+                itemId = item.id,
+                seasonNumber = 1,
+                episodeNumber = 1,
+                startMode = startMode,
+            ),
+            mapper = mapper,
+            interactor = interactor,
+            skipSegmentInteractor = skipSegmentInteractor,
+            contentStateFactory = contentStateFactory,
+            playbackController = playbackController,
+            resources = FakeResourceProvider(),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/kino/puber/ui/feature/player/vm/PlayerVMMutationAndResultTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/ui/feature/player/vm/PlayerVMMutationAndResultTest.kt
@@ -6,6 +6,7 @@ import com.kino.puber.core.ui.uikit.component.moviesList.VideoGridUIState
 import com.kino.puber.core.ui.uikit.component.moviesList.VideoItemUIState
 import com.kino.puber.data.api.models.ItemType
 import com.kino.puber.data.api.models.SkipSegmentType
+import com.kino.puber.data.api.models.Video
 import com.kino.puber.domain.interactor.player.WatchedDetailsRefreshException
 import com.kino.puber.ui.feature.player.model.PlayerAction
 import com.kino.puber.ui.feature.player.model.SkipSegmentUIState
@@ -33,9 +34,16 @@ internal class PlayerVMMutationAndResultTest : PlayerVMTestFixture() {
     // region Manual mark watched
 
     @Test
-    fun markCurrentWatched_movieCallsInteractorWithoutEpisodeAndUpdatesState() {
-        val updated = testItem.copy(type = ItemType.MOVIE, watched = 1)
-        coEvery { interactor.resolveMedia(any(), any(), any()) } returns testResolvedMedia.copy(
+    fun markCurrentWatched_moviePassesExactVideoAndUpdatesState() {
+        val updated = testItem.copy(
+            type = ItemType.MOVIE,
+            videos = listOf(
+                Video(id = 700, number = 7, watched = 1),
+                Video(id = 800, number = 8, watched = 0),
+            ),
+        )
+        every { interactor.resolveMedia(any(), any(), any(), any()) } returns testResolvedMedia.copy(
+            videoNumber = 7,
             isSeries = false,
             hasNext = false,
             hasPrevious = false,
@@ -50,7 +58,7 @@ internal class PlayerVMMutationAndResultTest : PlayerVMTestFixture() {
             hasPreviousEpisode = false,
         )
         coEvery {
-            interactor.markCurrentAsWatched(id = 42, season = null, episode = null)
+            interactor.markCurrentAsWatched(id = 42, season = null, videoNumber = 7)
         } returns updated
         val vm = startedVM()
 
@@ -58,7 +66,87 @@ internal class PlayerVMMutationAndResultTest : PlayerVMTestFixture() {
 
         assertTrue(contentState(vm).isCurrentMediaWatched)
         coVerify(exactly = 1) {
-            interactor.markCurrentAsWatched(id = 42, season = null, episode = null)
+            interactor.markCurrentAsWatched(id = 42, season = null, videoNumber = 7)
+        }
+    }
+
+    @Test
+    fun markCurrentWatched_movieSynchronizesOnlySelectedVideoStatus() {
+        val updated = testItem.copy(
+            type = ItemType.MOVIE,
+            watched = 1,
+            videos = listOf(
+                Video(id = 700, number = 7, watched = 0),
+                Video(id = 800, number = 8, watched = 1),
+            ),
+        )
+        every { interactor.resolveMedia(any(), any(), any(), any()) } returns testResolvedMedia.copy(
+            videoNumber = 7,
+            isSeries = false,
+            hasNext = false,
+            hasPrevious = false,
+            seasonNumber = null,
+            episodeNumber = null,
+            episodeId = null,
+            episodeTitle = null,
+        )
+        coEvery { contentStateFactory.build(any(), any(), any(), any(), any(), any()) } returns testContentState.copy(
+            isMovie = true,
+            hasNextEpisode = false,
+            hasPreviousEpisode = false,
+        )
+        coEvery {
+            interactor.markCurrentAsWatched(id = 42, season = null, videoNumber = 7)
+        } returns updated
+        val vm = startedVM()
+
+        vm.onAction(PlayerAction.MarkCurrentWatched)
+
+        assertFalse(contentState(vm).isCurrentMediaWatched)
+        coVerify(exactly = 1) {
+            interactor.markCurrentAsWatched(id = 42, season = null, videoNumber = 7)
+        }
+    }
+
+    @Test
+    fun markCurrentWatched_movieRefreshFailureSynchronizesSelectedVideoLocally() {
+        val movie = testItem.copy(
+            type = ItemType.MOVIE,
+            watched = 0,
+            videos = listOf(
+                Video(id = 700, number = 7, watched = 0),
+                Video(id = 800, number = 8, watched = 0),
+            ),
+        )
+        coEvery { interactor.getItemDetails(42) } returns movie
+        every { interactor.resolveMedia(any(), any(), any(), any()) } returns testResolvedMedia.copy(
+            videoNumber = 7,
+            isSeries = false,
+            hasNext = false,
+            hasPrevious = false,
+            seasonNumber = null,
+            episodeNumber = null,
+            episodeId = null,
+            episodeTitle = null,
+        )
+        coEvery { contentStateFactory.build(any(), any(), any(), any(), any(), any()) } returns testContentState.copy(
+            isMovie = true,
+            hasNextEpisode = false,
+            hasPreviousEpisode = false,
+        )
+        val refreshFailure = IllegalStateException("refresh failed")
+        coEvery {
+            interactor.markCurrentAsWatched(id = 42, season = null, videoNumber = 7)
+        } throws WatchedDetailsRefreshException(refreshFailure)
+        every { errorHandler.map(refreshFailure) } returns ErrorEntity(message = "Refresh failed", code = "test")
+        val vm = startedVM()
+
+        vm.onAction(PlayerAction.MarkCurrentWatched)
+        vm.onAction(PlayerAction.MarkCurrentWatched)
+
+        assertTrue(contentState(vm).isCurrentMediaWatched)
+        coVerify(exactly = 1) {
+            interactor.markCurrentAsWatched(id = 42, season = null, videoNumber = 7)
         }
     }
 
@@ -66,7 +154,7 @@ internal class PlayerVMMutationAndResultTest : PlayerVMTestFixture() {
     fun markCurrentWatched_episodePassesSeasonAndEpisodeAndUpdatesEpisodes() {
         val updated = testItem.copy(watched = 1)
         val updatedEpisodes = VideoGridUIState(emptyList())
-        coEvery { interactor.markCurrentAsWatched(id = 42, season = 1, episode = 1) } returns updated
+        coEvery { interactor.markCurrentAsWatched(id = 42, season = 1, videoNumber = 1) } returns updated
         every { mapper.mapEpisodes(updated) } returns updatedEpisodes
         val vm = startedVM()
 
@@ -74,7 +162,9 @@ internal class PlayerVMMutationAndResultTest : PlayerVMTestFixture() {
 
         assertTrue(contentState(vm).isCurrentMediaWatched)
         assertEquals(updatedEpisodes, contentState(vm).episodes)
-        coVerify(exactly = 1) { interactor.markCurrentAsWatched(id = 42, season = 1, episode = 1) }
+        coVerify(exactly = 1) {
+            interactor.markCurrentAsWatched(id = 42, season = 1, videoNumber = 1)
+        }
     }
 
     @Test
@@ -104,7 +194,7 @@ internal class PlayerVMMutationAndResultTest : PlayerVMTestFixture() {
     @Test
     fun markCurrentWatched_failurePreservesStateAndMapsError() {
         val failure = IllegalStateException("Failed")
-        coEvery { interactor.markCurrentAsWatched(id = 42, season = 1, episode = 1) } throws failure
+        coEvery { interactor.markCurrentAsWatched(id = 42, season = 1, videoNumber = 1) } throws failure
         every { errorHandler.map(failure) } returns ErrorEntity(message = "Mapped", code = "test")
         val vm = startedVM()
 
@@ -138,7 +228,9 @@ internal class PlayerVMMutationAndResultTest : PlayerVMTestFixture() {
         vm.onAction(PlayerAction.MarkCurrentWatched)
 
         assertTrue(contentState(vm).isCurrentMediaWatched)
-        coVerify(exactly = 1) { interactor.markCurrentAsWatched(id = 42, season = 1, episode = 1) }
+        coVerify(exactly = 1) {
+            interactor.markCurrentAsWatched(id = 42, season = 1, videoNumber = 1)
+        }
     }
 
     @Test
@@ -190,7 +282,7 @@ internal class PlayerVMMutationAndResultTest : PlayerVMTestFixture() {
     @Test
     fun markCurrentWatched_staleCompletionDoesNotUpdateNextEpisode() {
         val releaseMark = CompletableDeferred<Unit>()
-        coEvery { interactor.resolveMedia(any(), any(), any()) } returns testResolvedMedia andThen
+        every { interactor.resolveMedia(any(), any(), any(), any()) } returns testResolvedMedia andThen
             testResolvedMedia.copy(
                 videoNumber = 2,
                 episodeId = 102,

--- a/app/src/test/kotlin/com/kino/puber/ui/feature/player/vm/PlayerVMTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/ui/feature/player/vm/PlayerVMTest.kt
@@ -1,18 +1,26 @@
 package com.kino.puber.ui.feature.player.vm
 
+import com.kino.puber.R
 import com.kino.puber.core.content.ContentChangeSet
 import com.kino.puber.core.content.ContentChangeType
+import com.kino.puber.core.error.DefaultErrorHandler
 import com.kino.puber.core.ui.navigation.RESULT_CONTENT_CHANGED
+import com.kino.puber.data.api.models.Item
+import com.kino.puber.data.api.models.ItemType
 import com.kino.puber.data.api.models.SkipSegment
 import com.kino.puber.data.api.models.SkipSegmentType
 import com.kino.puber.domain.model.SubtitleSize
+import com.kino.puber.ui.ScreensImpl
 import com.kino.puber.ui.feature.player.model.ActivePanel
 import com.kino.puber.ui.feature.player.model.AudioTrackUIState
 import com.kino.puber.ui.feature.player.model.PlayerAction
+import com.kino.puber.ui.feature.player.model.PlayerScreenParams
 import com.kino.puber.ui.feature.player.model.PlayerViewState
 import com.kino.puber.ui.feature.player.model.ResumeDialogState
 import com.kino.puber.ui.feature.player.model.SkipSegmentUIState
+import com.kino.puber.util.FakeResourceProvider
 import com.kino.puber.util.MainDispatcherExtension
+import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -20,12 +28,14 @@ import io.mockk.verify
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
+import timber.log.Timber
 
 /**
  * PlayerVM tests.
@@ -63,7 +73,135 @@ internal class PlayerVMTest : PlayerVMTestFixture() {
         verify { playbackController.prepare("https://test/v.m3u8", any(), any()) }
     }
 
+    @Test
+    fun onStart_urlBearingItemDetailsFailurePreservesErrorAndSanitizesTimberPipeline() {
+        val privateItemId = 424_242
+        val privateUrl = "https://api.example.test/v1/items/$privateItemId"
+        val timeout = HttpRequestTimeoutException(privateUrl, 5_000L, null)
+        val failure = IllegalStateException("Player startup failed", timeout)
+        val logTree = CollectingLogTree()
+        coEvery { interactor.getItemDetails(privateItemId) } throws failure
+
+        Timber.plant(logTree)
+        val vm = try {
+            createVM(
+                playerParams = PlayerScreenParams(itemId = privateItemId, videoNumber = 1),
+                playerErrorHandler = DefaultErrorHandler(FakeResourceProvider()),
+            ).also(PlayerVM::testOnStart)
+        } finally {
+            Timber.uproot(logTree)
+        }
+
+        assertEquals(
+            "string_${R.string.error_generic}",
+            (vm.testStateValue as PlayerViewState.Error).message,
+        )
+        val output = logTree.output()
+        assertFalse(output.contains(privateItemId.toString()), output)
+        assertFalse(output.contains(privateUrl), output)
+        assertTrue(output.contains("/items/<redacted>"), output)
+        assertEquals(1, logTree.entryCount)
+        verify(exactly = 0) { contentStateFactory.build(any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { playbackController.prepare(any(), any(), any()) }
+    }
+
+    @Test
+    fun onStart_passesExplicitMovieVideoNumberToResolver() {
+        val movieParams = PlayerScreenParams(itemId = 42, videoNumber = 7)
+        val movieItem = Item(id = 42, title = "Movie", type = ItemType.MOVIE)
+        val movieMedia = testResolvedMedia.copy(
+            videoNumber = 7,
+            episodeId = null,
+            episodeTitle = null,
+            isSeries = false,
+            hasNext = false,
+            hasPrevious = false,
+            seasonNumber = null,
+            episodeNumber = null,
+        )
+        coEvery { interactor.getItemDetails(42) } returns movieItem
+        every { interactor.resolveMedia(movieItem, null, null, 7) } returns movieMedia
+
+        createVM(movieParams).testOnStart()
+
+        verify {
+            interactor.resolveMedia(
+                item = movieItem,
+                seasonNumber = null,
+                episodeNumber = null,
+                videoNumber = 7,
+            )
+        }
+    }
+
+    @Test
+    fun onStart_missingExplicitMovieVideo_showsPlaybackErrorWithoutInitialization() {
+        val movieParams = PlayerScreenParams(itemId = 42, videoNumber = 7)
+        val movieItem = Item(id = 42, title = "Movie", type = ItemType.MOVIE)
+        val missingMedia = testResolvedMedia.copy(
+            files = null,
+            audios = null,
+            subtitles = null,
+            videoNumber = null,
+            episodeId = null,
+            episodeTitle = null,
+            isSeries = false,
+            hasNext = false,
+            hasPrevious = false,
+            seasonNumber = null,
+            episodeNumber = null,
+        )
+        coEvery { interactor.getItemDetails(42) } returns movieItem
+        every { interactor.resolveMedia(movieItem, null, null, 7) } returns missingMedia
+
+        val vm = createVM(movieParams).also { it.testOnStart() }
+
+        assertEquals(
+            "string_${R.string.player_error_playback}",
+            (vm.testStateValue as PlayerViewState.Error).message,
+        )
+        verify(exactly = 0) { contentStateFactory.build(any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { playbackController.prepare(any(), any(), any()) }
+    }
+
+    @Test
+    fun playerScreenKey_includesExplicitMovieVideoNumber() {
+        assertEquals(
+            "PlayerScreen_42_v7",
+            ScreensImpl.player(itemId = 42, videoNumber = 7).key,
+        )
+    }
+
+    @Test
+    fun playerScreenKey_withoutVideoNumber_preservesExistingKey() {
+        assertEquals(
+            "PlayerScreen_42_s1_e2",
+            ScreensImpl.player(itemId = 42, seasonNumber = 1, episodeNumber = 2).key,
+        )
+    }
+
     // endregion
+
+    private class CollectingLogTree : Timber.Tree() {
+        private val entries = mutableListOf<Pair<String, Throwable?>>()
+        val entryCount: Int
+            get() = entries.size
+
+        override fun log(
+            priority: Int,
+            tag: String?,
+            message: String,
+            t: Throwable?,
+        ) {
+            entries += message to t
+        }
+
+        fun output(): String {
+            return entries.joinToString("\n") { (message, throwable) ->
+                listOfNotNull(message, throwable?.stackTraceToString()).joinToString("\n")
+            }
+        }
+    }
 
     // region Bug 2: Audio track restore by language
 
@@ -272,6 +410,35 @@ internal class PlayerVMTest : PlayerVMTestFixture() {
         verifyEmptyContentChangeResult()
     }
 
+    @Test
+    fun failedFinalProgressSave_emitsIdentityFreeDiagnostic() {
+        val privateItemId = 424_242
+        val privateTitle = "Private watched title"
+        val privateTime = "private-watching-time"
+        val failure = IllegalStateException(
+            "Failed to save $privateTitle for item=$privateItemId at time=$privateTime",
+        )
+        coEvery { interactor.saveWatchingTime(42, 1, 0, 1) } throws failure
+        val logTree = CollectingLogTree()
+        val vm = startedVM()
+
+        Timber.plant(logTree)
+        try {
+            vm.onAction(PlayerAction.OnBackPressed)
+        } finally {
+            Timber.uproot(logTree)
+        }
+
+        val output = logTree.output()
+        assertEquals(1, logTree.entryCount)
+        assertTrue(output.contains(PROGRESS_SAVE_FAILURE_DIAGNOSTIC), output)
+        assertFalse(output.contains(privateItemId.toString()), output)
+        assertFalse(output.contains(privateTitle), output)
+        assertFalse(output.contains(privateTime), output)
+        assertFalse(output.contains(failure.message.orEmpty()), output)
+        verifyEmptyContentChangeResult()
+    }
+
     // endregion
 
     // region Episode switching
@@ -280,6 +447,23 @@ internal class PlayerVMTest : PlayerVMTestFixture() {
     fun switchEpisode_releasesPlayer() {
         startedVM().onAction(PlayerAction.SelectEpisode(1, 2))
         verify { playbackController.release() }
+    }
+
+    @Test
+    fun switchEpisode_doesNotReuseInitialMovieVideoNumber() {
+        val vm = createVM(PlayerScreenParams(itemId = 42, seasonNumber = 1, episodeNumber = 1, videoNumber = 7))
+            .also { it.testOnStart() }
+
+        vm.onAction(PlayerAction.SelectEpisode(1, 2))
+
+        verify {
+            interactor.resolveMedia(
+                item = testItem,
+                seasonNumber = 1,
+                episodeNumber = 2,
+                videoNumber = null,
+            )
+        }
     }
 
     @Test
@@ -339,7 +523,7 @@ internal class PlayerVMTest : PlayerVMTestFixture() {
             episodeId = 102,
             episodeNumber = 2,
         )
-        coEvery { interactor.resolveMedia(any(), any(), any()) } returns nextEpisode
+        every { interactor.resolveMedia(any(), any(), any(), any()) } returns nextEpisode
         coEvery { contentStateFactory.build(any(), any(), any(), any(), any(), any()) } returns
             testContentState.copy(currentEpisodeId = 102)
         val vm = startedVM()
@@ -369,7 +553,7 @@ internal class PlayerVMTest : PlayerVMTestFixture() {
                 emptyList()
             }
         }
-        coEvery { interactor.resolveMedia(any(), any(), any()) } returns testResolvedMedia andThen
+        every { interactor.resolveMedia(any(), any(), any(), any()) } returns testResolvedMedia andThen
             testResolvedMedia.copy(videoNumber = 2, episodeId = 102, episodeNumber = 2)
         val vm = startedVM()
 

--- a/app/src/test/kotlin/com/kino/puber/ui/feature/player/vm/PlayerVMTestFixture.kt
+++ b/app/src/test/kotlin/com/kino/puber/ui/feature/player/vm/PlayerVMTestFixture.kt
@@ -63,7 +63,7 @@ internal abstract class PlayerVMTestFixture {
         }
 
         coEvery { interactor.getItemDetails(any()) } returns testItem
-        coEvery { interactor.resolveMedia(any(), any(), any()) } returns testResolvedMedia
+        every { interactor.resolveMedia(any(), any(), any(), any()) } returns testResolvedMedia
         coEvery { contentStateFactory.build(any(), any(), any(), any(), any(), any()) } returns testContentState
         coEvery { interactor.markCurrentAsWatched(any(), any(), any()) } returns
             testItem.withCurrentEpisodeWatched(true)
@@ -99,10 +99,13 @@ internal abstract class PlayerVMTestFixture {
         clearAllMocks()
     }
 
-    protected fun createVM() = PlayerVM(
+    protected fun createVM(
+        playerParams: PlayerScreenParams = params,
+        playerErrorHandler: ErrorHandler = errorHandler,
+    ) = PlayerVM(
         router = router,
-        errorHandler = errorHandler,
-        params = params,
+        errorHandler = playerErrorHandler,
+        params = playerParams,
         mapper = mapper,
         interactor = interactor,
         resources = FakeResourceProvider(),

--- a/app/src/test/resources/history/history-page-movie.json
+++ b/app/src/test/resources/history/history-page-movie.json
@@ -1,0 +1,37 @@
+{
+  "history": [
+    {
+      "counter": 4,
+      "first_seen": 4102444800,
+      "item": {
+        "id": 72001,
+        "title": "Synthetic Movie Alpha",
+        "type": "movie",
+        "posters": {
+          "small": "https://assets.example.test/movie-small.jpg",
+          "wide": "https://assets.example.test/movie-wide.jpg"
+        },
+        "synthetic_item_field": "ignored"
+      },
+      "last_seen": 4102444810,
+      "media": {
+        "id": 73001,
+        "number": 2,
+        "snumber": 0,
+        "duration": 5400,
+        "synthetic_media_field": "ignored"
+      },
+      "time": 1200,
+      "deleted": false,
+      "synthetic_history_field": "ignored"
+    }
+  ],
+  "pagination": {
+    "current": 1,
+    "perpage": 20,
+    "total": 1,
+    "total_items": 1,
+    "synthetic_pagination_field": "ignored"
+  },
+  "synthetic_envelope_field": "ignored"
+}

--- a/app/src/test/resources/history/history-page-series.json
+++ b/app/src/test/resources/history/history-page-series.json
@@ -1,0 +1,37 @@
+{
+  "history": [
+    {
+      "counter": 9,
+      "first_seen": 4105296000,
+      "item": {
+        "id": 82001,
+        "title": "Synthetic Series Beta",
+        "type": "serial",
+        "posters": {
+          "small": "https://assets.example.test/series-small.jpg",
+          "wide": "https://assets.example.test/series-wide.jpg"
+        },
+        "synthetic_item_field": "ignored"
+      },
+      "last_seen": 4105296010,
+      "media": {
+        "id": 83001,
+        "number": 9,
+        "snumber": 4,
+        "duration": 2700,
+        "synthetic_media_field": "ignored"
+      },
+      "time": 2700,
+      "deleted": false,
+      "synthetic_history_field": "ignored"
+    }
+  ],
+  "pagination": {
+    "current": 1,
+    "perpage": 20,
+    "total": 1,
+    "total_items": 1,
+    "synthetic_pagination_field": "ignored"
+  },
+  "synthetic_envelope_field": "ignored"
+}

--- a/app/src/test/resources/history/history-page-server-contract.json
+++ b/app/src/test/resources/history/history-page-server-contract.json
@@ -1,0 +1,32 @@
+{
+  "history": [
+    {
+      "counter": 1,
+      "first_seen": 411111100,
+      "item": {
+        "id": 92001,
+        "title": "Synthetic Server Contract Movie",
+        "type": "movie",
+        "posters": {
+          "small": "https://assets.example.test/server-contract-small.jpg",
+          "wide": "https://assets.example.test/server-contract-wide.jpg"
+        }
+      },
+      "last_seen": 411111111,
+      "media": {
+        "id": 93001,
+        "number": 2,
+        "snumber": 0,
+        "duration": 4800
+      },
+      "time": 1200,
+      "deleted": false
+    }
+  ],
+  "pagination": {
+    "current": 1,
+    "perpage": 20,
+    "total": 1,
+    "total_items": 1
+  }
+}


### PR DESCRIPTION
## Summary

- deliver the server-backed Viewing History feature preserved from PUB-26
- keep TopTabs focus ownership and contain D-pad RIGHT at complete and trailing grid rows
- route card selection to Details, including exact episode-panel targeting for series entries
- preserve explicit context-menu playback and exact movie/episode routing coverage
- keep the final Detekt-only production extractions behavior-preserving and bounded to PUB-31 regressions

## Compliance Review

Passed. Final Compliance Review found no violations in the reviewed PUB-31 scope. Authority files and workflow
procedures are unchanged, both planned coverage slices are complete, the three production extractions are within the
July 26 bounded authorization, and no unresolved blocker or workflow obligation remains before delivery.

## Verification

- joined deterministic verification — passed all 112 focused tests
- `./tools/agentw :app:compileDevDebugKotlin` — passed
- focused instrumentation — passed 35/35
- differential Detekt — pinned `origin/master` baseline 127 findings, final candidate 118 findings, zero new or
  worsened findings
- restored task-scoped metrics: `TopTabMainContent` 119 → 116, `KinoPubApiClient` 669 → 651, and `PlayerVM`
  1212 → 1144
- Standards Review — passed under the approved differential policy
- Specification Review and verification Gate — passed in the canonical review context
- focused runtime Smoke — passed using authorized retained evidence: S2E5 opened Details, the episode panel opened,
  exact S2E5 was focused, Player did not open, and scoped health reported zero fatal/crash/ANR/other errors
- all three runtime evidence audits — passed

## Intentionally skipped live check

Live context-menu Play was not selected because it could mutate authenticated History/account state. Exact routing and
invalidation-before-navigation ordering are covered by deterministic tests. GitHub's Detekt CI job is expected to skip
under the repository workflow; the machine-readable differential Detekt verification above is the authoritative result.
