### PR TITLE
Fix long-press context menu selection

### DIFF
--- a/app/src/androidTest/kotlin/com/kino/puber/core/ui/uikit/component/TvContextMenuLongPressTest.kt
+++ b/app/src/androidTest/kotlin/com/kino/puber/core/ui/uikit/component/TvContextMenuLongPressTest.kt
@@ -1,0 +1,137 @@
+package com.kino.puber.core.ui.uikit.component
+
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onParent
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performSemanticsAction
+import com.kino.puber.core.ui.uikit.model.TvContextMenuAction
+import com.kino.puber.core.ui.uikit.theme.PuberTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+private const val SOURCE_TAG = "context-menu-source"
+private const val MENU_TITLE = "Context menu"
+private const val FIRST_ACTION = "First action"
+private const val LONG_PRESS_DELAY_MS = 500L
+private const val NEXT_REPEAT_DELAY_MS = 50L
+
+internal class TvContextMenuLongPressTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun releasingLongSelectAfterDialogFocusesAction_doesNotInvokeAction() {
+        var actionInvocations = 0
+        setContextMenuContent(onAction = { actionInvocations += 1 })
+        val source = composeRule.onNodeWithTag(SOURCE_TAG)
+
+        source.performKeyInput {
+            keyDown(Key.Enter)
+            advanceEventTime(LONG_PRESS_DELAY_MS)
+        }
+
+        val firstAction = composeRule.waitForFirstActionFocus()
+        firstAction.performKeyInput {
+            advanceEventTime(NEXT_REPEAT_DELAY_MS)
+            keyUp(Key.Enter)
+        }
+
+        composeRule.runOnIdle {
+            assertEquals(0, actionInvocations)
+        }
+
+        firstAction.performKeyInput {
+            keyDown(Key.Enter)
+            keyUp(Key.Enter)
+        }
+
+        composeRule.runOnIdle {
+            assertEquals(1, actionInvocations)
+        }
+    }
+
+    @Test
+    fun openingWithDedicatedMenuKey_heldSelectWithRepeatsInvokesActionOnce() {
+        var actionInvocations = 0
+        setContextMenuContent(onAction = { actionInvocations += 1 })
+        val source = composeRule.onNodeWithTag(SOURCE_TAG)
+
+        source.performKeyInput {
+            keyDown(Key.Menu)
+            keyUp(Key.Menu)
+        }
+
+        val firstAction = composeRule.waitForFirstActionFocus()
+        firstAction.performKeyInput {
+            keyDown(Key.DirectionCenter)
+            advanceEventTime(LONG_PRESS_DELAY_MS)
+            advanceEventTime(NEXT_REPEAT_DELAY_MS)
+            keyUp(Key.DirectionCenter)
+        }
+
+        composeRule.runOnIdle {
+            assertEquals(1, actionInvocations)
+        }
+    }
+
+    private fun setContextMenuContent(onAction: () -> Unit) {
+        composeRule.setContent {
+            PuberTheme {
+                var menuVisible by remember { mutableStateOf(false) }
+                BasicText(
+                    text = "Open menu",
+                    modifier = Modifier
+                        .testTag(SOURCE_TAG)
+                        .onTvContextMenuKey { menuVisible = true }
+                        .focusable(),
+                )
+                if (menuVisible) {
+                    TvContextMenuDialog(
+                        title = MENU_TITLE,
+                        actions = listOf(
+                            TvContextMenuAction(
+                                id = "first",
+                                title = FIRST_ACTION,
+                            ),
+                        ),
+                        onAction = { onAction() },
+                        onDismiss = { menuVisible = false },
+                    )
+                }
+            }
+        }
+        composeRule
+            .onNodeWithTag(SOURCE_TAG)
+            .performSemanticsAction(SemanticsActions.RequestFocus)
+            .assertIsFocused()
+    }
+
+    private fun androidx.compose.ui.test.junit4.ComposeTestRule.waitForFirstActionFocus() =
+        onNodeWithText(FIRST_ACTION, useUnmergedTree = true)
+            .onParent()
+            .also { action ->
+                waitUntil {
+                    action.fetchSemanticsNode().config
+                        .getOrNull(SemanticsProperties.Focused) == true
+                }
+                onNodeWithText(MENU_TITLE).assertExists()
+                action.assertIsFocused()
+            }
+}

