### PR TITLE
PUB-41: Add Anime and Cartoons hero carousels

### DIFF
--- a/app/src/main/java/com/kino/puber/core/ui/model/VideoItemUIMapper.kt
+++ b/app/src/main/java/com/kino/puber/core/ui/model/VideoItemUIMapper.kt
@@ -2,6 +2,7 @@ package com.kino.puber.core.ui.model
 
 import com.kino.puber.R
 import com.kino.puber.core.system.ResourceProvider
+import com.kino.puber.core.ui.uikit.component.HeroItemState
 import com.kino.puber.core.ui.uikit.component.RatingUIState
 import com.kino.puber.core.ui.uikit.component.details.VideoDetailsUIState
 import com.kino.puber.core.ui.uikit.component.moviesList.VideoItemUIState
@@ -41,6 +42,32 @@ class VideoItemUIMapper(
                 item.bookmarks.orEmpty().isNotEmpty()
             },
         )
+    }
+
+    fun mapHeroItems(items: List<Item>): List<HeroItemState> {
+        return items.map { item ->
+            val widePosterUrls = mapPosterUrls(item.posters?.wide)
+            val bigPosterUrls = mapPosterUrls(item.posters?.big)
+            val heroPosterUrls = (widePosterUrls + bigPosterUrls).distinct()
+            HeroItemState(
+                id = item.id,
+                title = item.title,
+                wideImageUrl = heroPosterUrls.firstOrNull().orEmpty(),
+                fallbackImageUrl = heroPosterUrls.drop(1).firstOrNull().orEmpty(),
+                fallbackImageUrls = heroPosterUrls.drop(2),
+                year = item.year?.toString().orEmpty(),
+                ratings = buildRatings(item),
+                genres = item.genres?.joinToString(", ") { it.title }.orEmpty(),
+                country = item.countries?.joinToString(", ") { it.title }.orEmpty(),
+                duration = if (item.type.isSeriesLike()) {
+                    item.seasons?.size?.let {
+                        resources.getString(R.string.video_details_label_seasons, it)
+                    }.orEmpty()
+                } else {
+                    buildMovieDuration(item)
+                },
+            )
+        }
     }
 
     fun mapDetailedItem(item: Item): VideoDetailsUIState {
@@ -92,7 +119,11 @@ class VideoItemUIMapper(
     fun buildDuration(item: Item): String {
         return item.seasons?.let { seasons ->
             resources.getString(R.string.video_details_label_seasons, seasons.size)
-        } ?: resources.getString(
+        } ?: buildMovieDuration(item)
+    }
+
+    private fun buildMovieDuration(item: Item): String {
+        return resources.getString(
             R.string.video_details_label_duration,
             item.duration?.total?.formatDurationWithResources().orEmpty(),
         )

--- a/app/src/main/java/com/kino/puber/ui/feature/contentlist/ContentListScreen.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/contentlist/ContentListScreen.kt
@@ -52,6 +52,7 @@ internal class ContentListScreen(
                     navPrefs = get(),
                     contentListRefreshCoordinator = get(),
                     contentType = sections.firstOrNull()?.type,
+                    heroConfigs = TabTypeConfig.heroConfigsFor(tabType),
                 )
             }
 

--- a/app/src/main/java/com/kino/puber/ui/feature/contentlist/content/ContentListScreenContent.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/contentlist/content/ContentListScreenContent.kt
@@ -2,11 +2,14 @@ package com.kino.puber.ui.feature.contentlist.content
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
@@ -23,6 +26,7 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.kino.puber.core.ui.uikit.component.VideoItemContextMenuDialog
 import com.kino.puber.core.ui.uikit.component.GenreChipBar
+import com.kino.puber.core.ui.uikit.component.HeroCarousel
 import com.kino.puber.core.ui.uikit.component.details.VideoItemGridDetails
 import com.kino.puber.core.ui.uikit.theme.PuberTheme
 import com.kino.puber.core.ui.uikit.component.modifier.rememberFocusRequesterOnLaunch
@@ -32,6 +36,7 @@ import com.kino.puber.core.ui.uikit.model.UIAction
 import com.kino.puber.ui.feature.contentlist.model.ContentListAction
 import com.kino.puber.ui.feature.contentlist.model.ContentListViewState
 import com.kino.puber.ui.feature.contentlist.model.SectionConfig
+import com.kino.puber.ui.feature.contentlist.model.SectionState
 import com.kino.puber.ui.feature.contentlist.vm.SectionVM
 import com.kino.puber.core.di.LocalPuberKoinScope
 import org.koin.core.qualifier.named
@@ -58,82 +63,21 @@ internal fun ContentListScreenContent(
     }
 
     androidx.compose.foundation.layout.Box {
-        Column(
+        ContentListLayout(
+            state = state,
+            sections = sections,
+            sectionVms = sectionVms,
+            sectionStates = sectionStates,
+            focusedSectionIndex = focusedSectionIndex,
+            onSectionFocused = { focusedSectionIndex = it },
+            onContextMenu = { item, sectionVm ->
+                contextMenuTarget = ContentListContextMenuTarget(item, sectionVm)
+            },
+            onAction = onAction,
             modifier = Modifier
                 .fillMaxSize()
                 .focusRequester(mainContentFocus),
-        ) {
-            if (state.showDetailPanel) {
-                VideoItemGridDetails(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .weight(PuberTheme.Defaults.DetailsWeight),
-                    state = state.selectedItem,
-                )
-            }
-
-            if (state.showGenreChips && state.genres.isNotEmpty()) {
-                GenreChipBar(
-                    genres = state.genres,
-                    selectedGenreId = state.selectedGenreId,
-                    onGenreSelected = { genreId -> onAction(ContentListAction.GenreSelected(genreId)) },
-                )
-            }
-
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(if (state.showDetailPanel) PuberTheme.Defaults.ContentWeight else 1f)
-                    .focusRestorer()
-                    .focusGroup(),
-                contentPadding = PaddingValues(bottom = PuberTheme.Defaults.HorizontalVideoItemHeight),
-            ) {
-                sections.forEachIndexed { index, config ->
-                    val isLastSection = index == sections.lastIndex
-
-                    item(key = "title_${config.id}", contentType = "section_title") {
-                        Text(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 16.dp),
-                            text = config.title,
-                            style = MaterialTheme.typography.titleLarge,
-                        )
-                    }
-
-                    item(key = "content_${config.id}", contentType = "section_content") {
-                        val rememberedOnItemClick = remember(config.id) {
-                            { item: VideoItemUIState -> onAction(CommonAction.ItemSelected(item)) }
-                        }
-                        val rememberedOnItemFocused = remember(config.id) {
-                            { item: VideoItemUIState -> onAction(CommonAction.ItemFocused(item)) }
-                        }
-                        val rememberedOnSectionFocused = remember(index) {
-                            { focusedSectionIndex = index }
-                        }
-                        val rememberedOnShowAll = remember(config.id, isLastSection) {
-                            if (isLastSection) {
-                                { onAction(ContentListAction.ShowAll(config)) }
-                            } else {
-                                null
-                            }
-                        }
-                        SectionRowContent(
-                            state = sectionStates[index],
-                            config = config,
-                            isTargetRow = index == focusedSectionIndex,
-                            onItemClick = rememberedOnItemClick,
-                            onItemContextMenu = { contextMenuTarget = ContentListContextMenuTarget(it, sectionVms[index]) },
-                            onItemFocused = rememberedOnItemFocused,
-                            onSectionFocused = rememberedOnSectionFocused,
-                            onRetry = { sectionVms[index].onAction(CommonAction.RetryClicked) },
-                            onLoadMore = { sectionVms[index].onAction(CommonAction.LoadMore) },
-                            onShowAll = rememberedOnShowAll,
-                        )
-                    }
-                }
-            }
-        }
+        )
 
         val activeContextMenuTarget = contextMenuTarget
         VideoItemContextMenuDialog(
@@ -146,6 +90,160 @@ internal fun ContentListScreenContent(
                     onAction(action)
                 }
             },
+        )
+    }
+}
+
+@Composable
+private fun ContentListLayout(
+    state: ContentListViewState,
+    sections: List<SectionConfig>,
+    sectionVms: List<SectionVM>,
+    sectionStates: List<SectionState>,
+    focusedSectionIndex: Int,
+    onSectionFocused: (Int) -> Unit,
+    onContextMenu: (VideoItemUIState, SectionVM) -> Unit,
+    onAction: (UIAction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        if (state.showDetailPanel) {
+            VideoItemGridDetails(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(PuberTheme.Defaults.DetailsWeight),
+                state = state.selectedItem,
+            )
+        }
+
+        if (state.showGenreChips && state.genres.isNotEmpty()) {
+            GenreChipBar(
+                genres = state.genres,
+                selectedGenreId = state.selectedGenreId,
+                onGenreSelected = { genreId -> onAction(ContentListAction.GenreSelected(genreId)) },
+            )
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(if (state.showDetailPanel) PuberTheme.Defaults.ContentWeight else 1f)
+                .focusRestorer()
+                .focusGroup(),
+            contentPadding = PaddingValues(bottom = PuberTheme.Defaults.HorizontalVideoItemHeight),
+        ) {
+            heroItem(state, onAction)
+            sectionItems(
+                sections = sections,
+                sectionVms = sectionVms,
+                sectionStates = sectionStates,
+                focusedSectionIndex = focusedSectionIndex,
+                onSectionFocused = onSectionFocused,
+                onContextMenu = onContextMenu,
+                onAction = onAction,
+            )
+        }
+    }
+}
+
+private fun LazyListScope.heroItem(
+    state: ContentListViewState,
+    onAction: (UIAction) -> Unit,
+) {
+    if (state.isHeroLoading || state.heroItems.isNotEmpty()) {
+        item(key = "hero", contentType = "hero") {
+            if (state.heroItems.isEmpty()) {
+                Spacer(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(280.dp),
+                )
+            } else {
+                HeroCarousel(
+                    items = state.heroItems,
+                    onItemClick = { itemId ->
+                        onAction(ContentListAction.HeroSelected(itemId))
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+    }
+}
+
+private fun LazyListScope.sectionItems(
+    sections: List<SectionConfig>,
+    sectionVms: List<SectionVM>,
+    sectionStates: List<SectionState>,
+    focusedSectionIndex: Int,
+    onSectionFocused: (Int) -> Unit,
+    onContextMenu: (VideoItemUIState, SectionVM) -> Unit,
+    onAction: (UIAction) -> Unit,
+) {
+    sections.forEachIndexed { index, config ->
+        sectionItem(
+            index = index,
+            config = config,
+            sectionVm = sectionVms[index],
+            sectionState = sectionStates[index],
+            isLastSection = index == sections.lastIndex,
+            isTargetRow = index == focusedSectionIndex,
+            onSectionFocused = onSectionFocused,
+            onContextMenu = onContextMenu,
+            onAction = onAction,
+        )
+    }
+}
+
+private fun LazyListScope.sectionItem(
+    index: Int,
+    config: SectionConfig,
+    sectionVm: SectionVM,
+    sectionState: SectionState,
+    isLastSection: Boolean,
+    isTargetRow: Boolean,
+    onSectionFocused: (Int) -> Unit,
+    onContextMenu: (VideoItemUIState, SectionVM) -> Unit,
+    onAction: (UIAction) -> Unit,
+) {
+    item(key = "title_${config.id}", contentType = "section_title") {
+        Text(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            text = config.title,
+            style = MaterialTheme.typography.titleLarge,
+        )
+    }
+
+    item(key = "content_${config.id}", contentType = "section_content") {
+        val rememberedOnItemClick = remember(config.id) {
+            { item: VideoItemUIState -> onAction(CommonAction.ItemSelected(item)) }
+        }
+        val rememberedOnItemFocused = remember(config.id) {
+            { item: VideoItemUIState -> onAction(CommonAction.ItemFocused(item)) }
+        }
+        val rememberedOnSectionFocused = remember(index) {
+            { onSectionFocused(index) }
+        }
+        val rememberedOnShowAll = remember(config.id, isLastSection) {
+            if (isLastSection) {
+                { onAction(ContentListAction.ShowAll(config)) }
+            } else {
+                null
+            }
+        }
+        SectionRowContent(
+            state = sectionState,
+            config = config,
+            isTargetRow = isTargetRow,
+            onItemClick = rememberedOnItemClick,
+            onItemContextMenu = { onContextMenu(it, sectionVm) },
+            onItemFocused = rememberedOnItemFocused,
+            onSectionFocused = rememberedOnSectionFocused,
+            onRetry = { sectionVm.onAction(CommonAction.RetryClicked) },
+            onLoadMore = { sectionVm.onAction(CommonAction.LoadMore) },
+            onShowAll = rememberedOnShowAll,
         )
     }
 }

--- a/app/src/main/java/com/kino/puber/ui/feature/contentlist/model/ContentListAction.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/contentlist/model/ContentListAction.kt
@@ -5,4 +5,5 @@ import com.kino.puber.core.ui.uikit.model.UIAction
 internal sealed class ContentListAction : UIAction {
     data class ShowAll(val config: SectionConfig) : ContentListAction()
     data class GenreSelected(val genreId: Int?) : ContentListAction()
+    data class HeroSelected(val itemId: Int) : ContentListAction()
 }

--- a/app/src/main/java/com/kino/puber/ui/feature/contentlist/model/ContentListViewState.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/contentlist/model/ContentListViewState.kt
@@ -1,11 +1,14 @@
 package com.kino.puber.ui.feature.contentlist.model
 
 import androidx.compose.runtime.Immutable
+import com.kino.puber.core.ui.uikit.component.HeroItemState
 import com.kino.puber.core.ui.uikit.component.details.VideoDetailsUIState
 import com.kino.puber.data.api.models.Genre
 
 @Immutable
 internal data class ContentListViewState(
+    val heroItems: List<HeroItemState> = emptyList(),
+    val isHeroLoading: Boolean = false,
     val selectedItem: VideoDetailsUIState = VideoDetailsUIState.Loading,
     val genres: List<Genre> = emptyList(),
     val selectedGenreId: Int? = null,

--- a/app/src/main/java/com/kino/puber/ui/feature/contentlist/model/TabTypeConfig.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/contentlist/model/TabTypeConfig.kt
@@ -6,6 +6,20 @@ import com.kino.puber.ui.feature.main.model.TabType
 
 internal object TabTypeConfig {
 
+    fun heroConfigsFor(tabType: TabType): List<SectionConfig> = when (tabType) {
+        TabType.Cartoons -> heroConfigs(
+            idSuffix = "cartoon",
+            genre = CARTOON_GENRE_ID,
+            animeFilterMode = AnimeFilterMode.Exclude,
+        )
+        TabType.Anime -> heroConfigs(
+            idSuffix = "anime",
+            genre = ANIME_GENRE_ID,
+            animeFilterMode = AnimeFilterMode.Only,
+        )
+        else -> emptyList()
+    }
+
     fun sectionsFor(tabType: TabType): List<SectionConfig> = when (tabType) {
         TabType.Movies -> standardSections(
             type = "movie",
@@ -66,6 +80,21 @@ internal object TabTypeConfig {
             animeFilterMode = animeFilterMode,
         ),
     )
+
+    private fun heroConfigs(
+        idSuffix: String,
+        genre: Int,
+        animeFilterMode: AnimeFilterMode,
+    ): List<SectionConfig> = listOf("movie", "serial").map { type ->
+        SectionConfig(
+            id = "hero_hot_${idSuffix}_$type",
+            title = "",
+            type = type,
+            shortcut = "hot",
+            genre = genre.toString(),
+            animeFilterMode = animeFilterMode,
+        )
+    }
 
     private fun sectionsWithout4k(type: String): List<SectionConfig> = listOf(
         SectionConfig(

--- a/app/src/main/java/com/kino/puber/ui/feature/contentlist/vm/ContentListVM.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/contentlist/vm/ContentListVM.kt
@@ -1,6 +1,7 @@
 package com.kino.puber.ui.feature.contentlist.vm
 
 import com.kino.puber.core.content.ContentChangeSet
+import com.kino.puber.core.logger.log
 import com.kino.puber.core.model.NavigationMode
 import com.kino.puber.core.ui.PuberVM
 import com.kino.puber.core.ui.model.VideoItemUIMapper
@@ -17,8 +18,11 @@ import com.kino.puber.ui.feature.contentlist.model.ContentListAction
 import com.kino.puber.ui.feature.contentlist.model.ContentListViewState
 import com.kino.puber.ui.feature.contentlist.model.SectionConfig
 import com.kino.puber.ui.feature.showall.ShowAllScreen
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.supervisorScope
 
 internal class ContentListVM(
     router: AppRouter,
@@ -28,10 +32,14 @@ internal class ContentListVM(
     private val navPrefs: NavigationPreferencesRepository,
     private val contentListRefreshCoordinator: ContentListRefreshCoordinator,
     private val contentType: String? = null,
+    private val heroConfigs: List<SectionConfig> = emptyList(),
 ) : PuberVM<ContentListViewState>(router) {
 
-    override val initialViewState = ContentListViewState()
+    override val initialViewState = ContentListViewState(
+        isHeroLoading = heroConfigs.isNotEmpty(),
+    )
     private var focusedItemJob: Job? = null
+    private var heroLoadJob: Job? = null
 
     override fun onStart() {
         val isTopTabs = navPrefs.getNavigationMode() == NavigationMode.TopTabs
@@ -44,6 +52,7 @@ internal class ContentListVM(
         if (isTopTabs) {
             loadGenres()
         }
+        loadHero()
     }
 
     override fun onAction(action: UIAction) {
@@ -53,6 +62,7 @@ internal class ContentListVM(
             is CommonAction.ItemPlayed<*> -> onItemPlayed(action.item as VideoItemUIState)
             is ContentListAction.ShowAll -> openShowAll(action.config)
             is ContentListAction.GenreSelected -> onGenreSelected(action.genreId)
+            is ContentListAction.HeroSelected -> openDetails(action.itemId)
         }
     }
 
@@ -80,8 +90,12 @@ internal class ContentListVM(
     }
 
     private fun onItemSelected(item: VideoItemUIState) {
+        openDetails(item.id)
+    }
+
+    private fun openDetails(itemId: Int) {
         router.navigateForResult<ContentChangeSet>(
-            screen = router.screens.details(item.id),
+            screen = router.screens.details(itemId),
             requestCode = RESULT_CONTENT_CHANGED,
             listener = ::onReturnedContentChanges,
         )
@@ -117,6 +131,7 @@ internal class ContentListVM(
         changes.itemIds.forEach(interactor::invalidateItemDetails)
         interactor.invalidateFirstPageCache()
         contentListRefreshCoordinator.requestRefresh()
+        loadHero()
         val selectedItemId = stateValue.selectedItem.id
         if (selectedItemId > 0 && changes.affectsItem(selectedItemId)) {
             focusedItemJob?.cancel()
@@ -129,7 +144,55 @@ internal class ContentListVM(
         }
     }
 
+    private fun loadHero() {
+        if (heroConfigs.isEmpty()) return
+        heroLoadJob?.cancel()
+        updateViewState<ContentListViewState> {
+            copy(isHeroLoading = true)
+        }
+        heroLoadJob = launch {
+            try {
+                val items = supervisorScope {
+                    heroConfigs
+                        .map { config ->
+                            async { loadHeroItems(config) }
+                        }
+                        .flatMap { it.await() }
+                }
+                    .distinctBy { it.id }
+                    .sortedByDescending { it.ratingPercentage ?: 0 }
+                    .take(HERO_ITEMS_COUNT)
+                updateViewState<ContentListViewState> {
+                    copy(
+                        heroItems = mapper.mapHeroItems(items),
+                        isHeroLoading = false,
+                    )
+                }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                log(error, "Failed to load content-list hero")
+                updateViewState<ContentListViewState> {
+                    copy(
+                        heroItems = emptyList(),
+                        isHeroLoading = false,
+                    )
+                }
+            }
+        }
+    }
+
+    private suspend fun loadHeroItems(config: SectionConfig) = try {
+        interactor.loadPage(config, page = 1).items
+    } catch (error: CancellationException) {
+        throw error
+    } catch (error: Throwable) {
+        log(error, "Failed to load content-list hero ${config.type}")
+        emptyList()
+    }
+
     private companion object {
         const val FOCUS_DETAILS_DEBOUNCE_MS = 150L
+        const val HERO_ITEMS_COUNT = 10
     }
 }

--- a/app/src/main/java/com/kino/puber/ui/feature/home/model/HomeUIMapper.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/home/model/HomeUIMapper.kt
@@ -3,42 +3,14 @@ package com.kino.puber.ui.feature.home.model
 import com.kino.puber.R
 import com.kino.puber.core.system.ResourceProvider
 import com.kino.puber.core.ui.model.VideoItemUIMapper
-import com.kino.puber.core.ui.uikit.component.HeroItemState
 import com.kino.puber.core.ui.uikit.component.moviesList.VideoItemUIState
-import com.kino.puber.data.api.models.Item
 import com.kino.puber.data.api.models.KCollection
-import com.kino.puber.data.api.models.isSeriesLike
+import com.kino.puber.data.api.models.Item
 
 internal class HomeUIMapper(
     private val videoItemMapper: VideoItemUIMapper,
     private val resources: ResourceProvider,
 ) {
-
-    fun mapHeroItems(items: List<Item>): List<HeroItemState> {
-        return items.map { item ->
-            val widePosterUrls = videoItemMapper.mapPosterUrls(item.posters?.wide)
-            val bigPosterUrls = videoItemMapper.mapPosterUrls(item.posters?.big)
-            val heroPosterUrls = (widePosterUrls + bigPosterUrls).distinct()
-            HeroItemState(
-                id = item.id,
-                title = item.title,
-                wideImageUrl = heroPosterUrls.firstOrNull().orEmpty(),
-                fallbackImageUrl = heroPosterUrls.drop(1).firstOrNull().orEmpty(),
-                fallbackImageUrls = heroPosterUrls.drop(2),
-                year = item.year?.toString().orEmpty(),
-                ratings = videoItemMapper.buildRatings(item),
-                genres = item.genres?.joinToString(", ") { it.title }.orEmpty(),
-                country = item.countries?.joinToString(", ") { it.title }.orEmpty(),
-                duration = if (item.type.isSeriesLike()) {
-                    item.seasons?.size?.let {
-                        resources.getString(R.string.video_details_label_seasons, it)
-                    }.orEmpty()
-                } else {
-                    videoItemMapper.buildDuration(item)
-                },
-            )
-        }
-    }
 
     fun mapItemSection(items: List<Item>, type: HomeSectionType): HomeSectionState? {
         if (items.isEmpty()) return null

--- a/app/src/main/java/com/kino/puber/ui/feature/home/vm/HomeVM.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/home/vm/HomeVM.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.supervisorScope
 import com.kino.puber.R
 import com.kino.puber.core.ui.PuberVM
+import com.kino.puber.core.ui.model.VideoItemUIMapper
 import com.kino.puber.core.ui.navigation.AppRouter
 import com.kino.puber.core.ui.navigation.RESULT_CONTENT_CHANGED
 import com.kino.puber.core.ui.uikit.component.moviesList.VideoItemUIState
@@ -34,6 +35,7 @@ internal class HomeVM(
     router: AppRouter,
     private val interactor: HomeInteractor,
     private val mapper: HomeUIMapper,
+    private val videoItemMapper: VideoItemUIMapper,
     private val apiDomainInteractor: ApiDomainInteractor,
     private val savedItemInteractor: SavedItemInteractor,
     private val resources: ResourceProvider,
@@ -189,7 +191,7 @@ internal class HomeVM(
 
         updateViewState(
             HomeViewState.Content(
-                heroItems = mapper.mapHeroItems(hotItems.take(HERO_ITEMS_COUNT)),
+                heroItems = videoItemMapper.mapHeroItems(hotItems.take(HERO_ITEMS_COUNT)),
                 sections = sections,
                 apiDomainDialog = currentDialogState(),
             )

--- a/app/src/test/kotlin/com/kino/puber/core/ui/model/VideoItemUIMapperTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/core/ui/model/VideoItemUIMapperTest.kt
@@ -1,8 +1,14 @@
 package com.kino.puber.core.ui.model
 
+import com.kino.puber.R
 import com.kino.puber.data.api.models.Bookmark
+import com.kino.puber.data.api.models.Country
+import com.kino.puber.data.api.models.Duration
+import com.kino.puber.data.api.models.Genre
 import com.kino.puber.data.api.models.Item
 import com.kino.puber.data.api.models.ItemType
+import com.kino.puber.data.api.models.Posters
+import com.kino.puber.data.api.models.Season
 import com.kino.puber.util.FakeResourceProvider
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -112,10 +118,115 @@ class VideoItemUIMapperTest {
 
     // endregion
 
+    // region hero mapping
+
+    @Test
+    fun mapHeroItems_prefersWidePosterAndFallsBackToBigPosters() {
+        val item = testItem(
+            posters = Posters(
+                wide = "http://wide.example/hero.jpg",
+                big = "http://big.example/hero.jpg",
+            ),
+        )
+
+        val result = mapper.mapHeroItems(listOf(item)).single()
+
+        assertEquals("https://wide.example/hero.jpg", result.wideImageUrl)
+        assertEquals("https://big.example/hero.jpg", result.fallbackImageUrl)
+        assertEquals(emptyList<String>(), result.fallbackImageUrls)
+    }
+
+    @Test
+    fun mapHeroItems_mapsMovieMetadata() {
+        val item = testItem(
+            id = 42,
+            title = "Movie",
+            year = 2024,
+            genres = listOf(Genre(1, "Anime"), Genre(2, "Action")),
+            countries = listOf(Country(1, "Japan")),
+            duration = Duration(total = 5 * 60),
+            kinopoiskRating = "8.1",
+            imdbRating = "7.9",
+            ratingPercentage = 86,
+        )
+
+        val result = mapper.mapHeroItems(listOf(item)).single()
+
+        assertEquals(42, result.id)
+        assertEquals("Movie", result.title)
+        assertEquals("2024", result.year)
+        assertEquals("Anime, Action", result.genres)
+        assertEquals("Japan", result.country)
+        assertEquals(mapper.buildDuration(item), result.duration)
+        assertEquals(3, result.ratings.size)
+    }
+
+    @Test
+    fun mapHeroItems_mapsSeriesSeasonCount() {
+        val item = testItem(
+            type = ItemType.SERIAL,
+            seasons = listOf(
+                Season(id = 1, number = 1),
+                Season(id = 2, number = 2),
+            ),
+        )
+
+        val result = mapper.mapHeroItems(listOf(item)).single()
+
+        assertEquals(
+            "string_${R.string.video_details_label_seasons}_2",
+            result.duration,
+        )
+    }
+
+    @Test
+    fun mapHeroItems_leavesDurationEmptyForSeriesWithoutSeasons() {
+        val item = testItem(
+            type = ItemType.SERIAL,
+            duration = Duration(total = 5 * 60),
+            seasons = null,
+        )
+
+        val result = mapper.mapHeroItems(listOf(item)).single()
+
+        assertEquals("", result.duration)
+    }
+
+    @Test
+    fun mapHeroItems_usesMovieDurationForNonSeriesWithSeasons() {
+        val item = testItem(
+            type = ItemType.MOVIE,
+            duration = Duration(total = 5 * 60),
+            seasons = listOf(
+                Season(id = 1, number = 1),
+                Season(id = 2, number = 2),
+            ),
+        )
+
+        val result = mapper.mapHeroItems(listOf(item)).single()
+
+        assertEquals(
+            "string_${R.string.video_details_label_duration}_" +
+                "string_${R.string.duration_minutes_only}_5",
+            result.duration,
+        )
+    }
+
+    // endregion
+
     private fun testItem(
         id: Int = 1,
         title: String = "Test",
         type: ItemType = ItemType.MOVIE,
+        year: Int? = null,
+        genres: List<Genre>? = null,
+        countries: List<Country>? = null,
+        duration: Duration? = null,
+        posters: Posters? = null,
+        seasons: List<Season>? = null,
+        kinopoiskRating: String? = null,
+        imdbRating: String? = null,
+        ratingPercentage: Int? = null,
         watched: Int? = null,
         new: Int? = null,
         subscribed: Boolean? = null,
@@ -125,6 +236,15 @@ class VideoItemUIMapperTest {
         id = id,
         title = title,
         type = type,
+        year = year,
+        genres = genres,
+        countries = countries,
+        duration = duration,
+        posters = posters,
+        seasons = seasons,
+        kinopoiskRating = kinopoiskRating,
+        imdbRating = imdbRating,
+        ratingPercentage = ratingPercentage,
         watched = watched,
         new = new,
         subscribed = subscribed,

--- a/app/src/test/kotlin/com/kino/puber/domain/interactor/contentlist/ContentListInteractorTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/domain/interactor/contentlist/ContentListInteractorTest.kt
@@ -14,6 +14,8 @@ import com.kino.puber.data.preferences.ContentPreferences
 import com.kino.puber.data.preferences.NavigationPreferencesRepository
 import com.kino.puber.ui.feature.contentlist.model.AnimeFilterMode
 import com.kino.puber.ui.feature.contentlist.model.SectionConfig
+import com.kino.puber.ui.feature.contentlist.model.TabTypeConfig
+import com.kino.puber.ui.feature.main.model.TabType
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -141,6 +143,71 @@ class ContentListInteractorTest {
         )
 
         assertEquals(listOf(anime), interactor.loadPage(config, page = 1).items)
+    }
+
+    @Test
+    fun heroConfig_routesShortcutRequestWithGenreAndRetainsOnlyAnime() = runTest {
+        val config = TabTypeConfig.heroConfigsFor(TabType.Anime)
+            .single { it.type == "serial" }
+        val anime = item(id = 1, title = "Anime", ANIME_GENRE_ID)
+        coEvery {
+            api.getItemsByShortcut("hot", "serial", 1, ANIME_GENRE_ID.toString())
+        } returns Result.success(
+            page(
+                anime,
+                item(id = 2, title = "Movie"),
+            )
+        )
+
+        val result = interactor.loadPage(config, page = 1)
+
+        assertEquals(listOf(anime), result.items)
+        coVerify(exactly = 1) {
+            api.getItemsByShortcut("hot", "serial", 1, ANIME_GENRE_ID.toString())
+        }
+        coVerify(exactly = 0) { api.getItems(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun cartoonHeroConfig_refillsAcrossShortcutPagesAndSuppressesDuplicateIds() = runTest {
+        val config = TabTypeConfig.heroConfigsFor(TabType.Cartoons)
+            .single { it.type == "movie" }
+        val firstCartoon = item(id = 2, title = "Cartoon 1", CARTOON_GENRE_ID)
+        val secondCartoon = item(id = 3, title = "Cartoon 2", CARTOON_GENRE_ID)
+        coEvery {
+            api.getItemsByShortcut("hot", "movie", 1, CARTOON_GENRE_ID.toString())
+        } returns Result.success(
+            page(
+                item(id = 1, title = "Anime", ANIME_GENRE_ID),
+                firstCartoon,
+                current = 1,
+                total = 2,
+                perpage = 2,
+            )
+        )
+        coEvery {
+            api.getItemsByShortcut("hot", "movie", 2, CARTOON_GENRE_ID.toString())
+        } returns Result.success(
+            page(
+                firstCartoon.copy(title = "Duplicate"),
+                secondCartoon,
+                current = 2,
+                total = 2,
+                perpage = 2,
+            )
+        )
+
+        val result = interactor.loadPage(config, page = 1)
+
+        assertEquals(listOf(firstCartoon, secondCartoon), result.items)
+        assertEquals(2, result.pagination.current)
+        coVerify(exactly = 1) {
+            api.getItemsByShortcut("hot", "movie", 1, CARTOON_GENRE_ID.toString())
+        }
+        coVerify(exactly = 1) {
+            api.getItemsByShortcut("hot", "movie", 2, CARTOON_GENRE_ID.toString())
+        }
+        coVerify(exactly = 0) { api.getItems(any(), any(), any(), any(), any()) }
     }
 
     @Test

--- a/app/src/test/kotlin/com/kino/puber/ui/feature/contentlist/model/TabTypeConfigTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/ui/feature/contentlist/model/TabTypeConfigTest.kt
@@ -54,6 +54,54 @@ class TabTypeConfigTest {
     }
 
     @Test
+    fun heroConfigs_useHotShortcutAndDistinctGenreFilters() {
+        val cartoons = TabTypeConfig.heroConfigsFor(TabType.Cartoons)
+        val anime = TabTypeConfig.heroConfigsFor(TabType.Anime)
+
+        assertEquals(listOf("movie", "serial"), cartoons.map(SectionConfig::type))
+        cartoons.forEach { config ->
+            assertEquals("hot", config.shortcut)
+            assertEquals(CARTOON_GENRE_ID.toString(), config.genre)
+            assertEquals(AnimeFilterMode.Exclude, config.animeFilterMode)
+        }
+        assertEquals(
+            listOf("hero_hot_cartoon_movie", "hero_hot_cartoon_serial"),
+            cartoons.map(SectionConfig::id),
+        )
+
+        assertEquals(listOf("movie", "serial"), anime.map(SectionConfig::type))
+        anime.forEach { config ->
+            assertEquals("hot", config.shortcut)
+            assertEquals(ANIME_GENRE_ID.toString(), config.genre)
+            assertEquals(AnimeFilterMode.Only, config.animeFilterMode)
+        }
+        assertEquals(
+            listOf("hero_hot_anime_movie", "hero_hot_anime_serial"),
+            anime.map(SectionConfig::id),
+        )
+
+        assertTrue(
+            cartoons.none { it.id in TabTypeConfig.sectionsFor(TabType.Cartoons).map(SectionConfig::id) },
+        )
+        assertTrue(
+            anime.none { it.id in TabTypeConfig.sectionsFor(TabType.Anime).map(SectionConfig::id) },
+        )
+    }
+
+    @Test
+    fun heroConfig_isAbsentForUnrelatedTabs() {
+        TabType.entries
+            .filterNot { it == TabType.Cartoons || it == TabType.Anime }
+            .forEach { tabType ->
+                assertEquals(
+                    emptyList<SectionConfig>(),
+                    TabTypeConfig.heroConfigsFor(tabType),
+                    "$tabType unexpectedly generated a hero config",
+                )
+            }
+    }
+
+    @Test
     fun unrelatedCatalogTabs_doNotFilterAnime() {
         val unfilteredTabs = listOf(
             TabType.For4k,

--- a/app/src/test/kotlin/com/kino/puber/ui/feature/contentlist/vm/ContentListVMTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/ui/feature/contentlist/vm/ContentListVMTest.kt
@@ -8,24 +8,32 @@ import com.kino.puber.core.ui.navigation.AppRouter
 import com.kino.puber.core.ui.navigation.PuberScreen
 import com.kino.puber.core.ui.navigation.RESULT_CONTENT_CHANGED
 import com.kino.puber.core.ui.navigation.Screens
+import com.kino.puber.core.ui.uikit.component.HeroItemState
 import com.kino.puber.core.ui.uikit.component.details.VideoDetailsUIState
 import com.kino.puber.core.ui.uikit.component.moviesList.VideoItemUIState
 import com.kino.puber.core.ui.uikit.model.CommonAction
 import com.kino.puber.data.api.models.Item
 import com.kino.puber.data.api.models.ItemType
+import com.kino.puber.data.api.models.PaginatedResponse
+import com.kino.puber.data.api.models.Pagination
 import com.kino.puber.data.preferences.NavigationPreferencesRepository
 import com.kino.puber.domain.interactor.contentlist.ContentListInteractor
 import com.kino.puber.domain.interactor.genre.GenreInteractor
 import com.kino.puber.ui.feature.contentlist.model.ContentListAction
 import com.kino.puber.ui.feature.contentlist.model.SectionConfig
+import com.kino.puber.ui.feature.contentlist.model.TabTypeConfig
 import com.kino.puber.ui.feature.showall.ShowAllScreen
+import com.kino.puber.ui.feature.main.model.TabType
 import com.kino.puber.util.MainDispatcherExtension
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.coVerify
 import io.mockk.verify
 import io.mockk.verifyOrder
+import kotlinx.coroutines.CompletableDeferred
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
@@ -65,6 +73,129 @@ class ContentListVMTest {
         vm.onAction(CommonAction.ItemSelected(videoItem(42)))
 
         verify { router.navigateForResult<ContentChangeSet>(screen, RESULT_CONTENT_CHANGED, any()) }
+    }
+
+    @Test
+    fun heroSelected_navigatesForContentChangeResultToDetails() {
+        val screen = mockk<PuberScreen>()
+        every { screens.details(42) } returns screen
+        val vm = createVM()
+
+        vm.onAction(ContentListAction.HeroSelected(42))
+
+        verify { router.navigateForResult<ContentChangeSet>(screen, RESULT_CONTENT_CHANGED, any()) }
+    }
+
+    @Test
+    fun animeHero_loadsAndCapsItemsAtTen() {
+        val configs = TabTypeConfig.heroConfigsFor(TabType.Anime)
+        val movieItems = (1..6).map { item(it, ratingPercentage = it) }
+        val serialItems = (7..12).map { item(it, ratingPercentage = it) }
+        val expectedItems = (movieItems + serialItems)
+            .sortedByDescending { it.ratingPercentage }
+            .take(10)
+        val mappedItems = expectedItems.map { heroItem(it.id) }
+        coEvery { interactor.loadPage(configs[0], page = 1) } returns page(movieItems)
+        coEvery { interactor.loadPage(configs[1], page = 1) } returns page(serialItems)
+        every { mapper.mapHeroItems(expectedItems) } returns mappedItems
+        val vm = createVM(heroConfigs = configs)
+
+        assertEquals(true, vm.testStateValue.isHeroLoading)
+        vm.testOnStart()
+        mainDispatcher.dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(mappedItems, vm.testStateValue.heroItems)
+        assertEquals(false, vm.testStateValue.isHeroLoading)
+        verify { mapper.mapHeroItems(expectedItems) }
+    }
+
+    @Test
+    fun cartoonHero_loadsUsingCartoonConfiguration() {
+        val config = TabTypeConfig.heroConfigsFor(TabType.Cartoons)
+            .single { it.type == "movie" }
+        val items = listOf(item(42))
+        val mappedItems = listOf(heroItem(42))
+        coEvery { interactor.loadPage(config, page = 1) } returns page(items)
+        every { mapper.mapHeroItems(items) } returns mappedItems
+        val vm = createVM(heroConfigs = listOf(config))
+
+        vm.testOnStart()
+        mainDispatcher.dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(mappedItems, vm.testStateValue.heroItems)
+        coVerify(exactly = 1) { interactor.loadPage(config, page = 1) }
+    }
+
+    @Test
+    fun unrelatedTab_doesNotRequestHero() {
+        val vm = createVM()
+
+        vm.testOnStart()
+        mainDispatcher.dispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 0) { interactor.loadPage(any(), any()) }
+        assertEquals(emptyList<HeroItemState>(), vm.testStateValue.heroItems)
+    }
+
+    @Test
+    fun heroFailure_keepsHeroEmptyWithoutReplacingContentState() {
+        val config = TabTypeConfig.heroConfigsFor(TabType.Anime).first()
+        coEvery { interactor.loadPage(config, page = 1) } throws IllegalStateException("network")
+        val vm = createVM(heroConfigs = listOf(config))
+
+        vm.testOnStart()
+        mainDispatcher.dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(emptyList<HeroItemState>(), vm.testStateValue.heroItems)
+        assertEquals(false, vm.testStateValue.isHeroLoading)
+    }
+
+    @Test
+    fun returnedContentChanges_reserveHeroSlotWhileReloadingAfterInitialEmptyResult() {
+        val config = TabTypeConfig.heroConfigsFor(TabType.Anime).first()
+        val screen = mockk<PuberScreen>()
+        val listener = slot<(ContentChangeSet?) -> Unit>()
+        val refreshedItem = item(43)
+        val refreshedPage = CompletableDeferred<PaginatedResponse<Item>>()
+        every { screens.details(42) } returns screen
+        var requestCount = 0
+        coEvery { interactor.loadPage(config, page = 1) } coAnswers {
+            requestCount += 1
+            if (requestCount == 1) page(emptyList()) else refreshedPage.await()
+        }
+        every { mapper.mapHeroItems(any()) } answers {
+            firstArg<List<Item>>().map { heroItem(it.id) }
+        }
+        val vm = createVM(heroConfigs = listOf(config))
+
+        vm.testOnStart()
+        mainDispatcher.dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(false, vm.testStateValue.isHeroLoading)
+        assertEquals(emptyList<HeroItemState>(), vm.testStateValue.heroItems)
+
+        vm.onAction(ContentListAction.HeroSelected(42))
+        verify {
+            router.navigateForResult<ContentChangeSet>(
+                screen,
+                RESULT_CONTENT_CHANGED,
+                capture(listener),
+            )
+        }
+
+        listener.captured(ContentChangeSet.single(42, ContentChangeType.Watched))
+        assertEquals(true, vm.testStateValue.isHeroLoading)
+        assertEquals(emptyList<HeroItemState>(), vm.testStateValue.heroItems)
+
+        refreshedPage.complete(page(listOf(refreshedItem)))
+        mainDispatcher.dispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 2) { interactor.loadPage(config, page = 1) }
+        verifyOrder {
+            interactor.invalidateFirstPageCache()
+            refreshCoordinator.requestRefresh()
+        }
+        assertEquals(false, vm.testStateValue.isHeroLoading)
+        assertEquals(listOf(heroItem(43)), vm.testStateValue.heroItems)
     }
 
     @Test
@@ -166,5 +297,41 @@ class ContentListVMTest {
         contentListRefreshCoordinator = refreshCoordinator,
     )
 
+    private fun createVM(heroConfigs: List<SectionConfig>) = ContentListVM(
+        router = router,
+        interactor = interactor,
+        mapper = mapper,
+        genreInteractor = mockk(relaxed = true),
+        navPrefs = mockk<NavigationPreferencesRepository>(relaxed = true) {
+            every { getNavigationMode() } returns NavigationMode.SideDrawer
+        },
+        contentListRefreshCoordinator = refreshCoordinator,
+        heroConfigs = heroConfigs,
+    )
+
     private fun videoItem(id: Int) = VideoItemUIState(id, "Item $id", "", "")
+
+    private fun item(
+        id: Int,
+        ratingPercentage: Int? = null,
+    ) = Item(
+        id = id,
+        title = "Item $id",
+        type = ItemType.MOVIE,
+        ratingPercentage = ratingPercentage,
+    )
+
+    private fun page(items: List<Item>) = PaginatedResponse(
+        items = items,
+        pagination = Pagination(current = 1, perpage = items.size, total = 1),
+    )
+
+    private fun heroItem(id: Int) = HeroItemState(
+        id = id,
+        title = "Hero $id",
+        wideImageUrl = "",
+        fallbackImageUrl = "",
+        year = "",
+        genres = "",
+    )
 }

--- a/app/src/test/kotlin/com/kino/puber/ui/feature/home/vm/HomeVMTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/ui/feature/home/vm/HomeVMTest.kt
@@ -3,6 +3,7 @@ package com.kino.puber.ui.feature.home.vm
 import com.kino.puber.core.content.ContentChangeSet
 import com.kino.puber.core.content.ContentChangeType
 import com.kino.puber.core.error.ErrorHandler
+import com.kino.puber.core.ui.model.VideoItemUIMapper
 import com.kino.puber.core.ui.navigation.AppRouter
 import com.kino.puber.core.ui.navigation.PuberScreen
 import com.kino.puber.core.ui.navigation.RESULT_CONTENT_CHANGED
@@ -43,6 +44,7 @@ class HomeVMTest {
     private lateinit var screens: Screens
     private lateinit var interactor: HomeInteractor
     private lateinit var mapper: HomeUIMapper
+    private lateinit var videoItemMapper: VideoItemUIMapper
     private lateinit var apiDomainInteractor: ApiDomainInteractor
     private lateinit var savedItemInteractor: SavedItemInteractor
     private lateinit var errorHandler: ErrorHandler
@@ -54,6 +56,7 @@ class HomeVMTest {
         every { router.screens } returns screens
         interactor = mockk(relaxed = true)
         mapper = mockk(relaxed = true)
+        videoItemMapper = mockk(relaxed = true)
         apiDomainInteractor = mockk(relaxed = true)
         savedItemInteractor = mockk(relaxed = true)
         errorHandler = mockk { every { proceed(any()) } returns { } }
@@ -71,7 +74,7 @@ class HomeVMTest {
         coEvery { interactor.getCollections() } returns Result.success(emptyList())
         every { mapper.mapItemSection(any(), any()) } returns null
         every { mapper.mapCollectionSection(any()) } returns null
-        every { mapper.mapHeroItems(any()) } returns emptyList()
+        every { videoItemMapper.mapHeroItems(any()) } returns emptyList()
     }
 
     @Test
@@ -150,7 +153,7 @@ class HomeVMTest {
         vm.testOnStart()
         mainDispatcher.dispatcher.scheduler.advanceUntilIdle()
 
-        verify { mapper.mapHeroItems(listOf(filteredHotItem)) }
+        verify { videoItemMapper.mapHeroItems(listOf(filteredHotItem)) }
         verify { mapper.mapItemSection(listOf(filteredHotItem), HomeSectionType.Hot) }
         verify { mapper.mapItemSection(listOf(personalWatchingItem), HomeSectionType.ContinueWatching) }
     }
@@ -159,6 +162,7 @@ class HomeVMTest {
         router = router,
         interactor = interactor,
         mapper = mapper,
+        videoItemMapper = videoItemMapper,
         apiDomainInteractor = apiDomainInteractor,
         savedItemInteractor = savedItemInteractor,
         resources = FakeResourceProvider(),


### PR DESCRIPTION
## Summary
- Add the Home-style hero carousel to the Anime and Cartoons content tabs.
- Load genre-filtered `hot` movie and serial feeds, merge/de-duplicate and cap hero items at ten.
- Share hero mapping with Home and preserve existing Popular/All rows and details navigation.

## Compliance Review
- Final Compliance Review: **PASS**.
- Task scope is limited to the 14 reviewed production/test files.
- Authority, repository contract, and workflow rules were unchanged and followed.
- Required runtime Smoke was completed; no bypass was used.

## Verification
- Focused unit tests for shared hero mapping, tab feed policy/interactor behavior, ViewModel loading/reload/navigation, and Home behavior: passed.
- Full app unit-test verification: passed.
- `./tools/agentw :app:compileDevDebugKotlin`: passed.
- Dev debug Android test assembly: passed.
- Runtime Smoke on locked Android TV emulator `emulator-5554` with a freshly assembled, installed, and launched stage APK: passed for carousel rendering, D-pad focus/page changes, details/Back restoration, row reachability, Side Drawer independence, settings restoration, foreground liveness, and absence of current-PID crash/ANR/fatal markers.
- Mobile evidence audit passed for 56 scoped files.

## Known skipped checks or blockers
- None.
