### PR TITLE
PUB-44: Add global remote hotkeys

### DIFF
--- a/app/src/androidTest/kotlin/com/kino/puber/core/ui/navigation/component/FlowComponentRemoteHotkeyTest.kt
+++ b/app/src/androidTest/kotlin/com/kino/puber/core/ui/navigation/component/FlowComponentRemoteHotkeyTest.kt
@@ -1,0 +1,183 @@
+package com.kino.puber.core.ui.navigation.component
+
+import android.app.Activity
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performSemanticsAction
+import com.kino.puber.core.ui.navigation.AppLauncher
+import com.kino.puber.core.ui.navigation.AppRemoteHotkeyHandler
+import com.kino.puber.core.ui.navigation.PuberScreen
+import com.kino.puber.core.ui.navigation.Screens
+import com.kino.puber.ui.feature.details.model.DetailsEpisodeTarget
+import com.kino.puber.ui.feature.history.model.HistoryPresentation
+import com.kino.puber.ui.feature.main.model.TabType
+import com.kino.puber.ui.feature.player.model.PlayerStartMode
+import kotlinx.parcelize.Parcelize
+import org.junit.Rule
+import org.junit.Test
+import org.koin.core.qualifier.named
+import org.koin.dsl.module
+
+private const val ROOT_TAG = "remote-hotkey-root"
+private const val SEARCH_TAG = "remote-hotkey-search"
+private const val SETTINGS_TAG = "remote-hotkey-settings"
+
+internal class FlowComponentRemoteHotkeyTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun unconsumedSearchKey_reachesRootHandlerAndNavigatesThroughRootRouter() {
+        setContent("search")
+
+        focusRoot()
+        composeRule.onNodeWithTag(ROOT_TAG).performKeyInput {
+            keyDown(Key.Search)
+            keyUp(Key.Search)
+        }
+
+        composeRule.onNodeWithTag(SEARCH_TAG).assertExists()
+    }
+
+    @Test
+    fun unconsumedSettingsKey_reachesRootHandlerAndNavigatesThroughRootRouter() {
+        setContent("settings")
+
+        focusRoot()
+        composeRule.onNodeWithTag(ROOT_TAG).performKeyInput {
+            keyDown(Key.Settings)
+            keyUp(Key.Settings)
+        }
+
+        composeRule.onNodeWithTag(SETTINGS_TAG).assertExists()
+    }
+
+    private fun setContent(scopeSuffix: String) {
+        composeRule.setContent {
+            FlowComponent(
+                scopeName = "FlowComponentRemoteHotkeyTest:$scopeSuffix",
+                screen = ProbeRootScreen,
+                remoteKeyHandler = AppRemoteHotkeyHandler::handle,
+                moduleFactory = { scopeId, _ ->
+                    module {
+                        scope(named(scopeId)) {
+                            scoped<AppLauncher> { NoOpAppLauncher }
+                            scoped<Screens> { ProbeScreens }
+                        }
+                    }
+                },
+            )
+        }
+    }
+
+    private fun focusRoot() {
+        composeRule
+            .onNodeWithTag(ROOT_TAG)
+            .performSemanticsAction(SemanticsActions.RequestFocus)
+    }
+}
+
+private object NoOpAppLauncher : AppLauncher {
+    override fun restart() = Unit
+
+    override fun finish() = Unit
+
+    override fun bind(activity: Activity) = Unit
+
+    override fun unbind() = Unit
+}
+
+private object ProbeScreens : Screens {
+    override fun auth(): PuberScreen = unsupported()
+
+    override fun main(): PuberScreen = unsupported()
+
+    override fun search(): PuberScreen = ProbeSearchScreen
+
+    override fun home(): PuberScreen = unsupported()
+
+    override fun history(presentation: HistoryPresentation): PuberScreen = unsupported()
+
+    override fun collections(): PuberScreen = unsupported()
+
+    override fun bookmarks(): PuberScreen = unsupported()
+
+    override fun favorites(): PuberScreen = unsupported()
+
+    override fun deviceSettings(): PuberScreen = ProbeSettingsScreen
+
+    override fun contentList(tabType: TabType): PuberScreen = unsupported()
+
+    override fun underDevelopment(): PuberScreen = unsupported()
+
+    override fun details(itemId: Int): PuberScreen = unsupported()
+
+    override fun details(
+        itemId: Int,
+        initialEpisode: DetailsEpisodeTarget,
+    ): PuberScreen = unsupported()
+
+    override fun player(
+        itemId: Int,
+        seasonNumber: Int?,
+        episodeNumber: Int?,
+        videoNumber: Int?,
+        startMode: PlayerStartMode,
+    ): PuberScreen = unsupported()
+
+    private fun unsupported(): Nothing {
+        error("Not used by the remote hotkey integration test")
+    }
+}
+
+@Parcelize
+private data object ProbeRootScreen : PuberScreen {
+    @Composable
+    override fun Content() {
+        BasicText(
+            text = "Root",
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag(ROOT_TAG)
+                .focusable(),
+        )
+    }
+}
+
+@Parcelize
+private data object ProbeSearchScreen : PuberScreen {
+    @Composable
+    override fun Content() {
+        BasicText(
+            text = "Search",
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag(SEARCH_TAG)
+                .focusable(),
+        )
+    }
+}
+
+@Parcelize
+private data object ProbeSettingsScreen : PuberScreen {
+    @Composable
+    override fun Content() {
+        BasicText(
+            text = "Settings",
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag(SETTINGS_TAG)
+                .focusable(),
+        )
+    }
+}

