### PR TITLE
Fix DPAD Down navigation from Search input

### DIFF
--- a/app/src/androidTest/kotlin/com/kino/puber/ui/feature/search/content/SearchScreenContentTest.kt
+++ b/app/src/androidTest/kotlin/com/kino/puber/ui/feature/search/content/SearchScreenContentTest.kt
@@ -1,0 +1,59 @@
+package com.kino.puber.ui.feature.search.content
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performKeyInput
+import com.kino.puber.core.ui.uikit.component.moviesList.VideoItemUIState
+import com.kino.puber.core.ui.uikit.theme.PuberTheme
+import com.kino.puber.ui.feature.search.model.SearchViewState
+import org.junit.Rule
+import org.junit.Test
+
+private const val RESULT_TITLE = "Unique search result"
+
+internal class SearchScreenContentTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun directionDownFromFocusedInputFocusesFirstResult() {
+        composeRule.setContent {
+            PuberTheme {
+                SearchScreenContent(
+                    state = SearchViewState.Content(
+                        items = listOf(
+                            VideoItemUIState(
+                                id = 1,
+                                title = RESULT_TITLE,
+                                imageUrl = "",
+                                bigImageUrl = "",
+                            ),
+                        ),
+                    ),
+                    onAction = {},
+                )
+            }
+        }
+
+        val searchInput = composeRule.onNode(hasSetTextAction())
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            searchInput.fetchSemanticsNode().config
+                .getOrNull(SemanticsProperties.Focused) == true
+        }
+
+        searchInput
+            .assertIsFocused()
+            .performKeyInput {
+                keyDown(Key.DirectionDown)
+                keyUp(Key.DirectionDown)
+            }
+
+        composeRule.onNodeWithText(RESULT_TITLE).assertIsFocused()
+    }
+}

--- a/app/src/main/java/com/kino/puber/ui/feature/search/content/SearchScreenContent.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/search/content/SearchScreenContent.kt
@@ -33,6 +33,11 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
@@ -69,6 +74,10 @@ internal fun SearchScreenContent(
     val textFieldFocusRequester = remember { FocusRequester() }
     val gridFocusRequester = remember { FocusRequester() }
     var focusTarget by rememberSaveable { mutableStateOf(FOCUS_TARGET_TEXT_FIELD) }
+    val focusResults: () -> Unit = {
+        focusTarget = FOCUS_TARGET_GRID
+        gridFocusRequester.requestFocus()
+    }
 
     // Restore focus on (re-)composition: text field on first launch, grid on return from details
     LaunchedEffect(Unit) {
@@ -98,8 +107,8 @@ internal fun SearchScreenContent(
         SearchInputField(
             query = query,
             textFieldFocusRequester = textFieldFocusRequester,
-            gridFocusRequester = gridFocusRequester,
             hasResults = state is SearchViewState.Content,
+            onFocusResults = focusResults,
             onQueryChanged = { text ->
                 query = text
                 onAction(CommonAction.TextChanged(text, SEARCH_TAG))
@@ -121,8 +130,8 @@ internal fun SearchScreenContent(
 private fun SearchInputField(
     query: String,
     textFieldFocusRequester: FocusRequester,
-    gridFocusRequester: FocusRequester,
     hasResults: Boolean,
+    onFocusResults: () -> Unit,
     onQueryChanged: (String) -> Unit,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -142,7 +151,11 @@ private fun SearchInputField(
             onValueChange = onQueryChanged,
             modifier = Modifier
                 .fillMaxWidth()
-                .focusRequester(textFieldFocusRequester),
+                .focusRequester(textFieldFocusRequester)
+                .onDpadDown(hasResults = hasResults) {
+                    keyboardController?.hide()
+                    onFocusResults()
+                },
             textStyle = MaterialTheme.typography.bodyLarge.copy(
                 color = MaterialTheme.colorScheme.onSurface,
             ),
@@ -152,7 +165,7 @@ private fun SearchInputField(
             keyboardActions = KeyboardActions(
                 onSearch = {
                     keyboardController?.hide()
-                    if (hasResults) gridFocusRequester.requestFocus()
+                    if (hasResults) onFocusResults()
                 },
             ),
             decorationBox = { innerTextField ->
@@ -173,6 +186,23 @@ private fun SearchInputField(
                 }
             },
         )
+    }
+}
+
+private fun Modifier.onDpadDown(
+    hasResults: Boolean,
+    onKeyDown: () -> Unit,
+): Modifier = onPreviewKeyEvent { event ->
+    if (!hasResults || event.key != Key.DirectionDown) {
+        return@onPreviewKeyEvent false
+    }
+    when (event.type) {
+        KeyEventType.KeyDown -> {
+            onKeyDown()
+            true
+        }
+        KeyEventType.KeyUp -> true
+        else -> false
     }
 }
 


### PR DESCRIPTION
## Summary
- Route DPAD Down from a focused Search input directly to existing result-grid focus when results exist.
- Hide the software keyboard and consume the handled down/up pair.
- Add focused Compose instrumentation coverage for the input-to-first-result transition.

## Compliance
Final Compliance Review passed; no violations in PUB-36 scope.

## Verification
- `./tools/agentw :app:compileDevDebugKotlin` — passed
- `./tools/agentw :app:compileDevDebugAndroidTestKotlin` — passed
- `./tools/agentw :app:testDevDebugUnitTest --tests com.kino.puber.ui.feature.search.vm.SearchVMTest` — passed
- `SearchScreenContentTest#directionDownFromFocusedInputFocusesFirstResult` — passed on emulator-5554
- Required Android TV smoke and mobile evidence audit — passed

## Residual risk
The emulator did not expose app-local IME visibility during the rerun, so the visible=true-to-false transition was not directly observed. This risk was explicitly accepted in the July 28, 2026 task comment; source invokes `keyboardController.hide()` and focused instrumentation/runtime focus evidence passed.