--- a/app/src/main/java/com/kino/puber/core/ui/uikit/component/TvContextMenu.kt
+++ b/app/src/main/java/com/kino/puber/core/ui/uikit/component/TvContextMenu.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -46,6 +47,11 @@ private const val LONG_SELECT_REPEAT_THRESHOLD = 1
 
 private val ContextMenuWidth = 520.dp
 
+internal val LocalTvContextMenuLongSelectState =
+    compositionLocalOf<TvContextMenuLongSelectState> {
+        error("TvContextMenuLongSelectState must be provided by PuberTheme")
+    }
+
 @Composable
 internal fun TvContextMenuDialog(
     title: String,
@@ -80,7 +86,11 @@ internal fun TvContextMenuDialog(
         }
     }
 
-    TvDialogOverlay(onDismiss = onDismiss) { dismiss ->
+    val longSelectState = LocalTvContextMenuLongSelectState.current
+    TvDialogOverlay(
+        onDismiss = onDismiss,
+        modifier = Modifier.consumeContextMenuLongSelectGesture(longSelectState),
+    ) { dismiss ->
         Card(
             modifier = modifier.width(ContextMenuWidth),
         ) {
@@ -289,7 +299,7 @@ internal fun Modifier.onTvContextMenuKey(
     enabled: Boolean = true,
     onOpen: () -> Unit,
 ): Modifier {
-    val longSelectState = remember { TvContextMenuLongSelectState() }
+    val longSelectState = LocalTvContextMenuLongSelectState.current
     val focusRestorer = LocalTvDialogFocusRestorer.current
     val openWithFocusSave = {
         focusRestorer?.onDialogOpening()
@@ -324,6 +334,22 @@ internal fun Modifier.onTvContextMenuKey(
     }
 }
 
+private fun Modifier.consumeContextMenuLongSelectGesture(
+    longSelectState: TvContextMenuLongSelectState,
+): Modifier {
+    return onPreviewKeyEvent { event ->
+        if (!event.key.isSelectKey()) {
+            return@onPreviewKeyEvent false
+        }
+        when (event.type) {
+            KeyEventType.KeyDown ->
+                longSelectState.consumeSelectRepeatIfTracking(event.nativeKeyEvent.repeatCount)
+            KeyEventType.KeyUp -> longSelectState.consumeSelectKeyUpIfTracking()
+            else -> false
+        }
+    }
+}
+
 internal class TvContextMenuLongSelectState(
     private val repeatThreshold: Int = LONG_SELECT_REPEAT_THRESHOLD,
 ) {
@@ -349,6 +375,14 @@ internal class TvContextMenuLongSelectState(
         } else {
             false
         }
+    }
+
+    fun consumeSelectRepeatIfTracking(repeatCount: Int): Boolean {
+        return suppressSelectUp && repeatCount >= repeatThreshold
+    }
+
+    fun consumeSelectKeyUpIfTracking(): Boolean {
+        return suppressSelectUp && onSelectKeyUp()
     }
 }
 

--- a/app/src/main/java/com/kino/puber/core/ui/uikit/theme/PuberTheme.kt
+++ b/app/src/main/java/com/kino/puber/core/ui/uikit/theme/PuberTheme.kt
@@ -1,9 +1,13 @@
 package com.kino.puber.core.ui.uikit.theme
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.darkColorScheme
+import com.kino.puber.core.ui.uikit.component.LocalTvContextMenuLongSelectState
+import com.kino.puber.core.ui.uikit.component.TvContextMenuLongSelectState
 
 data object PuberTheme {
     data object Defaults {
@@ -20,6 +24,7 @@ data object PuberTheme {
 fun PuberTheme(
     content: @Composable () -> Unit,
 ) {
+    val contextMenuLongSelectState = remember { TvContextMenuLongSelectState() }
     val colorSchemeTv = darkColorScheme(
         primary = Purple80,
         secondary = PurpleGrey80,
@@ -35,14 +40,18 @@ fun PuberTheme(
         error = Error60,
         errorContainer = Error60,
     )
-    androidx.compose.material3.MaterialTheme(
-        colorScheme = colorScheme,
-        content = {
-            MaterialTheme(
-                colorScheme = colorSchemeTv,
-                typography = Typography,
-                content = content
-            )
-        }
-    )
+    CompositionLocalProvider(
+        LocalTvContextMenuLongSelectState provides contextMenuLongSelectState,
+    ) {
+        androidx.compose.material3.MaterialTheme(
+            colorScheme = colorScheme,
+            content = {
+                MaterialTheme(
+                    colorScheme = colorSchemeTv,
+                    typography = Typography,
+                    content = content
+                )
+            }
+        )
+    }
 }

--- a/app/src/test/kotlin/com/kino/puber/core/ui/uikit/component/TvContextMenuLongSelectStateTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/core/ui/uikit/component/TvContextMenuLongSelectStateTest.kt
@@ -44,4 +44,50 @@ class TvContextMenuLongSelectStateTest {
 
         assertEquals(TvContextMenuLongSelectDecision.Open, state.onSelectKeyDown(repeatCount = 1))
     }
+
+    @Test
+    fun sharedState_consumesOpeningGestureAcrossFocusHandoff() {
+        val sharedState = TvContextMenuLongSelectState(repeatThreshold = 1)
+        val sourceConsumer = LongSelectConsumer(sharedState)
+        val dialogConsumer = DialogLongSelectConsumer(sharedState)
+
+        assertEquals(TvContextMenuLongSelectDecision.Open, sourceConsumer.onKeyDown(repeatCount = 1))
+        assertTrue(dialogConsumer.onKeyDown(repeatCount = 2))
+        assertTrue(dialogConsumer.onKeyDown(repeatCount = 3))
+        assertTrue(dialogConsumer.onKeyUp())
+        assertFalse(sourceConsumer.onKeyUp())
+
+        assertEquals(TvContextMenuLongSelectDecision.Open, sourceConsumer.onKeyDown(repeatCount = 1))
+        assertTrue(dialogConsumer.onKeyUp())
+    }
+
+    @Test
+    fun sharedState_doesNotClaimOrdinarySelectAfterDedicatedMenuOpening() {
+        val sharedState = TvContextMenuLongSelectState(repeatThreshold = 1)
+        val dialogConsumer = DialogLongSelectConsumer(sharedState)
+
+        assertFalse(dialogConsumer.onKeyDown(repeatCount = 0))
+        assertFalse(dialogConsumer.onKeyDown(repeatCount = 1))
+        assertFalse(dialogConsumer.onKeyDown(repeatCount = 2))
+        assertFalse(dialogConsumer.onKeyUp())
+        assertEquals(TvContextMenuLongSelectDecision.Open, sharedState.onSelectKeyDown(repeatCount = 1))
+    }
+
+    private class LongSelectConsumer(
+        private val state: TvContextMenuLongSelectState,
+    ) {
+        fun onKeyDown(repeatCount: Int): TvContextMenuLongSelectDecision =
+            state.onSelectKeyDown(repeatCount)
+
+        fun onKeyUp(): Boolean = state.onSelectKeyUp()
+    }
+
+    private class DialogLongSelectConsumer(
+        private val state: TvContextMenuLongSelectState,
+    ) {
+        fun onKeyDown(repeatCount: Int): Boolean =
+            state.consumeSelectRepeatIfTracking(repeatCount)
+
+        fun onKeyUp(): Boolean = state.consumeSelectKeyUpIfTracking()
+    }
 }


### PR DESCRIPTION
## Summary
- Share context-menu long-select gesture state across source and dialog focus handoff.
- Consume the opening gesture release so it cannot activate the initially focused menu action.
- Add JVM state-machine and Android Compose regressions.

## Compliance
Final Compliance Review passed with no violations.

## Verification
- `./tools/agentw :app:testDevDebugUnitTest --tests com.kino.puber.core.ui.uikit.component.TvContextMenuLongSelectStateTest` — passed
- `./tools/agentw :app:compileDevDebugKotlin` — passed
- `./tools/agentw :app:compileDevDebugAndroidTestKotlin` — passed
- `.kent/scripts/workflow-verify-report` — passed
- Locked-emulator Smoke on `emulator-5554` — passed after fresh `devDebug` install; sanitized crash/ANR/liveness evidence audit passed.

## Known limits
Physical-TV hardware, account-mutating actions, and nonrepresentative menu types were not exercised.