--- a/app/src/androidTest/kotlin/com/kino/puber/core/ui/uikit/component/TvContextMenuLongPressTest.kt
+++ b/app/src/androidTest/kotlin/com/kino/puber/core/ui/uikit/component/TvContextMenuLongPressTest.kt
@@ -1,6 +1,8 @@
 package com.kino.puber.core.ui.uikit.component
 
 import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -8,6 +10,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsProperties
@@ -91,29 +94,59 @@ internal class TvContextMenuLongPressTest {
         }
     }
 
-    private fun setContextMenuContent(onAction: () -> Unit) {
+    @Test
+    fun settingsKey_consumedByFocusedContextMenu_doesNotReachRootFallback() {
+        var rootFallbackInvocations = 0
+        setContextMenuContent(
+            onAction = {},
+            onRootKeyEvent = { rootFallbackInvocations += 1 },
+        )
+
+        composeRule.onNodeWithTag(SOURCE_TAG).performKeyInput {
+            keyDown(Key.Settings)
+        }
+
+        composeRule.onNodeWithText(MENU_TITLE).assertExists()
+        composeRule.runOnIdle {
+            assertEquals(0, rootFallbackInvocations)
+        }
+    }
+
+    private fun setContextMenuContent(
+        onAction: () -> Unit,
+        onRootKeyEvent: () -> Unit = {},
+    ) {
         composeRule.setContent {
             PuberTheme {
                 var menuVisible by remember { mutableStateOf(false) }
-                BasicText(
-                    text = "Open menu",
+                Box(
                     modifier = Modifier
-                        .testTag(SOURCE_TAG)
-                        .onTvContextMenuKey { menuVisible = true }
-                        .focusable(),
-                )
-                if (menuVisible) {
-                    TvContextMenuDialog(
-                        title = MENU_TITLE,
-                        actions = listOf(
-                            TvContextMenuAction(
-                                id = "first",
-                                title = FIRST_ACTION,
-                            ),
-                        ),
-                        onAction = { onAction() },
-                        onDismiss = { menuVisible = false },
+                        .fillMaxSize()
+                        .onKeyEvent {
+                            onRootKeyEvent()
+                            false
+                        },
+                ) {
+                    BasicText(
+                        text = "Open menu",
+                        modifier = Modifier
+                            .testTag(SOURCE_TAG)
+                            .onTvContextMenuKey { menuVisible = true }
+                            .focusable(),
                     )
+                    if (menuVisible) {
+                        TvContextMenuDialog(
+                            title = MENU_TITLE,
+                            actions = listOf(
+                                TvContextMenuAction(
+                                    id = "first",
+                                    title = FIRST_ACTION,
+                                ),
+                            ),
+                            onAction = { onAction() },
+                            onDismiss = { menuVisible = false },
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/kino/puber/core/ui/navigation/AppRemoteHotkeyHandler.kt
+++ b/app/src/main/java/com/kino/puber/core/ui/navigation/AppRemoteHotkeyHandler.kt
@@ -1,0 +1,46 @@
+package com.kino.puber.core.ui.navigation
+
+import android.view.KeyEvent
+
+internal interface GlobalRemoteHotkeyBlockedScreen
+
+internal enum class AppRemoteHotkeyAction {
+    Search,
+    Settings,
+}
+
+internal object AppRemoteHotkeyHandler {
+
+    fun handle(
+        event: KeyEvent,
+        router: AppRouter,
+        currentScreen: PuberScreen,
+    ): Boolean {
+        if (currentScreen is GlobalRemoteHotkeyBlockedScreen) {
+            return false
+        }
+
+        val action = event.keyCode.toRemoteHotkeyAction() ?: return false
+        if (event.action == KeyEvent.ACTION_DOWN && event.repeatCount == 0) {
+            val target = when (action) {
+                AppRemoteHotkeyAction.Search -> router.screens.search()
+                AppRemoteHotkeyAction.Settings -> router.screens.deviceSettings()
+            }
+            if (target.key != currentScreen.key) {
+                router.navigateTo(target)
+            }
+        }
+
+        return event.action == KeyEvent.ACTION_DOWN || event.action == KeyEvent.ACTION_UP
+    }
+
+    private fun Int.toRemoteHotkeyAction(): AppRemoteHotkeyAction? = when (this) {
+        KeyEvent.KEYCODE_SEARCH,
+        KeyEvent.KEYCODE_ASSIST,
+        KeyEvent.KEYCODE_VOICE_ASSIST,
+        -> AppRemoteHotkeyAction.Search
+
+        KeyEvent.KEYCODE_SETTINGS -> AppRemoteHotkeyAction.Settings
+        else -> null
+    }
+}

--- a/app/src/main/java/com/kino/puber/core/ui/navigation/component/FlowComponent.kt
+++ b/app/src/main/java/com/kino/puber/core/ui/navigation/component/FlowComponent.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -18,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
+import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.platform.LocalContext
 import cafe.adriel.voyager.core.screen.ScreenKey
 import cafe.adriel.voyager.navigator.LocalNavigator
@@ -72,6 +74,7 @@ fun FlowComponent(
     screen: PuberScreen = LoadingScreen,
     composableScope: CoroutineScope = rememberCoroutineScope(),
     moduleFactory: (scopeId: ScopeID, parentScope: Scope) -> Module = { _, _ -> module {} },
+    remoteKeyHandler: ((android.view.KeyEvent, AppRouter, PuberScreen) -> Boolean)? = null,
     content: @Composable () -> Unit = {},
 ) = DIScope(
     moduleFactory = { scopeId, parentScope ->
@@ -90,7 +93,20 @@ fun FlowComponent(
         screen = screen,
         onBackPressed = { onBackPressed(router) },
     ) {
-        CurrentScreen("currentScreen$scopeName")
+        val navigator = LocalNavigator.currentOrThrow
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .onKeyEvent { event ->
+                    remoteKeyHandler?.invoke(
+                        event.nativeKeyEvent,
+                        router,
+                        navigator.lastItem as PuberScreen,
+                    ) ?: false
+                },
+        ) {
+            CurrentScreen("currentScreen$scopeName")
+        }
         FlowCommandRunner(router)
     }
     content()

--- a/app/src/main/java/com/kino/puber/ui/feature/auth/component/AuthScreen.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/auth/component/AuthScreen.kt
@@ -2,6 +2,7 @@ package com.kino.puber.ui.feature.auth.component
 
 import androidx.compose.runtime.Composable
 import com.kino.puber.core.di.DIScope
+import com.kino.puber.core.ui.navigation.GlobalRemoteHotkeyBlockedScreen
 import com.kino.puber.core.ui.navigation.PuberScreen
 import com.kino.puber.ui.feature.auth.vm.AuthVM
 import kotlinx.parcelize.Parcelize
@@ -12,7 +13,7 @@ import org.koin.core.scope.ScopeID
 import org.koin.dsl.module
 
 @Parcelize
-internal class AuthScreen : PuberScreen {
+internal class AuthScreen : PuberScreen, GlobalRemoteHotkeyBlockedScreen {
 
     @Suppress("unused")
     private fun buildModule(scopeId: ScopeID, parentScope: Scope) = module {

--- a/app/src/main/java/com/kino/puber/ui/feature/root/component/App.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/root/component/App.kt
@@ -18,6 +18,7 @@ import com.kino.puber.core.ui.model.VideoItemTypeMapper
 import com.kino.puber.core.ui.model.VideoItemUIMapper
 import com.kino.puber.core.ui.navigation.AppLauncher
 import com.kino.puber.core.ui.navigation.AppLauncherImpl
+import com.kino.puber.core.ui.navigation.AppRemoteHotkeyHandler
 import com.kino.puber.core.ui.navigation.Screens
 import com.kino.puber.core.ui.navigation.component.FlowComponent
 import com.kino.puber.core.ui.uikit.theme.PuberTheme
@@ -90,6 +91,7 @@ fun App() {
             FlowComponent(
                 scopeName = ScopeRoot,
                 screen = LauncherScreen(),
+                remoteKeyHandler = AppRemoteHotkeyHandler::handle,
                 moduleFactory = { scopeId, parentScope ->
                     buildFlowModule(
                         scopeId,

--- a/app/src/main/java/com/kino/puber/ui/feature/root/component/LauncherScreen.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/root/component/LauncherScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.dp
 import com.kino.puber.R
 import com.kino.puber.core.di.DIScope
 import com.kino.puber.core.di.puberViewModel
+import com.kino.puber.core.ui.navigation.GlobalRemoteHotkeyBlockedScreen
 import com.kino.puber.core.ui.navigation.PuberScreen
 import com.kino.puber.ui.feature.root.vm.LauncherVM
 import kotlinx.parcelize.Parcelize
@@ -32,7 +33,7 @@ import org.koin.dsl.module
 private val SplashBackground = Color(0xFF1A0E2E)
 
 @Parcelize
-internal class LauncherScreen : PuberScreen {
+internal class LauncherScreen : PuberScreen, GlobalRemoteHotkeyBlockedScreen {
 
     @Suppress("unused")
     private fun buildModule(scopeId: ScopeID, parentScope: Scope) = module {

--- a/app/src/test/kotlin/com/kino/puber/core/ui/navigation/AppRemoteHotkeyHandlerTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/core/ui/navigation/AppRemoteHotkeyHandlerTest.kt
@@ -1,0 +1,138 @@
+package com.kino.puber.core.ui.navigation
+
+import android.view.KeyEvent
+import com.kino.puber.ui.feature.auth.component.AuthScreen
+import com.kino.puber.ui.feature.root.component.LauncherScreen
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class AppRemoteHotkeyHandlerTest {
+
+    private lateinit var router: AppRouter
+    private lateinit var screens: Screens
+    private lateinit var currentScreen: PuberScreen
+    private lateinit var searchScreen: PuberScreen
+    private lateinit var settingsScreen: PuberScreen
+
+    @BeforeEach
+    fun setUp() {
+        router = mockk(relaxed = true)
+        screens = mockk()
+        currentScreen = mockk()
+        searchScreen = mockk()
+        settingsScreen = mockk()
+
+        every { router.screens } returns screens
+        every { currentScreen.key } returns "CurrentScreen"
+        every { searchScreen.key } returns "SearchScreen"
+        every { settingsScreen.key } returns "SettingsScreen"
+        every { screens.search() } returns searchScreen
+        every { screens.deviceSettings() } returns settingsScreen
+    }
+
+    @Test
+    fun searchKeys_navigateToSearchOnFirstDown() {
+        listOf(
+            KeyEvent.KEYCODE_SEARCH,
+            KeyEvent.KEYCODE_ASSIST,
+            KeyEvent.KEYCODE_VOICE_ASSIST,
+        ).forEach { keyCode ->
+            assertTrue(handle(keyCode))
+        }
+
+        verify(exactly = 3) { router.navigateTo(searchScreen) }
+        verify(exactly = 3) { screens.search() }
+        verify(exactly = 0) { screens.deviceSettings() }
+    }
+
+    @Test
+    fun settingsKey_navigatesToDeviceSettingsOnFirstDown() {
+        assertTrue(handle(KeyEvent.KEYCODE_SETTINGS))
+
+        verify(exactly = 1) { router.navigateTo(settingsScreen) }
+        verify(exactly = 1) { screens.deviceSettings() }
+        verify(exactly = 0) { screens.search() }
+    }
+
+    @Test
+    fun recognizedKey_repeatedDownAndUpAreConsumedWithoutNavigatingAgain() {
+        assertTrue(handle(KeyEvent.KEYCODE_SEARCH))
+        assertTrue(handle(KeyEvent.KEYCODE_SEARCH, repeatCount = 1))
+        assertTrue(handle(KeyEvent.KEYCODE_SEARCH, action = KeyEvent.ACTION_UP))
+
+        verify(exactly = 1) { router.navigateTo(searchScreen) }
+        verify(exactly = 1) { screens.search() }
+    }
+
+    @Test
+    fun sameTarget_isConsumedWithoutPushingDuplicateDestination() {
+        every { currentScreen.key } returns searchScreen.key
+
+        assertTrue(handle(KeyEvent.KEYCODE_SEARCH))
+
+        verify(exactly = 1) { screens.search() }
+        verify(exactly = 0) { router.navigateTo(any()) }
+    }
+
+    @Test
+    fun unrelatedKeys_areLeftUnhandled() {
+        listOf(
+            KeyEvent.KEYCODE_MENU,
+            KeyEvent.KEYCODE_TV_CONTENTS_MENU,
+            KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE,
+            KeyEvent.KEYCODE_VOLUME_UP,
+        ).forEach { keyCode ->
+            assertFalse(handle(keyCode))
+        }
+
+        verify(exactly = 0) { router.navigateTo(any()) }
+        verify(exactly = 0) { screens.search() }
+        verify(exactly = 0) { screens.deviceSettings() }
+    }
+
+    @Test
+    fun nonDownOrUpAction_isLeftUnhandled() {
+        assertFalse(handle(KeyEvent.KEYCODE_SEARCH, action = KeyEvent.ACTION_MULTIPLE))
+
+        verify(exactly = 0) { router.navigateTo(any()) }
+        verify(exactly = 0) { screens.search() }
+    }
+
+    @Test
+    fun launcherAndAuthScreens_blockGlobalNavigation() {
+        listOf<PuberScreen>(LauncherScreen(), AuthScreen()).forEach { blockedScreen ->
+            assertFalse(
+                AppRemoteHotkeyHandler.handle(
+                    event = KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_SEARCH),
+                    router = router,
+                    currentScreen = blockedScreen,
+                )
+            )
+        }
+
+        verify(exactly = 0) { router.navigateTo(any()) }
+        verify(exactly = 0) { screens.search() }
+        verify(exactly = 0) { screens.deviceSettings() }
+    }
+
+    private fun handle(
+        keyCode: Int,
+        action: Int = KeyEvent.ACTION_DOWN,
+        repeatCount: Int = 0,
+    ): Boolean {
+        return AppRemoteHotkeyHandler.handle(
+            event = mockk {
+                every { this@mockk.keyCode } returns keyCode
+                every { this@mockk.action } returns action
+                every { this@mockk.repeatCount } returns repeatCount
+            },
+            router = router,
+            currentScreen = currentScreen,
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add global SEARCH, ASSIST, VOICE_ASSIST, and SETTINGS remote-key navigation.
- Preserve child-first context-menu handling and block global navigation on launcher/auth screens.
- Add deterministic handler, root-flow integration, and context-menu regression coverage.

## Compliance Review
PASS — no compliance violations found. Scope is limited to the reviewed PUB-44 production and test files.

## Verification
- `AppRemoteHotkeyHandlerTest`: all 7 tests passed.
- `./tools/agentw :app:compileDevDebugKotlin`: passed.
- `./tools/agentw :app:compileDevDebugAndroidTestKotlin`: passed.
- Android TV emulator-5554 Smoke: passed after fresh devDebug build/install/launch; SEARCH, SETTINGS, ASSIST/VOICE_ASSIST, context-menu precedence, Back restoration, and liveness verified.
- Mobile evidence audit: passed (`files_scanned=1`).
- Rebase replay onto fresh `origin/master`: passed in isolated temporary clone.

## Known skipped checks
No unresolved blockers or skipped required checks.