### PR TITLE
Release 1.6.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
     alias(libs.plugins.androidx.baselineprofile)
 }
 
-val currentVersion = "1.5.0"
+val currentVersion = "1.6.0"
 
 /**
  * Reads CLIENT_SECRET from local.properties or system environment variable


### PR DESCRIPTION
## Summary
- Bump the Puber app version from `1.5.0` to `1.6.0`.
- Prepare the minor release from the current `origin/master`.

## Compliance Review
- Passed with no compliance violations.
- The release branch contains only the authorized version change in `app/build.gradle.kts`.
- No `v1.6.0` tag was created or pushed before PR merge.

## Verification
- `./tools/agentw :app:compileDevDebugKotlin` — passed.
- `./tools/agentw :app:compileProdReleaseKotlin` — passed.
- Worktree was clean before push.

## Known limitation
- Release-signing secrets are unavailable in this environment, so production packaging with real signing was not locally proven. This is non-blocking for the version-bump PR under the release contract.

The `v1.6.0` tag must be created only after this PR is merged into `master`.