### PR TITLE
Fix Android TV focus restoration edge cases

### DIFF
--- a/app/src/androidTest/kotlin/com/kino/puber/core/ui/uikit/component/moviesList/VideoGridInitialFocusTest.kt
+++ b/app/src/androidTest/kotlin/com/kino/puber/core/ui/uikit/component/moviesList/VideoGridInitialFocusTest.kt
@@ -1,8 +1,18 @@
 package com.kino.puber.core.ui.uikit.component.moviesList
 
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotFocused
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.text.TextStyle
+import androidx.tv.material3.Text
 import com.kino.puber.core.ui.uikit.theme.PuberTheme
 import org.junit.Rule
 import org.junit.Test
@@ -23,7 +33,7 @@ internal class VideoGridInitialFocusTest {
                             listOf(
                                 VideoGridItemUIState.Title("Season $seasonNumber"),
                                 VideoGridItemUIState.Items(
-                                    listOf(
+                                    items = listOf(
                                         episode(
                                             id = seasonNumber * 100 + 1,
                                             seasonNumber = seasonNumber,
@@ -39,6 +49,7 @@ internal class VideoGridInitialFocusTest {
                                             )
                                         },
                                     ),
+                                    rowKey = "season_$seasonNumber",
                                 ),
                             )
                         },
@@ -49,6 +60,207 @@ internal class VideoGridInitialFocusTest {
         }
 
         composeRule.onNodeWithText(target.title).assertIsFocused()
+    }
+
+    @Test
+    fun changedInitialFocusedItemIdRefocusesTheRetainedRow() {
+        var initialFocusedItemId by mutableStateOf(1)
+        val state = VideoGridUIState(
+            list = listOf(
+                VideoGridItemUIState.Items(
+                    items = listOf(videoItem(1), videoItem(2), videoItem(3)),
+                    rowKey = "retained",
+                ),
+            ),
+        )
+        composeRule.setContent {
+            PuberTheme {
+                VideoGrid(
+                    state = state,
+                    initialFocusedItemId = initialFocusedItemId,
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Item 1").assertIsFocused()
+        composeRule.runOnIdle {
+            initialFocusedItemId = 3
+        }
+        composeRule.onNodeWithText("Item 3").assertIsFocused()
+    }
+
+    @Test
+    fun removingFocusedFirstItemFocusesTheRightNeighborAndNotSearch() {
+        assertRemovalFocus(
+            previousIds = listOf(1, 2, 3),
+            removedId = 1,
+            expectedId = 2,
+        )
+    }
+
+    @Test
+    fun removingFocusedMiddleItemFocusesTheRightNeighborAndNotSearch() {
+        assertRemovalFocus(
+            previousIds = listOf(1, 2, 3, 4),
+            removedId = 2,
+            expectedId = 3,
+        )
+    }
+
+    @Test
+    fun removingFocusedLastItemFocusesThePreviousItemAndNotSearch() {
+        assertRemovalFocus(
+            previousIds = listOf(1, 2, 3),
+            removedId = 3,
+            expectedId = 2,
+        )
+    }
+
+    @Test
+    fun removingOnlyItemFocusesTheNearestContentRowAndNotSearch() {
+        var state by mutableStateOf(
+            VideoGridUIState(
+                list = listOf(
+                    VideoGridItemUIState.Items(
+                        items = listOf(videoItem(1)),
+                        rowKey = "removed",
+                    ),
+                    VideoGridItemUIState.Items(
+                        items = listOf(videoItem(2)),
+                        rowKey = "remaining",
+                    ),
+                ),
+            ),
+        )
+        composeRule.setContent {
+            PuberTheme {
+                Column(Modifier.fillMaxSize()) {
+                    Text("Search", Modifier.focusable(), style = TextStyle.Default)
+                    VideoGrid(
+                        modifier = Modifier.weight(1f),
+                        state = state,
+                        initialFocusedItemId = 1,
+                    )
+                }
+            }
+        }
+
+        composeRule.onNodeWithText("Item 1").assertIsFocused()
+        composeRule.runOnIdle {
+            state = state.copy(
+                list = listOf(
+                    VideoGridItemUIState.Items(
+                        items = emptyList(),
+                        rowKey = "removed",
+                    ),
+                    VideoGridItemUIState.Items(
+                        items = listOf(videoItem(2)),
+                        rowKey = "remaining",
+                    ),
+                ),
+            )
+        }
+        composeRule.onNodeWithText("Item 2").assertIsFocused()
+        composeRule.onNodeWithText("Search").assertIsNotFocused()
+    }
+
+    @Test
+    fun removingFocusedRowFocusesTheRowNowAtTheSameIndexAndNotSearch() {
+        var state by mutableStateOf(
+            VideoGridUIState(
+                list = listOf(
+                    row(key = "before", itemId = 1),
+                    row(key = "removed", itemId = 2),
+                    row(key = "after", itemId = 3),
+                ),
+            ),
+        )
+        composeRule.setContent {
+            PuberTheme {
+                Column(Modifier.fillMaxSize()) {
+                    Text("Search", Modifier.focusable(), style = TextStyle.Default)
+                    VideoGrid(
+                        modifier = Modifier.weight(1f),
+                        state = state,
+                        initialFocusedItemId = 2,
+                    )
+                }
+            }
+        }
+
+        composeRule.onNodeWithText("Item 2").assertIsFocused()
+        composeRule.runOnIdle {
+            state = state.copy(
+                list = listOf(
+                    row(key = "before", itemId = 1),
+                    row(key = "after", itemId = 3),
+                ),
+            )
+        }
+        composeRule.onNodeWithText("Item 3").assertIsFocused()
+        composeRule.onNodeWithText("Search").assertIsNotFocused()
+    }
+
+    private fun assertRemovalFocus(
+        previousIds: List<Int>,
+        removedId: Int,
+        expectedId: Int,
+    ) {
+        var state by mutableStateOf(
+            VideoGridUIState(
+                list = listOf(
+                    VideoGridItemUIState.Items(
+                        items = previousIds.map(::videoItem),
+                        rowKey = "removable",
+                    ),
+                ),
+            ),
+        )
+        composeRule.setContent {
+            PuberTheme {
+                Column(Modifier.fillMaxSize()) {
+                    Text("Search", Modifier.focusable(), style = TextStyle.Default)
+                    VideoGrid(
+                        modifier = Modifier.weight(1f),
+                        state = state,
+                        initialFocusedItemId = removedId,
+                    )
+                }
+            }
+        }
+
+        composeRule.onNodeWithText("Item $removedId").assertIsFocused()
+        composeRule.runOnIdle {
+            state = state.copy(
+                list = listOf(
+                    VideoGridItemUIState.Items(
+                        items = previousIds
+                            .filterNot { it == removedId }
+                            .map(::videoItem),
+                        rowKey = "removable",
+                    ),
+                ),
+            )
+        }
+        composeRule.onNodeWithText("Item $expectedId").assertIsFocused()
+        composeRule.onNodeWithText("Search").assertIsNotFocused()
+    }
+
+    private fun videoItem(id: Int): VideoItemUIState {
+        return VideoItemUIState(
+            id = id,
+            title = "Item $id",
+            imageUrl = "",
+            bigImageUrl = "",
+            showTitle = true,
+        )
+    }
+
+    private fun row(key: String, itemId: Int): VideoGridItemUIState.Items {
+        return VideoGridItemUIState.Items(
+            items = listOf(videoItem(itemId)),
+            rowKey = key,
+        )
     }
 
     private fun episode(

--- a/app/src/androidTest/kotlin/com/kino/puber/ui/feature/contentlist/content/SectionRowFocusTraversalTest.kt
+++ b/app/src/androidTest/kotlin/com/kino/puber/ui/feature/contentlist/content/SectionRowFocusTraversalTest.kt
@@ -1,0 +1,286 @@
+package com.kino.puber.ui.feature.contentlist.content
+
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.hasAnyDescendant
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isFocused
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.dp
+import com.kino.puber.core.ui.uikit.component.PositionFocusedItemInLazyLayout
+import com.kino.puber.core.ui.uikit.component.moviesList.VideoItemUIState
+import com.kino.puber.core.ui.uikit.theme.PuberTheme
+import com.kino.puber.ui.feature.contentlist.model.SectionConfig
+import com.kino.puber.ui.feature.contentlist.model.SectionState
+import kotlin.math.abs
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+internal class SectionRowFocusTraversalTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun dpadFocusOnNonFallbackItemInNonTargetRowRecordsActualIdentity() {
+        var focusedItemId: Int? = null
+        composeRule.setContent {
+            PuberTheme {
+                SectionRowContent(
+                    state = SectionState.Content(
+                        items = listOf(item(0, 0), item(0, 1), item(0, 2)),
+                    ),
+                    config = SectionConfig(id = "row_0", title = "Row 0"),
+                    isTargetRow = false,
+                    onItemClick = {},
+                    onItemContextMenu = {},
+                    onItemFocused = { focusedItemId = it.id },
+                    onSectionFocused = {},
+                    onRetry = {},
+                    onLoadMore = {},
+                )
+            }
+        }
+
+        requestFocus(itemTitle(row = 0, column = 0))
+        composeRule.runOnIdle {
+            focusedItemId = null
+        }
+        pressCurrent(Key.DirectionRight)
+
+        composeRule.runOnIdle {
+            assertEquals(1, focusedItemId)
+        }
+        composeRule.onNodeWithText(itemTitle(row = 0, column = 1)).assertIsFocused()
+    }
+
+    @Test
+    fun downToEndRightThenUpRestoresGenericRowTargetsInsideViewport() {
+        val rows = (0 until ROW_COUNT).map { rowIndex ->
+            RowFixture(
+                config = SectionConfig(id = "row_$rowIndex", title = "Row $rowIndex"),
+                state = SectionState.Content(
+                    items = listOf(
+                        item(rowIndex, 0),
+                        item(rowIndex, 1),
+                        item(rowIndex, 2),
+                    ),
+                ),
+            )
+        }
+        var focusedRowIndex by mutableIntStateOf(0)
+        val trace = mutableStateOf<List<FocusTarget>>(emptyList())
+
+        composeRule.setContent {
+            PuberTheme {
+                Box(
+                    Modifier
+                        .fillMaxWidth()
+                        .height(VIEWPORT_HEIGHT)
+                        .testTag(VIEWPORT_TAG),
+                ) {
+                    PositionFocusedItemInLazyLayout(keepFullyVisibleItemInPlace = true) {
+                        LazyColumn(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(VIEWPORT_HEIGHT)
+                                .focusGroup(),
+                        ) {
+                            items(rows, key = { it.config.id }) { row ->
+                                SectionRowContent(
+                                    state = row.state,
+                                    config = row.config,
+                                    isTargetRow = rows.indexOf(row) == focusedRowIndex,
+                                    onItemClick = {},
+                                    onItemContextMenu = {},
+                                    onItemFocused = { item ->
+                                        trace.value += FocusTarget(
+                                            row = row.config.id,
+                                            item = item.id,
+                                        )
+                                    },
+                                    onSectionFocused = {
+                                        focusedRowIndex = rows.indexOf(row)
+                                    },
+                                    onRetry = {},
+                                    onLoadMore = {},
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        requestFocus(itemTitle(0, 0))
+        seedStableTargets()
+        composeRule.runOnIdle {
+            trace.value = emptyList()
+        }
+
+        val snapshots = buildList {
+            repeat(ROW_COUNT - 1) {
+                add(pressCurrentAndCapture(Key.DirectionDown, trace))
+            }
+            add(pressCurrentAndCapture(Key.DirectionRight, trace))
+            repeat(ROW_COUNT - 1) {
+                add(pressCurrentAndCapture(Key.DirectionUp, trace))
+            }
+        }
+        val expected = buildList {
+            add(FocusTarget("row_1", 11))
+            add(FocusTarget("row_2", 20))
+            add(FocusTarget("row_3", 31))
+            add(FocusTarget("row_4", 41))
+            add(FocusTarget("row_4", 42))
+            add(FocusTarget("row_3", 31))
+            add(FocusTarget("row_2", 20))
+            add(FocusTarget("row_1", 11))
+            add(FocusTarget("row_0", 0))
+        }
+
+        assertEquals(
+            "generic settled focus trace for Down-to-end → Right → Up; " +
+                "raw focus callbacks=${trace.value}",
+            expected,
+            snapshots.map(FocusSnapshot::target),
+        )
+        assertBoundsAndViewport(snapshots)
+    }
+
+    private fun seedStableTargets() {
+        repeat(ROW_COUNT - 1) { index ->
+            val row = index + 1
+            pressCurrent(Key.DirectionDown)
+            requestFocus(
+                when (row) {
+                    1, 3, 4 -> itemTitle(row, 1)
+                    else -> itemTitle(row, 0)
+                },
+            )
+        }
+        repeat(ROW_COUNT - 1) {
+            pressCurrent(Key.DirectionUp)
+        }
+        requestFocus(itemTitle(0, 0))
+    }
+
+    private fun requestFocus(title: String) {
+        composeRule
+            .onNodeWithText(title)
+            .performSemanticsAction(SemanticsActions.RequestFocus)
+            .assertIsFocused()
+        composeRule.waitForIdle()
+    }
+
+    private fun pressCurrent(key: Key) {
+        composeRule
+            .onNode(focusedCardMatcher, useUnmergedTree = true)
+            .performKeyInput {
+                keyDown(key)
+                keyUp(key)
+            }
+        composeRule.waitForIdle()
+    }
+
+    private fun pressCurrentAndCapture(
+        key: Key,
+        trace: androidx.compose.runtime.State<List<FocusTarget>>,
+    ): FocusSnapshot {
+        pressCurrent(key)
+        val target = trace.value.last()
+        val row = target.row.removePrefix("row_").toInt()
+        val column = target.item % 10
+        val bounds = composeRule
+            .onNodeWithText(itemTitle(row, column))
+            .assertIsFocused()
+            .getUnclippedBoundsInRoot()
+        return FocusSnapshot(target = target, bounds = bounds)
+    }
+
+    private fun assertBoundsAndViewport(snapshots: List<FocusSnapshot>) {
+        val viewport = composeRule.onNodeWithTag(VIEWPORT_TAG).getUnclippedBoundsInRoot()
+        snapshots.forEach { snapshot ->
+            assertTrue(
+                "${snapshot.target} top ${snapshot.bounds.top} is above viewport ${viewport.top}",
+                snapshot.bounds.top.value >= viewport.top.value - BOUNDS_TOLERANCE,
+            )
+            assertTrue(
+                "${snapshot.target} bottom ${snapshot.bounds.bottom} is below viewport ${viewport.bottom}",
+                snapshot.bounds.bottom.value <= viewport.bottom.value + BOUNDS_TOLERANCE,
+            )
+        }
+        snapshots.zipWithNext().forEach { (before, after) ->
+            assertTrue(
+                "vertical focus delta from ${before.target} to ${after.target} was " +
+                    "${abs(after.bounds.top.value - before.bounds.top.value)}dp",
+                abs(after.bounds.top.value - before.bounds.top.value) <= MAX_VERTICAL_DELTA.value,
+            )
+        }
+        assertVerticalBoundsEqual(
+            before = snapshots[ROW_COUNT - 2].bounds,
+            after = snapshots[ROW_COUNT - 1].bounds,
+        )
+    }
+
+    private fun assertVerticalBoundsEqual(before: DpRect, after: DpRect) {
+        assertEquals("top after Right", before.top.value, after.top.value, BOUNDS_TOLERANCE)
+        assertEquals("bottom after Right", before.bottom.value, after.bottom.value, BOUNDS_TOLERANCE)
+    }
+
+    private data class RowFixture(
+        val config: SectionConfig,
+        val state: SectionState.Content,
+    )
+
+    private data class FocusTarget(
+        val row: String,
+        val item: Int,
+    )
+
+    private data class FocusSnapshot(
+        val target: FocusTarget,
+        val bounds: DpRect,
+    )
+
+    private companion object {
+        const val ROW_COUNT = 5
+        const val VIEWPORT_TAG = "section_traversal_viewport"
+        const val BOUNDS_TOLERANCE = 1f
+        val VIEWPORT_HEIGHT = 420.dp
+        val MAX_VERTICAL_DELTA = 210.dp
+        val focusedCardMatcher = isFocused() and hasAnyDescendant(
+            hasText("row-", substring = true),
+        )
+
+        fun item(row: Int, column: Int) = VideoItemUIState(
+            id = row * 10 + column,
+            title = itemTitle(row, column),
+            imageUrl = "",
+            bigImageUrl = "",
+        )
+
+        fun itemTitle(row: Int, column: Int) = "row-$row-item-$column"
+    }
+}

--- a/app/src/androidTest/kotlin/com/kino/puber/ui/feature/details/component/DetailsScreenContentTest.kt
+++ b/app/src/androidTest/kotlin/com/kino/puber/ui/feature/details/component/DetailsScreenContentTest.kt
@@ -157,7 +157,7 @@ internal class DetailsScreenContentTest {
                 listOf(
                     VideoGridItemUIState.Title("Season $seasonNumber"),
                     VideoGridItemUIState.Items(
-                        listOf(
+                        items = listOf(
                             episode(
                                 id = seasonNumber * 100 + 1,
                                 seasonNumber = seasonNumber,
@@ -178,6 +178,7 @@ internal class DetailsScreenContentTest {
                                 )
                             },
                         ),
+                        rowKey = "season_$seasonNumber",
                     ),
                 )
             },

--- a/app/src/androidTest/kotlin/com/kino/puber/ui/feature/home/component/HomeFocusTraversalTest.kt
+++ b/app/src/androidTest/kotlin/com/kino/puber/ui/feature/home/component/HomeFocusTraversalTest.kt
@@ -1,0 +1,238 @@
+package com.kino.puber.ui.feature.home.component
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isFocused
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.dp
+import com.kino.puber.core.ui.uikit.component.moviesList.VideoItemUIState
+import com.kino.puber.core.ui.uikit.theme.PuberTheme
+import com.kino.puber.ui.feature.home.model.HomeSectionState
+import com.kino.puber.ui.feature.home.model.HomeSectionType
+import com.kino.puber.ui.feature.home.model.HomeViewState
+import kotlin.math.abs
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+internal class HomeFocusTraversalTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun dpadFocusOnNonFallbackItemInNonTargetHomeRowRecordsActualIdentity() {
+        var focusedItemId: Int? = null
+        composeRule.setContent {
+            PuberTheme {
+                HomeSectionRow(
+                    rowKey = "home_row",
+                    items = listOf(item(0, 0), item(0, 1), item(0, 2)),
+                    isTargetRow = false,
+                    onSectionFocused = {},
+                    onItemClick = {},
+                    onItemContextMenu = null,
+                    onItemFocused = { focusedItemId = it.id },
+                    onRowEmpty = {},
+                )
+            }
+        }
+
+        requestFocus(itemTitle(row = 0, column = 0))
+        composeRule.runOnIdle {
+            focusedItemId = null
+        }
+        pressCurrent(Key.DirectionRight)
+
+        composeRule.runOnIdle {
+            assertEquals(1, focusedItemId)
+        }
+        composeRule.onNodeWithText(itemTitle(row = 0, column = 1)).assertIsFocused()
+    }
+
+    @Test
+    fun downToEndRightThenUpRestoresHomeRowTargetsInsideViewport() {
+        val sections = HOME_ROW_TYPES.mapIndexed { row, type ->
+            HomeSectionState(
+                title = "Home row $row",
+                type = type,
+                items = (0 until ITEM_COUNT).map { column -> item(row, column) },
+            )
+        }
+        composeRule.setContent {
+            PuberTheme {
+                HomeScreenContent(
+                    state = HomeViewState.Content(sections = sections),
+                    onAction = {},
+                    onHeroClick = {},
+                    onCollectionClick = { _, _ -> },
+                )
+            }
+        }
+
+        requestFocus(itemTitle(0, 0))
+        seedStableTargets()
+
+        val snapshots = buildList {
+            repeat(HOME_ROW_TYPES.lastIndex) {
+                add(pressCurrentAndCapture(Key.DirectionDown))
+            }
+            add(pressCurrentAndCapture(Key.DirectionRight))
+            repeat(HOME_ROW_TYPES.lastIndex) {
+                add(pressCurrentAndCapture(Key.DirectionUp))
+            }
+        }
+        val expected = buildList {
+            add(FocusTarget(HomeSectionType.WatchLater.name, 11))
+            add(FocusTarget(HomeSectionType.Bookmarks.name, 20))
+            add(FocusTarget(HomeSectionType.Fresh.name, 31))
+            add(FocusTarget(HomeSectionType.PopularMovies.name, 41))
+            add(FocusTarget(HomeSectionType.PopularMovies.name, 42))
+            add(FocusTarget(HomeSectionType.Fresh.name, 31))
+            add(FocusTarget(HomeSectionType.Bookmarks.name, 20))
+            add(FocusTarget(HomeSectionType.WatchLater.name, 11))
+            add(FocusTarget(HomeSectionType.ContinueWatching.name, 0))
+        }
+
+        assertEquals(
+            "Home focus trace for Down-to-end → Right → Up",
+            expected,
+            snapshots.map(FocusSnapshot::target),
+        )
+        assertBoundsAndViewport(snapshots)
+    }
+
+    private fun seedStableTargets() {
+        repeat(HOME_ROW_TYPES.lastIndex) { index ->
+            val row = index + 1
+            pressCurrent(Key.DirectionDown)
+            requestFocus(
+                when (row) {
+                    1, 3, 4 -> itemTitle(row, 1)
+                    else -> itemTitle(row, 0)
+                },
+            )
+        }
+        repeat(HOME_ROW_TYPES.lastIndex) {
+            pressCurrent(Key.DirectionUp)
+        }
+        requestFocus(itemTitle(0, 0))
+    }
+
+    private fun requestFocus(title: String) {
+        composeRule
+            .onNodeWithText(title)
+            .performSemanticsAction(SemanticsActions.RequestFocus)
+            .assertIsFocused()
+        composeRule.waitForIdle()
+    }
+
+    private fun pressCurrent(key: Key) {
+        focusedCard().performKeyInput {
+            keyDown(key)
+            keyUp(key)
+        }
+        composeRule.waitForIdle()
+    }
+
+    private fun pressCurrentAndCapture(key: Key): FocusSnapshot {
+        pressCurrent(key)
+        val focusedCard = focusedCard()
+        val title = focusedCard.fetchSemanticsNode()
+            .config[SemanticsProperties.Text]
+            .joinToString(separator = " ") { it.text }
+        val match = requireNotNull(ITEM_TITLE_PATTERN.find(title)) {
+            "Focused Home card has no item identity: $title"
+        }
+        val row = match.groupValues[1].toInt()
+        val column = match.groupValues[2].toInt()
+        return FocusSnapshot(
+            target = FocusTarget(
+                row = HOME_ROW_TYPES[row].name,
+                item = row * 10 + column,
+            ),
+            bounds = focusedCard.getUnclippedBoundsInRoot(),
+        )
+    }
+
+    private fun focusedCard(): SemanticsNodeInteraction {
+        return composeRule.onNode(
+            isFocused() and hasText(ITEM_TITLE_PREFIX, substring = true),
+        )
+    }
+
+    private fun assertBoundsAndViewport(snapshots: List<FocusSnapshot>) {
+        val viewport = composeRule.onRoot().getUnclippedBoundsInRoot()
+        snapshots.forEach { snapshot ->
+            assertTrue(
+                "${snapshot.target} top ${snapshot.bounds.top} is above viewport ${viewport.top}",
+                snapshot.bounds.top.value >= viewport.top.value - BOUNDS_TOLERANCE,
+            )
+            assertTrue(
+                "${snapshot.target} bottom ${snapshot.bounds.bottom} is below viewport ${viewport.bottom}",
+                snapshot.bounds.bottom.value <= viewport.bottom.value + BOUNDS_TOLERANCE,
+            )
+        }
+        snapshots.zipWithNext().forEach { (before, after) ->
+            assertTrue(
+                "vertical focus delta from ${before.target} to ${after.target} was " +
+                    "${abs(after.bounds.top.value - before.bounds.top.value)}dp",
+                abs(after.bounds.top.value - before.bounds.top.value) <= MAX_VERTICAL_DELTA.value,
+            )
+        }
+        assertVerticalBoundsEqual(
+            before = snapshots[HOME_ROW_TYPES.lastIndex - 1].bounds,
+            after = snapshots[HOME_ROW_TYPES.lastIndex].bounds,
+        )
+    }
+
+    private fun assertVerticalBoundsEqual(before: DpRect, after: DpRect) {
+        assertEquals("top after Right", before.top.value, after.top.value, BOUNDS_TOLERANCE)
+        assertEquals("bottom after Right", before.bottom.value, after.bottom.value, BOUNDS_TOLERANCE)
+    }
+
+    private data class FocusTarget(
+        val row: String,
+        val item: Int,
+    )
+
+    private data class FocusSnapshot(
+        val target: FocusTarget,
+        val bounds: DpRect,
+    )
+
+    private companion object {
+        const val ITEM_COUNT = 3
+        const val ITEM_TITLE_PREFIX = "home-row-"
+        const val BOUNDS_TOLERANCE = 1f
+        val MAX_VERTICAL_DELTA = 240.dp
+        val ITEM_TITLE_PATTERN = Regex("""home-row-(\d+)-item-(\d+)""")
+        val HOME_ROW_TYPES = listOf(
+            HomeSectionType.ContinueWatching,
+            HomeSectionType.WatchLater,
+            HomeSectionType.Bookmarks,
+            HomeSectionType.Fresh,
+            HomeSectionType.PopularMovies,
+        )
+
+        fun item(row: Int, column: Int) = VideoItemUIState(
+            id = row * 10 + column,
+            title = itemTitle(row, column),
+            imageUrl = "",
+            bigImageUrl = "",
+        )
+
+        fun itemTitle(row: Int, column: Int) = "home-row-$row-item-$column"
+    }
+}

--- a/app/src/androidTest/kotlin/com/kino/puber/ui/feature/home/component/HomeSectionRemovalFocusTest.kt
+++ b/app/src/androidTest/kotlin/com/kino/puber/ui/feature/home/component/HomeSectionRemovalFocusTest.kt
@@ -1,18 +1,47 @@
 package com.kino.puber.ui.feature.home.component
 
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotFocused
+import androidx.compose.ui.test.hasAnyDescendant
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isFocused
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performKeyInput
 import androidx.compose.ui.test.performSemanticsAction
+import com.adamglin.PhosphorIcons
+import com.adamglin.phosphoricons.Duotone
+import com.adamglin.phosphoricons.duotone.House
+import com.kino.puber.core.di.DIScope
+import com.kino.puber.core.ui.navigation.PuberScreen
+import com.kino.puber.core.ui.navigation.PuberTab
+import com.kino.puber.core.ui.navigation.TabRouter
+import com.kino.puber.core.ui.navigation.component.TabAppRouterHolder
 import com.kino.puber.core.ui.uikit.component.moviesList.VideoItemUIState
 import com.kino.puber.core.ui.uikit.theme.PuberTheme
+import com.kino.puber.ui.ScreensImpl
 import com.kino.puber.ui.feature.home.model.HomeSectionState
 import com.kino.puber.ui.feature.home.model.HomeSectionType
 import com.kino.puber.ui.feature.home.model.HomeViewState
+import com.kino.puber.ui.feature.main.model.MainTab
+import com.kino.puber.ui.feature.main.model.MainViewState
+import com.kino.puber.ui.feature.main.model.TabType
+import com.kino.puber.ui.feature.main.toptabs.TopTabMainContent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.parcelize.Parcelize
+import org.junit.After
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
@@ -20,6 +49,90 @@ internal class HomeSectionRemovalFocusTest {
 
     @get:Rule
     val composeRule = createComposeRule()
+
+    private lateinit var coroutineScope: CoroutineScope
+    private lateinit var tabRouter: TabRouter
+    private lateinit var tabAppRouterHolder: TabAppRouterHolder
+
+    @Before
+    fun setUp() {
+        coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        tabRouter = TabRouter(coroutineScope)
+        tabAppRouterHolder = TabAppRouterHolder(ScreensImpl)
+        TopTabHomeRemovalProbeHost.reset()
+    }
+
+    @After
+    fun tearDown() {
+        composeRule.runOnIdle { tabAppRouterHolder.dispose() }
+        TopTabHomeRemovalProbeHost.reset()
+        coroutineScope.cancel()
+    }
+
+    @Test
+    fun removingFocusedFirstCardFocusesTheRightNeighborAndNotSearch() {
+        assertRetainedRowRemovalFocus(
+            previousIds = listOf(1, 2, 3),
+            removedId = 1,
+            expectedId = 2,
+        )
+    }
+
+    @Test
+    fun removingFocusedMiddleCardFocusesTheRightNeighborAndNotSearch() {
+        assertRetainedRowRemovalFocus(
+            previousIds = listOf(1, 2, 3, 4),
+            removedId = 2,
+            expectedId = 3,
+        )
+    }
+
+    @Test
+    fun removingFocusedLastCardFocusesThePreviousCardAndNotSearch() {
+        assertRetainedRowRemovalFocus(
+            previousIds = listOf(1, 2, 3),
+            removedId = 3,
+            expectedId = 2,
+        )
+    }
+
+    @Test
+    fun removingCardWhileSearchIsFocusedDoesNotStealTopChromeFocus() {
+        val previousIds = listOf(1, 2, 3)
+        setTopTabHomeContent(
+            homeState(
+                sections = listOf(
+                    section(
+                        type = HomeSectionType.ContinueWatching,
+                        title = "Retained",
+                        itemIds = previousIds,
+                    ),
+                ),
+            )
+        )
+
+        focusCard(previousIds = previousIds, targetId = 2)
+        val productionSearch = productionSearchControl()
+        productionSearch
+            .performSemanticsAction(SemanticsActions.RequestFocus)
+            .assertIsFocused()
+        composeRule.waitForIdle()
+
+        composeRule.runOnIdle {
+            TopTabHomeRemovalProbeHost.state = homeState(
+                sections = listOf(
+                    section(
+                        type = HomeSectionType.ContinueWatching,
+                        title = "Retained",
+                        itemIds = previousIds.filterNot { it == 2 },
+                    ),
+                ),
+            )
+        }
+
+        productionSearch.assertIsFocused()
+        composeRule.onNodeWithText(cardTitle(3)).assertIsNotFocused()
+    }
 
     @Test
     fun removingTheFocusedSectionSelectsTheReplacementSection() {
@@ -58,6 +171,144 @@ internal class HomeSectionRemovalFocusTest {
         composeRule.onNodeWithText("Replacement card").assertIsFocused()
     }
 
+    private fun assertRetainedRowRemovalFocus(
+        previousIds: List<Int>,
+        removedId: Int,
+        expectedId: Int,
+    ) {
+        setTopTabHomeContent(
+            homeState(
+                sections = listOf(
+                    section(
+                        type = HomeSectionType.ContinueWatching,
+                        title = "Retained",
+                        itemIds = previousIds,
+                    ),
+                ),
+            )
+        )
+
+        val productionSearch = productionSearchControl()
+        productionSearch
+            .assertExists()
+            .performSemanticsAction(SemanticsActions.RequestFocus)
+            .assertIsFocused()
+        composeRule.waitForIdle()
+
+        focusCard(previousIds = previousIds, targetId = removedId)
+        productionSearch.assertIsNotFocused()
+
+        composeRule.runOnIdle {
+            TopTabHomeRemovalProbeHost.state = homeState(
+                sections = listOf(
+                    section(
+                        type = HomeSectionType.ContinueWatching,
+                        title = "Retained",
+                        itemIds = previousIds.filterNot { it == removedId },
+                    ),
+                ),
+            )
+        }
+
+        composeRule.onNodeWithText(cardTitle(expectedId)).assertIsFocused()
+        productionSearch.assertIsNotFocused()
+    }
+
+    private fun focusCard(
+        previousIds: List<Int>,
+        targetId: Int,
+    ) {
+        val targetIndex = previousIds.indexOf(targetId)
+        check(targetIndex >= 0)
+        composeRule
+            .onNodeWithText(cardTitle(previousIds.first()))
+            .performSemanticsAction(SemanticsActions.RequestFocus)
+            .assertIsFocused()
+
+        repeat(targetIndex) { index ->
+            composeRule
+                .onNodeWithText(cardTitle(previousIds[index]))
+                .performKeyInput {
+                    keyDown(Key.DirectionRight)
+                    keyUp(Key.DirectionRight)
+                }
+            composeRule
+                .onNodeWithText(cardTitle(previousIds[index + 1]))
+                .assertIsFocused()
+        }
+    }
+
+    private fun setTopTabHomeContent(state: HomeViewState) {
+        TopTabHomeRemovalProbeHost.state = state
+        composeRule.setContent {
+            PuberTheme {
+                DIScope(scopeName = "HomeSectionRemovalFocusTest") {
+                    TopTabMainContent(
+                        state = homeMainState(),
+                        onAction = {},
+                        tabRouter = tabRouter,
+                        tabAppRouterHolder = tabAppRouterHolder,
+                        onSearchClick = {},
+                        onSettingsClick = {},
+                    )
+                }
+            }
+        }
+        composeRule.runOnIdle {
+            tabRouter.openTab(
+                PuberTab(
+                    screen = TopTabHomeRemovalProbeScreen,
+                    tag = TabType.Home,
+                ),
+            )
+        }
+        composeRule.waitUntil {
+            composeRule
+                .onAllNodes(hasText("Retained card", substring = true))
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        composeRule.waitUntil {
+            composeRule
+                .onAllNodes(
+                    matcher = isFocused() and hasAnyDescendant(hasText("Home")),
+                    useUnmergedTree = true,
+                )
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+    }
+
+    private fun productionSearchControl() = composeRule.onNode(
+        matcher = hasClickAction() and hasAnyDescendant(hasContentDescription("Search")),
+        useUnmergedTree = true,
+    )
+
+    private fun homeMainState() = MainViewState(
+        tabs = listOf(
+            MainTab(
+                type = TabType.Home,
+                label = "Home",
+                icon = PhosphorIcons.Duotone.House,
+                isSelected = true,
+            ),
+        ),
+        selectedTab = TabType.Home,
+    )
+
+    @Parcelize
+    private data object TopTabHomeRemovalProbeScreen : PuberScreen {
+        @Composable
+        override fun Content() {
+            HomeScreenContent(
+                state = TopTabHomeRemovalProbeHost.state,
+                onAction = {},
+                onHeroClick = {},
+                onCollectionClick = { _, _ -> },
+            )
+        }
+    }
+
     private fun homeState(
         sections: List<HomeSectionState>,
     ) = HomeViewState.Content(sections = sections)
@@ -65,16 +316,33 @@ internal class HomeSectionRemovalFocusTest {
     private fun section(
         type: HomeSectionType,
         title: String,
+        itemIds: List<Int> = listOf(title.hashCode()),
     ) = HomeSectionState(
         title = "$title section",
         type = type,
-        items = listOf(
+        items = itemIds.map { id ->
             VideoItemUIState(
-                id = title.hashCode(),
-                title = "$title card",
+                id = id,
+                title = if (itemIds.size == 1 && id == title.hashCode()) {
+                    "$title card"
+                } else {
+                    cardTitle(id)
+                },
                 imageUrl = "",
                 bigImageUrl = "",
-            ),
-        ),
+            )
+        },
     )
+
+    private companion object {
+        fun cardTitle(id: Int) = "Retained card $id"
+    }
+}
+
+private object TopTabHomeRemovalProbeHost {
+    var state by mutableStateOf<HomeViewState>(HomeViewState.Content())
+
+    fun reset() {
+        state = HomeViewState.Content()
+    }
 }

--- a/app/src/androidTest/kotlin/com/kino/puber/ui/feature/home/component/HomeSectionRemovalFocusTest.kt
+++ b/app/src/androidTest/kotlin/com/kino/puber/ui/feature/home/component/HomeSectionRemovalFocusTest.kt
@@ -1,0 +1,80 @@
+package com.kino.puber.ui.feature.home.component
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performSemanticsAction
+import com.kino.puber.core.ui.uikit.component.moviesList.VideoItemUIState
+import com.kino.puber.core.ui.uikit.theme.PuberTheme
+import com.kino.puber.ui.feature.home.model.HomeSectionState
+import com.kino.puber.ui.feature.home.model.HomeSectionType
+import com.kino.puber.ui.feature.home.model.HomeViewState
+import org.junit.Rule
+import org.junit.Test
+
+internal class HomeSectionRemovalFocusTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun removingTheFocusedSectionSelectsTheReplacementSection() {
+        var state by mutableStateOf(
+            homeState(
+                sections = listOf(
+                    section(HomeSectionType.ContinueWatching, "Focused"),
+                    section(HomeSectionType.Fresh, "Replacement"),
+                ),
+            ),
+        )
+        composeRule.setContent {
+            PuberTheme {
+                HomeScreenContent(
+                    state = state,
+                    onAction = {},
+                    onHeroClick = {},
+                    onCollectionClick = { _, _ -> },
+                )
+            }
+        }
+
+        composeRule
+            .onNodeWithText("Focused card")
+            .performSemanticsAction(SemanticsActions.RequestFocus)
+            .assertIsFocused()
+
+        composeRule.runOnIdle {
+            state = homeState(
+                sections = listOf(
+                    section(HomeSectionType.Fresh, "Replacement"),
+                ),
+            )
+        }
+
+        composeRule.onNodeWithText("Replacement card").assertIsFocused()
+    }
+
+    private fun homeState(
+        sections: List<HomeSectionState>,
+    ) = HomeViewState.Content(sections = sections)
+
+    private fun section(
+        type: HomeSectionType,
+        title: String,
+    ) = HomeSectionState(
+        title = "$title section",
+        type = type,
+        items = listOf(
+            VideoItemUIState(
+                id = title.hashCode(),
+                title = "$title card",
+                imageUrl = "",
+                bigImageUrl = "",
+            ),
+        ),
+    )
+}

--- a/app/src/androidTest/kotlin/com/kino/puber/ui/feature/main/toptabs/TopTabDetailsBackFocusTest.kt
+++ b/app/src/androidTest/kotlin/com/kino/puber/ui/feature/main/toptabs/TopTabDetailsBackFocusTest.kt
@@ -1,0 +1,498 @@
+package com.kino.puber.ui.feature.main.toptabs
+
+import android.app.Activity
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.ComposeTimeoutException
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isFocused
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.DpRect
+import androidx.tv.material3.Button
+import androidx.tv.material3.Text
+import com.adamglin.PhosphorIcons
+import com.adamglin.phosphoricons.Duotone
+import com.adamglin.phosphoricons.duotone.FilmSlate
+import com.adamglin.phosphoricons.duotone.House
+import com.kino.puber.core.di.LocalPuberKoinScope
+import com.kino.puber.core.ui.navigation.AppLauncher
+import com.kino.puber.core.ui.navigation.AppRouter
+import com.kino.puber.core.ui.navigation.PuberScreen
+import com.kino.puber.core.ui.navigation.PuberTab
+import com.kino.puber.core.ui.navigation.RootPuberScreen
+import com.kino.puber.core.ui.navigation.Screens
+import com.kino.puber.core.ui.navigation.TabRouter
+import com.kino.puber.core.ui.navigation.component.FlowComponent
+import com.kino.puber.core.ui.navigation.component.PreserveLazyListAnchorOnRootReturn
+import com.kino.puber.core.ui.navigation.component.TabAppRouterHolder
+import com.kino.puber.core.ui.uikit.component.PositionFocusedItemInLazyLayout
+import com.kino.puber.core.ui.uikit.component.moviesList.VideoItemUIState
+import com.kino.puber.core.ui.uikit.model.CommonAction
+import com.kino.puber.core.ui.uikit.theme.PuberTheme
+import com.kino.puber.ui.ScreensImpl
+import com.kino.puber.ui.feature.contentlist.content.SectionRowContent
+import com.kino.puber.ui.feature.contentlist.model.SectionConfig
+import com.kino.puber.ui.feature.contentlist.model.SectionState
+import com.kino.puber.ui.feature.home.component.HomeScreenContent
+import com.kino.puber.ui.feature.home.model.HomeSectionState
+import com.kino.puber.ui.feature.home.model.HomeSectionType
+import com.kino.puber.ui.feature.home.model.HomeViewState
+import com.kino.puber.ui.feature.main.model.MainTab
+import com.kino.puber.ui.feature.main.model.MainViewState
+import com.kino.puber.ui.feature.main.model.TabType
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.parcelize.Parcelize
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.koin.core.qualifier.named
+import org.koin.dsl.module
+
+private const val FOCUSED_TITLE = "row-4-item-1"
+private const val DETAILS_TAG = "details_destination"
+private const val BACK_TAG = "details_back"
+private const val BOUNDS_TOLERANCE = 1f
+private const val MAX_FOCUSED_NODE_DIAGNOSTICS = 5
+
+internal class TopTabDetailsBackFocusTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun homeDetailsBackRestoresFocusedCardAndViewport() {
+        detailsBackRestoresFocusedCardAndViewport(
+            tabType = TabType.Home,
+            tabScreen = TopTabHomeProbeScreen,
+        )
+    }
+
+    @Test
+    fun nonHomeDetailsBackRestoresFocusedCardAndViewport() {
+        detailsBackRestoresFocusedCardAndViewport(
+            tabType = TabType.Movies,
+            tabScreen = TopTabNonHomeProbeScreen,
+        )
+    }
+
+    private fun detailsBackRestoresFocusedCardAndViewport(
+        tabType: TabType,
+        tabScreen: PuberScreen,
+    ) {
+        val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        val tabRouter = TabRouter(coroutineScope)
+        val tabAppRouterHolder = TabAppRouterHolder(ScreensImpl)
+        TopTabDetailsProbeHost.bind(tabRouter, tabAppRouterHolder, tabType)
+
+        try {
+            composeRule.setContent {
+                PuberTheme {
+                    FlowComponent(
+                        scopeName = "TopTabDetailsBackFocusTest_${tabType.name}",
+                        screen = TopTabDetailsProbeHostScreen,
+                        moduleFactory = { scopeId, _ ->
+                            module {
+                                scope(named(scopeId)) {
+                                    scoped<AppLauncher> { TopTabDetailsNoOpAppLauncher }
+                                    scoped<Screens> { ScreensImpl }
+                                }
+                            }
+                        },
+                    )
+                }
+            }
+            composeRule.runOnIdle {
+                tabRouter.openTab(
+                    PuberTab(
+                        screen = tabScreen,
+                        tag = tabType,
+                    ),
+                )
+            }
+            composeRule.waitUntil(timeoutMillis = 1_500) {
+                composeRule
+                    .onAllNodes(hasText("row-0-item-0"))
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }
+            composeRule.mainClock.advanceTimeBy(200)
+
+            composeRule
+                .onNodeWithText("row-0-item-0")
+                .performSemanticsAction(SemanticsActions.RequestFocus)
+                .assertIsFocused()
+            repeat(4) { row ->
+                composeRule
+                    .onNodeWithText("row-$row-item-0")
+                    .performDirectionDown()
+                composeRule.waitForIdle()
+            }
+            composeRule
+                .onNodeWithText("row-4-item-0")
+                .performDirectionRight()
+            composeRule.mainClock.advanceTimeBy(1_000)
+            composeRule.waitForIdle()
+
+            val focusedCard = composeRule.onNodeWithText(FOCUSED_TITLE)
+            focusedCard.assertIsFocused()
+            val viewportBounds = composeRule.onRoot().getUnclippedBoundsInRoot()
+            val settledBounds = focusedCard.getUnclippedBoundsInRoot()
+            assertCardInsideViewport(settledBounds, viewportBounds)
+            composeRule.waitForIdle()
+            val boundsBefore = settledBounds
+            val anchorBefore = composeRule.runOnIdle {
+                TopTabDetailsProbeHost.anchor(tabType)
+            }
+
+            focusedCard.performSelect()
+            composeRule.onNodeWithTag(DETAILS_TAG).assertExists()
+            composeRule.runOnIdle {
+                TopTabDetailsProbeHost.back()
+            }
+            composeRule.waitUntil(timeoutMillis = 1_500) {
+                composeRule
+                    .onAllNodes(hasTestTag(DETAILS_TAG))
+                    .fetchSemanticsNodes()
+                    .isEmpty()
+            }
+
+            composeRule.waitUntil(timeoutMillis = 1_500) {
+                composeRule
+                    .onAllNodes(hasText("row-", substring = true))
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }
+            composeRule.waitUntil(timeoutMillis = 1_500) {
+                TopTabDetailsProbeHost.anchor(tabType) == anchorBefore
+            }
+            val anchorAfter = composeRule.runOnIdle {
+                TopTabDetailsProbeHost.anchor(tabType)
+            }
+            assertEquals("lazy anchor", anchorBefore, anchorAfter)
+            try {
+                composeRule.waitUntil(timeoutMillis = 1_500) {
+                    composeRule
+                        .onAllNodes(isFocused() and hasText(FOCUSED_TITLE))
+                        .fetchSemanticsNodes()
+                        .isNotEmpty()
+                }
+            } catch (error: ComposeTimeoutException) {
+                throw AssertionError(
+                    "Expected $FOCUSED_TITLE after anchor restoration; focused nodes=" +
+                        focusedNodeSummary(),
+                    error,
+                )
+            }
+            val restoredCard = composeRule.onNode(isFocused() and hasText(FOCUSED_TITLE))
+            restoredCard.assertIsFocused()
+            val boundsAfter = restoredCard.getUnclippedBoundsInRoot()
+            assertRectEquals(boundsBefore, boundsAfter)
+        } finally {
+            composeRule.runOnIdle { tabAppRouterHolder.dispose() }
+            coroutineScope.cancel()
+            TopTabDetailsProbeHost.clear()
+        }
+    }
+
+    private fun assertRectEquals(before: DpRect, after: DpRect) {
+        assertEquals("left", before.left.value, after.left.value, BOUNDS_TOLERANCE)
+        assertEquals("top", before.top.value, after.top.value, BOUNDS_TOLERANCE)
+        assertEquals("right", before.right.value, after.right.value, BOUNDS_TOLERANCE)
+        assertEquals("bottom", before.bottom.value, after.bottom.value, BOUNDS_TOLERANCE)
+    }
+
+    private fun assertCardInsideViewport(card: DpRect, viewport: DpRect) {
+        org.junit.Assert.assertTrue(
+            "focused card top ${card.top} is above viewport ${viewport.top}",
+            card.top.value >= viewport.top.value - BOUNDS_TOLERANCE,
+        )
+        org.junit.Assert.assertTrue(
+            "focused card bottom ${card.bottom} is below viewport ${viewport.bottom}",
+            card.bottom.value <= viewport.bottom.value + BOUNDS_TOLERANCE,
+        )
+    }
+
+    private fun focusedNodeSummary(): List<String> {
+        return composeRule
+            .onAllNodes(isFocused(), useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .take(MAX_FOCUSED_NODE_DIAGNOSTICS)
+            .map { node ->
+                val text = node.config
+                    .getOrNull(SemanticsProperties.Text)
+                    ?.joinToString(separator = "|") { it.text }
+                val tag = node.config.getOrNull(SemanticsProperties.TestTag)
+                "text=$text, tag=$tag, bounds=${node.boundsInRoot}"
+            }
+    }
+
+    private fun androidx.compose.ui.test.SemanticsNodeInteraction.performDirectionDown() {
+        performKeyInput {
+            keyDown(androidx.compose.ui.input.key.Key.DirectionDown)
+            keyUp(androidx.compose.ui.input.key.Key.DirectionDown)
+        }
+    }
+
+    private fun androidx.compose.ui.test.SemanticsNodeInteraction.performDirectionRight() {
+        performKeyInput {
+            keyDown(androidx.compose.ui.input.key.Key.DirectionRight)
+            keyUp(androidx.compose.ui.input.key.Key.DirectionRight)
+        }
+    }
+
+    private fun androidx.compose.ui.test.SemanticsNodeInteraction.performSelect() {
+        performKeyInput {
+            keyDown(androidx.compose.ui.input.key.Key.DirectionCenter)
+            keyUp(androidx.compose.ui.input.key.Key.DirectionCenter)
+        }
+    }
+}
+
+private object TopTabDetailsProbeHost {
+    private var tabRouter: TabRouter? = null
+    private var tabAppRouterHolder: TabAppRouterHolder? = null
+    private var selectedTab: TabType? = null
+    private var rootRouter: AppRouter? = null
+    private val lazyListStates = mutableMapOf<TabType, LazyListState>()
+
+    fun bind(
+        tabRouter: TabRouter,
+        tabAppRouterHolder: TabAppRouterHolder,
+        selectedTab: TabType,
+    ) {
+        this.tabRouter = tabRouter
+        this.tabAppRouterHolder = tabAppRouterHolder
+        this.selectedTab = selectedTab
+    }
+
+    fun clear() {
+        tabRouter = null
+        tabAppRouterHolder = null
+        selectedTab = null
+        rootRouter = null
+        lazyListStates.clear()
+    }
+
+    fun requireTabRouter(): TabRouter = requireNotNull(tabRouter)
+
+    fun requireTabAppRouterHolder(): TabAppRouterHolder = requireNotNull(tabAppRouterHolder)
+
+    fun requireSelectedTab(): TabType = requireNotNull(selectedTab)
+
+    fun recordRootRouter(router: AppRouter) {
+        rootRouter = router
+    }
+
+    fun recordLazyListState(tabType: TabType, state: LazyListState) {
+        lazyListStates[tabType] = state
+    }
+
+    fun back() {
+        requireNotNull(rootRouter).back()
+    }
+
+    fun anchor(tabType: TabType): LazyAnchor {
+        val state = requireNotNull(lazyListStates[tabType])
+        return LazyAnchor(
+            index = state.firstVisibleItemIndex,
+            offset = state.firstVisibleItemScrollOffset,
+        )
+    }
+}
+
+@Parcelize
+private data object TopTabDetailsProbeHostScreen : PuberScreen {
+    @Composable
+    override fun Content() {
+        val rootRouter = requireNotNull(LocalPuberKoinScope.current).get<AppRouter>()
+        val selectedTab = TopTabDetailsProbeHost.requireSelectedTab()
+        SideEffect {
+            TopTabDetailsProbeHost.recordRootRouter(rootRouter)
+        }
+        TopTabMainContent(
+            state = MainViewState(
+                tabs = listOf(
+                    MainTab(
+                        type = TabType.Home,
+                        label = "Главная",
+                        icon = PhosphorIcons.Duotone.House,
+                        isSelected = selectedTab == TabType.Home,
+                    ),
+                    MainTab(
+                        type = TabType.Movies,
+                        label = "Фильмы",
+                        icon = PhosphorIcons.Duotone.FilmSlate,
+                        isSelected = selectedTab == TabType.Movies,
+                    ),
+                ),
+                selectedTab = selectedTab,
+            ),
+            onAction = {},
+            tabRouter = TopTabDetailsProbeHost.requireTabRouter(),
+            tabAppRouterHolder = TopTabDetailsProbeHost.requireTabAppRouterHolder(),
+            onSearchClick = {},
+            onSettingsClick = {},
+        )
+    }
+}
+
+@Parcelize
+private data object TopTabHomeProbeScreen : PuberScreen {
+    @Composable
+    override fun Content() {
+        val router = requireNotNull(LocalPuberKoinScope.current).get<AppRouter>()
+        val listState = rememberLazyListState()
+        SideEffect {
+            TopTabDetailsProbeHost.recordLazyListState(TabType.Home, listState)
+        }
+        HomeScreenContent(
+            state = HomeViewState.Content(
+                sections = (0..5).map { row ->
+                    HomeSectionState(
+                        title = "Row $row",
+                        type = HomeSectionType.values()[row],
+                        items = (0..2).map { column ->
+                            VideoItemUIState(
+                                id = row * 10 + column,
+                                title = "row-$row-item-$column",
+                                imageUrl = "",
+                                bigImageUrl = "",
+                                showTitle = true,
+                            )
+                        },
+                    )
+                },
+            ),
+            onAction = { action ->
+                if (action is CommonAction.ItemSelected<*>) {
+                    router.navigateTo(TopTabDetailsProbeDetailsScreen)
+                }
+            },
+            onHeroClick = {},
+            onCollectionClick = { _, _ -> },
+            lazyListState = listState,
+        )
+    }
+}
+
+@Parcelize
+private data object TopTabNonHomeProbeScreen : PuberScreen {
+    @Composable
+    override fun Content() {
+        val router = requireNotNull(LocalPuberKoinScope.current).get<AppRouter>()
+        val listState = rememberLazyListState()
+        val focusedSectionIndex = rememberSaveable { mutableIntStateOf(0) }
+        PreserveLazyListAnchorOnRootReturn(listState)
+        SideEffect {
+            TopTabDetailsProbeHost.recordLazyListState(TabType.Movies, listState)
+        }
+        val rows = (0..5).map { row ->
+            NonHomeRow(
+                config = SectionConfig(id = "row-$row", title = "Row $row"),
+                state = SectionState.Content(
+                    items = (0..2).map { column ->
+                        VideoItemUIState(
+                            id = row * 10 + column,
+                            title = "row-$row-item-$column",
+                            imageUrl = "",
+                            bigImageUrl = "",
+                            showTitle = true,
+                        )
+                    },
+                ),
+            )
+        }
+
+        PositionFocusedItemInLazyLayout(keepFullyVisibleItemInPlace = true) {
+            LazyColumn(
+                state = listState,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .focusGroup(),
+            ) {
+                items(rows, key = { it.config.id }) { row ->
+                    val rowIndex = rows.indexOf(row)
+                    SectionRowContent(
+                        state = row.state,
+                        config = row.config,
+                        isTargetRow = rowIndex == focusedSectionIndex.intValue,
+                        onItemClick = {
+                            router.navigateTo(TopTabDetailsProbeDetailsScreen)
+                        },
+                        onItemContextMenu = {},
+                        onItemFocused = {},
+                        onSectionFocused = {
+                            focusedSectionIndex.intValue = rowIndex
+                        },
+                        onRetry = {},
+                        onLoadMore = {},
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Parcelize
+private data object TopTabDetailsProbeDetailsScreen : RootPuberScreen {
+    @Composable
+    override fun Content() {
+        val router = requireNotNull(LocalPuberKoinScope.current).get<AppRouter>()
+        Column {
+            Text(text = "Details", modifier = Modifier.testTag(DETAILS_TAG))
+            Button(
+                onClick = router::back,
+                modifier = Modifier.testTag(BACK_TAG),
+            ) {
+                Text("Back")
+            }
+        }
+    }
+}
+
+private data object TopTabDetailsNoOpAppLauncher : AppLauncher {
+    override fun restart() = Unit
+
+    override fun finish() = Unit
+
+    override fun bind(activity: Activity) = Unit
+
+    override fun unbind() = Unit
+}
+
+private data class NonHomeRow(
+    val config: SectionConfig,
+    val state: SectionState.Content,
+)
+
+private data class LazyAnchor(
+    val index: Int,
+    val offset: Int,
+)

--- a/app/src/androidTest/kotlin/com/kino/puber/ui/feature/main/toptabs/TopTabRapidSwitchingFocusTest.kt
+++ b/app/src/androidTest/kotlin/com/kino/puber/ui/feature/main/toptabs/TopTabRapidSwitchingFocusTest.kt
@@ -1,0 +1,269 @@
+package com.kino.puber.ui.feature.main.toptabs
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasAnyDescendant
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isFocused
+import androidx.compose.ui.test.isSelected
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.platform.testTag
+import androidx.tv.material3.Text
+import com.adamglin.PhosphorIcons
+import com.adamglin.phosphoricons.Duotone
+import com.adamglin.phosphoricons.duotone.FilmSlate
+import com.adamglin.phosphoricons.duotone.House
+import com.adamglin.phosphoricons.duotone.TelevisionSimple
+import com.kino.puber.core.di.DIScope
+import com.kino.puber.core.ui.navigation.PuberScreen
+import com.kino.puber.core.ui.navigation.PuberTab
+import com.kino.puber.core.ui.navigation.TabRouter
+import com.kino.puber.core.ui.navigation.component.TabAppRouterHolder
+import com.kino.puber.core.ui.uikit.model.CommonAction
+import com.kino.puber.core.ui.uikit.theme.PuberTheme
+import com.kino.puber.ui.ScreensImpl
+import com.kino.puber.ui.feature.main.model.MainTab
+import com.kino.puber.ui.feature.main.model.MainViewState
+import com.kino.puber.ui.feature.main.model.TabType
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+internal class TopTabRapidSwitchingFocusTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private lateinit var coroutineScope: CoroutineScope
+    private lateinit var tabRouter: TabRouter
+    private lateinit var tabAppRouterHolder: TabAppRouterHolder
+
+    @Before
+    fun setUp() {
+        coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        tabRouter = TabRouter(coroutineScope)
+        tabAppRouterHolder = TabAppRouterHolder(ScreensImpl)
+    }
+
+    @After
+    fun tearDown() {
+        composeRule.runOnIdle { tabAppRouterHolder.dispose() }
+        coroutineScope.cancel()
+    }
+
+    @Test
+    fun oneToThreeTransitionsPerSecondConvergeAtEverySettlePoint() {
+        var selectedTabFromAction = TabType.Home
+        composeRule.mainClock.autoAdvance = false
+
+        composeRule.setContent {
+            PuberTheme {
+                DIScope(scopeName = "TopTabRapidSwitchingFocusTest") {
+                    RapidSwitchingHost(
+                        tabRouter = tabRouter,
+                        tabAppRouterHolder = tabAppRouterHolder,
+                        onTabSelected = { selectedTabFromAction = it },
+                    )
+                }
+            }
+        }
+        composeRule.runOnIdle {
+            tabRouter.openTab(
+                PuberTab(
+                    screen = TopTabRapidProbeScreen(TabType.Home),
+                    tag = TabType.Home,
+                ),
+            )
+        }
+        composeRule.mainClock.advanceTimeBy(INITIAL_SETTLE_MS)
+        composeRule.waitForIdle()
+
+        assertConverged(TabType.Home, selectedTabFromAction)
+
+        transitionAndAssert(Key.DirectionRight, THREE_TRANSITIONS_PER_SECOND_MS, TabType.Movies) {
+            selectedTabFromAction
+        }
+        transitionAndAssert(Key.DirectionRight, THREE_TRANSITIONS_PER_SECOND_MS, TabType.Series) {
+            selectedTabFromAction
+        }
+        transitionAndAssert(Key.DirectionLeft, TWO_TRANSITIONS_PER_SECOND_MS, TabType.Movies) {
+            selectedTabFromAction
+        }
+        transitionAndAssert(Key.DirectionLeft, TWO_TRANSITIONS_PER_SECOND_MS, TabType.Home) {
+            selectedTabFromAction
+        }
+        transitionAndAssert(Key.DirectionRight, ONE_TRANSITION_PER_SECOND_MS, TabType.Movies) {
+            selectedTabFromAction
+        }
+        transitionAndAssert(Key.DirectionRight, ONE_TRANSITION_PER_SECOND_MS, TabType.Series) {
+            selectedTabFromAction
+        }
+    }
+
+    private fun transitionAndAssert(
+        key: Key,
+        intervalMillis: Long,
+        expectedTab: TabType,
+        selectedTab: () -> TabType,
+    ) {
+        focusedTab(tabLabel(expectedTab.previous(key))).performDirection(key)
+        composeRule.mainClock.advanceTimeBy(intervalMillis)
+        composeRule.waitForIdle()
+        assertConverged(expectedTab, selectedTab())
+    }
+
+    private fun assertConverged(expectedTab: TabType, selectedTab: TabType) {
+        rapidTabTypes.forEach { tabType ->
+            val label = tabLabel(tabType)
+            if (tabType == expectedTab) {
+                focusedTab(label).assertIsFocused()
+                selectedTab(label).assertExists()
+            } else {
+                focusedTab(label).assertDoesNotExist()
+                selectedTab(label).assertDoesNotExist()
+            }
+        }
+        composeRule
+            .onNodeWithTag("tab_content_${expectedTab.name.lowercase()}")
+            .assertIsDisplayed()
+        composeRule.runOnIdle {
+            assertEquals(expectedTab, selectedTab)
+        }
+    }
+
+    private fun focusedTab(label: String) = composeRule.onNode(
+        isFocused() and tabWithLabel(label),
+        useUnmergedTree = true,
+    )
+
+    private fun selectedTab(label: String) = composeRule.onNode(
+        isSelected() and tabWithLabel(label),
+        useUnmergedTree = true,
+    )
+
+    private fun tabWithLabel(label: String) = hasAnyDescendant(hasText(label))
+
+    private fun androidx.compose.ui.test.SemanticsNodeInteraction.performDirection(key: Key) =
+        performKeyInput {
+            keyDown(key)
+            keyUp(key)
+        }
+}
+
+@Composable
+private fun RapidSwitchingHost(
+    tabRouter: TabRouter,
+    tabAppRouterHolder: TabAppRouterHolder,
+    onTabSelected: (TabType) -> Unit,
+) {
+    var selectedTab by remember { mutableStateOf(TabType.Home) }
+    TopTabMainContent(
+        state = MainViewState(
+            tabs = rapidTabs(selectedTab),
+            selectedTab = selectedTab,
+        ),
+        onAction = { action ->
+            if (action is CommonAction.ItemSelected<*>) {
+                val tab = action.item as MainTab
+                selectedTab = tab.type
+                onTabSelected(tab.type)
+                tabRouter.openTab(
+                    PuberTab(
+                        screen = TopTabRapidProbeScreen(tab.type),
+                        tag = tab.type,
+                    ),
+                )
+            }
+        },
+        tabRouter = tabRouter,
+        tabAppRouterHolder = tabAppRouterHolder,
+        onSearchClick = {},
+        onSettingsClick = {},
+    )
+}
+
+private fun rapidTabs(selectedTab: TabType): List<MainTab> {
+    return listOf(
+        MainTab(
+            type = TabType.Home,
+            label = "Главная",
+            icon = PhosphorIcons.Duotone.House,
+            isSelected = selectedTab == TabType.Home,
+        ),
+        MainTab(
+            type = TabType.Movies,
+            label = "Фильмы",
+            icon = PhosphorIcons.Duotone.FilmSlate,
+            isSelected = selectedTab == TabType.Movies,
+        ),
+        MainTab(
+            type = TabType.Series,
+            label = "Сериалы",
+            icon = PhosphorIcons.Duotone.TelevisionSimple,
+            isSelected = selectedTab == TabType.Series,
+        ),
+    )
+}
+
+private val rapidTabTypes = listOf(TabType.Home, TabType.Movies, TabType.Series)
+
+private fun tabLabel(tabType: TabType): String = when (tabType) {
+    TabType.Home -> "Главная"
+    TabType.Movies -> "Фильмы"
+    TabType.Series -> "Сериалы"
+    else -> error("Unsupported rapid-tab fixture type: $tabType")
+}
+
+private fun TabType.previous(direction: Key): TabType = when (direction) {
+    Key.DirectionRight -> when (this) {
+        TabType.Movies -> TabType.Home
+        TabType.Series -> TabType.Movies
+        else -> error("No rapid-tab predecessor for $this moving right")
+    }
+    Key.DirectionLeft -> when (this) {
+        TabType.Home -> TabType.Movies
+        TabType.Movies -> TabType.Series
+        else -> error("No rapid-tab predecessor for $this moving left")
+    }
+    else -> error("Unsupported rapid-tab direction: $direction")
+}
+
+@Parcelize
+private data class TopTabRapidProbeScreen(
+    val tabType: TabType,
+) : PuberScreen {
+    @IgnoredOnParcel
+    override val key = "TopTabRapidProbeScreen_${tabType.name}"
+
+    @Composable
+    override fun Content() {
+        Text(
+            text = tabType.name,
+            modifier = Modifier.testTag("tab_content_${tabType.name.lowercase()}"),
+        )
+    }
+}
+
+private const val INITIAL_SETTLE_MS = 500L
+private const val THREE_TRANSITIONS_PER_SECOND_MS = 334L
+private const val TWO_TRANSITIONS_PER_SECOND_MS = 500L
+private const val ONE_TRANSITION_PER_SECOND_MS = 1_000L

--- a/app/src/main/java/com/kino/puber/core/ui/navigation/component/FlowComponent.kt
+++ b/app/src/main/java/com/kino/puber/core/ui/navigation/component/FlowComponent.kt
@@ -124,7 +124,7 @@ private fun FlowNavigator(
         CompositionLocalProvider(
             LocalRootFocusRestoreVersion provides rootFocusRestoreVersion,
             LocalRootAnchorCaptureRegistry provides rootAnchorCaptureRegistry,
-            LocalRootAnchorFocusRestored provides rootAnchorCaptureRegistry::markFocusRestored,
+            LocalRootAnchorFocusRestored provides { rootAnchorCaptureRegistry.markFocusRestored(currentScreenKey) },
             LocalRootAnchorRestoreCompletion provides rootAnchorCaptureRegistry.restoreCompletion,
             LocalRootAnchorRestorePending provides rootAnchorCaptureRegistry.restorePending,
         ) {
@@ -153,9 +153,12 @@ private fun FlowNavigator(
             router = router,
             contentFocusRequester = contentFocusRequester,
             onBeforeNavigate = { rootAnchorCaptureRegistry.capture(currentScreenKey) },
+            rootAnchorCaptureRegistry = rootAnchorCaptureRegistry,
         )
         RootFlowReturnEffect(
             stackSize = navigator.items.size,
+            currentScreenKey = currentScreenKey,
+            rootAnchorCaptureRegistry = rootAnchorCaptureRegistry,
             onReturned = { rootFocusRestoreVersion++ },
         )
     }
@@ -174,6 +177,7 @@ private fun FlowCommandRunner(
     router: AppRouter,
     contentFocusRequester: FocusRequester,
     onBeforeNavigate: () -> Unit,
+    rootAnchorCaptureRegistry: RootAnchorCaptureRegistry,
 ) {
     val navigator = LocalNavigator.currentOrThrow
     val context = LocalContext.current
@@ -201,8 +205,18 @@ private fun FlowCommandRunner(
                     }
 
                     is Command.Replace -> navigator.puberReplace(event.screen)
-                    is Command.NewRoot -> navigator.puberReplaceAll(*event.screens.toTypedArray())
-                    is Command.BackTo -> onBackTo(navigator, event)
+                    is Command.NewRoot -> {
+                        navigator.puberReplaceAll(*event.screens.toTypedArray())
+                        rootAnchorCaptureRegistry.reconcilePendingRestore(
+                            rootScreenCompositionKey(scopeName, event.screen?.key),
+                        )
+                    }
+                    is Command.BackTo -> {
+                        onBackTo(navigator, event)
+                        rootAnchorCaptureRegistry.reconcilePendingRestore(
+                            rootScreenCompositionKey(scopeName, event.screen.key),
+                        )
+                    }
                     Command.FinishFlow -> navigator.parent?.let { parentNavigator ->
                         onBackEventNavigator(
                             navigator = parentNavigator,
@@ -223,6 +237,8 @@ private fun FlowCommandRunner(
 @Composable
 private fun RootFlowReturnEffect(
     stackSize: Int,
+    currentScreenKey: String,
+    rootAnchorCaptureRegistry: RootAnchorCaptureRegistry,
     onReturned: () -> Unit,
 ) {
     var lastStackSize by remember { mutableIntStateOf(stackSize) }
@@ -231,6 +247,7 @@ private fun RootFlowReturnEffect(
         lastStackSize = stackSize
         if (returned) {
             withFrameNanos { }
+            rootAnchorCaptureRegistry.reconcilePendingRestore(currentScreenKey)
             onReturned()
         }
     }
@@ -323,12 +340,25 @@ internal class RootAnchorCaptureRegistry {
         return true
     }
 
-    fun savedAnchor(key: String): LazyAnchor? =
-        pendingRestoreFrames.lastOrNull { it.screenKey == key }?.anchor
+    fun reconcilePendingRestore(currentScreenKey: String?) {
+        val matchingFrameIndex = currentScreenKey?.let { screenKey ->
+            pendingRestoreFrames.indexOfLast { it.screenKey == screenKey }
+        } ?: -1
+        pendingRestoreFrames = if (matchingFrameIndex >= 0) {
+            pendingRestoreFrames.take(matchingFrameIndex + 1)
+        } else {
+            emptyList()
+        }
+    }
 
-    fun markFocusRestored() {
+    fun savedAnchor(key: String): LazyAnchor? =
+        pendingRestoreFrames.lastOrNull()
+            ?.takeIf { it.screenKey == key }
+            ?.anchor
+
+    fun markFocusRestored(key: String) {
         val frame = pendingRestoreFrames.lastOrNull() ?: return
-        if (frame.focusRestored) return
+        if (frame.screenKey != key || frame.focusRestored) return
         pendingRestoreFrames = pendingRestoreFrames.dropLast(1) +
             frame.copy(focusRestored = true)
     }
@@ -425,6 +455,14 @@ private fun CurrentScreen(key: String) {
 }
 
 private fun screenCompositionKey(prefix: String, screenKey: ScreenKey): String = prefix + screenKey
+
+private fun rootScreenCompositionKey(scopeName: String, screenKey: ScreenKey?): String? =
+    screenKey?.let {
+        screenCompositionKey(
+            prefix = "currentScreen$scopeName",
+            screenKey = it,
+        )
+    }
 
 @Parcelize
 object LoadingScreen : PuberScreen {

--- a/app/src/main/java/com/kino/puber/core/ui/navigation/component/FlowComponent.kt
+++ b/app/src/main/java/com/kino/puber/core/ui/navigation/component/FlowComponent.kt
@@ -5,16 +5,20 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -88,26 +92,55 @@ fun FlowComponent(
     scopeName = scopeName,
 ) {
     val router by LocalPuberKoinScope.current!!.inject<AppRouter>()
+    val contentFocusRequester = remember { FocusRequester() }
+    val rootAnchorCaptureRegistry = remember { RootAnchorCaptureRegistry() }
+    var rootFocusRestoreVersion by remember { mutableIntStateOf(0) }
 
     Navigator(
         screen = screen,
         onBackPressed = { onBackPressed(router) },
-    ) {
-        val navigator = LocalNavigator.currentOrThrow
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .onKeyEvent { event ->
-                    remoteKeyHandler?.invoke(
-                        event.nativeKeyEvent,
-                        router,
-                        navigator.lastItem as PuberScreen,
-                    ) ?: false
-                },
+    ) { navigator ->
+        val currentScreenKey = screenCompositionKey(
+            prefix = "currentScreen$scopeName",
+            screenKey = navigator.lastItem.key,
+        )
+        CompositionLocalProvider(
+            LocalRootFocusRestoreVersion provides rootFocusRestoreVersion,
+            LocalRootAnchorCaptureRegistry provides rootAnchorCaptureRegistry,
+            LocalRootAnchorFocusRestored provides rootAnchorCaptureRegistry::markFocusRestored,
+            LocalRootAnchorRestoreCompletion provides rootAnchorCaptureRegistry.restoreCompletion,
+            LocalRootAnchorRestorePending provides rootAnchorCaptureRegistry.restorePending,
         ) {
-            CurrentScreen("currentScreen$scopeName")
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .onKeyEvent { event ->
+                        remoteKeyHandler?.invoke(
+                            event.nativeKeyEvent,
+                            router,
+                            navigator.lastItem as PuberScreen,
+                        ) ?: false
+                    },
+            ) {
+                Box(
+                    Modifier
+                        .focusRequester(contentFocusRequester)
+                        .focusRestorer()
+                        .focusGroup()
+                ) {
+                    CurrentScreen("currentScreen$scopeName")
+                }
+            }
         }
-        FlowCommandRunner(router)
+        FlowCommandRunner(
+            router = router,
+            contentFocusRequester = contentFocusRequester,
+            onBeforeNavigate = { rootAnchorCaptureRegistry.capture(currentScreenKey) },
+        )
+        RootFlowReturnEffect(
+            stackSize = navigator.items.size,
+            onReturned = { rootFocusRestoreVersion++ },
+        )
     }
     content()
 }
@@ -121,7 +154,11 @@ private fun onBackPressed(router: AppRouter): Boolean {
 }
 
 @Composable
-private fun FlowCommandRunner(router: AppRouter) {
+private fun FlowCommandRunner(
+    router: AppRouter,
+    contentFocusRequester: FocusRequester,
+    onBeforeNavigate: () -> Unit,
+) {
     val navigator = LocalNavigator.currentOrThrow
     val context = LocalContext.current
     val activityNavigator = remember(context) { ActivityNavigator(context) }
@@ -135,8 +172,14 @@ private fun FlowCommandRunner(router: AppRouter) {
                 activityNavigator.navigateTo(event.screen as PuberScreenActivity)
             } else {
                 when (event) {
-                    is Command.NavigateTo -> navigator.puberPush(event.screen)
+                    is Command.NavigateTo -> {
+                        onBeforeNavigate()
+                        contentFocusRequester.saveFocusedChild()
+                        navigator.puberPush(event.screen)
+                    }
                     is Command.NavigateForResult -> {
+                        onBeforeNavigate()
+                        contentFocusRequester.saveFocusedChild()
                         router.setOnceResultListener(event.requestCode, event.listener)
                         navigator.puberPush(event.screen)
                     }
@@ -157,6 +200,22 @@ private fun FlowCommandRunner(router: AppRouter) {
                     )
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun RootFlowReturnEffect(
+    stackSize: Int,
+    onReturned: () -> Unit,
+) {
+    var lastStackSize by remember { mutableIntStateOf(stackSize) }
+    LaunchedEffect(stackSize) {
+        val returned = stackSize < lastStackSize
+        lastStackSize = stackSize
+        if (returned) {
+            withFrameNanos { }
+            onReturned()
         }
     }
 }
@@ -200,12 +259,140 @@ private class ActivityNavigator(private val context: Context) {
 }
 
 val LocalScreenKey: ProvidableCompositionLocal<ScreenKey?> = staticCompositionLocalOf { null }
+internal val LocalRootFocusRestoreVersion = staticCompositionLocalOf { 0 }
+internal val LocalRootAnchorFocusRestored = staticCompositionLocalOf<() -> Unit> { {} }
+internal val LocalRootAnchorRestoreCompletion = staticCompositionLocalOf {
+    RootAnchorRestoreCompletion()
+}
+internal val LocalRootAnchorRestorePending = staticCompositionLocalOf { false }
+private val LocalRootAnchorCaptureRegistry =
+    staticCompositionLocalOf<RootAnchorCaptureRegistry?> { null }
+
+internal data class RootAnchorRestoreCompletion(
+    val screenKey: String? = null,
+    val version: Int = 0,
+)
+
+internal data class LazyAnchor(
+    val index: Int,
+    val offset: Int,
+)
+
+internal class RootAnchorCaptureRegistry {
+    private val captures = mutableMapOf<String, AnchorCapture>()
+    private val savedAnchors = mutableMapOf<String, LazyAnchor>()
+    private var pendingRestoreKey: String? = null
+    var restorePending by mutableStateOf(false)
+        private set
+    var focusRestored by mutableStateOf(false)
+        private set
+    var restoreCompletion by mutableStateOf(RootAnchorRestoreCompletion())
+        private set
+
+    fun register(key: String, capture: () -> LazyAnchor): () -> Unit {
+        val registration = AnchorCapture(capture)
+        captures[key] = registration
+        return {
+            if (captures[key] === registration) {
+                captures.remove(key)
+            }
+        }
+    }
+
+    fun capture(key: String): Boolean {
+        val anchor = captures[key]?.capture?.invoke() ?: return false
+        savedAnchors[key] = anchor
+        pendingRestoreKey = key
+        restorePending = true
+        focusRestored = false
+        return true
+    }
+
+    fun savedAnchor(key: String): LazyAnchor? = savedAnchors[key]
+
+    fun markFocusRestored() {
+        if (restorePending) {
+            focusRestored = true
+        }
+    }
+
+    fun completeRestore(key: String) {
+        if (pendingRestoreKey == key) {
+            pendingRestoreKey = null
+            restorePending = false
+            focusRestored = false
+            restoreCompletion = RootAnchorRestoreCompletion(
+                screenKey = key,
+                version = restoreCompletion.version + 1,
+            )
+        }
+    }
+
+    private class AnchorCapture(
+        val capture: () -> LazyAnchor,
+    )
+}
+
+@Composable
+internal fun PreserveLazyListAnchorOnRootReturn(lazyListState: LazyListState) {
+    val restoreVersion = LocalRootFocusRestoreVersion.current
+    val captureRegistry = LocalRootAnchorCaptureRegistry.current
+    val screenKey = LocalScreenKey.current
+    val focusRestored = captureRegistry?.focusRestored == true
+    DisposableEffect(screenKey, lazyListState, captureRegistry) {
+        val unregister = if (screenKey != null) {
+            captureRegistry?.register(screenKey) {
+                LazyAnchor(
+                    index = lazyListState.firstVisibleItemIndex,
+                    offset = lazyListState.firstVisibleItemScrollOffset,
+                )
+            }
+        } else {
+            null
+        }
+        onDispose {
+            unregister?.invoke()
+        }
+    }
+    LaunchedEffect(restoreVersion, focusRestored) {
+        if (restoreVersion == 0 || !focusRestored) return@LaunchedEffect
+
+        val registry = captureRegistry ?: return@LaunchedEffect
+        val savedAnchor = screenKey?.let(registry::savedAnchor)
+            ?: return@LaunchedEffect
+        lazyListState.awaitRestoredFocusScrollSettled()
+        repeat(ROOT_RETURN_ANCHOR_SETTLE_FRAMES) {
+            withFrameNanos { }
+            if (
+                lazyListState.firstVisibleItemIndex != savedAnchor.index ||
+                lazyListState.firstVisibleItemScrollOffset != savedAnchor.offset
+            ) {
+                lazyListState.scrollToItem(savedAnchor.index, savedAnchor.offset)
+            }
+        }
+        registry.completeRestore(screenKey)
+    }
+}
+
+private suspend fun LazyListState.awaitRestoredFocusScrollSettled() {
+    var consecutiveIdleFrames = 0
+    repeat(ROOT_RETURN_FOCUS_SETTLE_MAX_FRAMES) { frame ->
+        withFrameNanos { }
+        consecutiveIdleFrames = if (isScrollInProgress) 0 else consecutiveIdleFrames + 1
+        if (
+            frame >= ROOT_RETURN_FOCUS_SETTLE_MIN_FRAMES &&
+            consecutiveIdleFrames >= ROOT_RETURN_FOCUS_SETTLE_IDLE_FRAMES
+        ) {
+            return
+        }
+    }
+}
 
 @Composable
 private fun CurrentScreen(key: String) {
     val navigator = LocalNavigator.currentOrThrow
     val currentScreen = navigator.lastItem
-    val screenKey = key + currentScreen.key
+    val screenKey = screenCompositionKey(key, currentScreen.key)
 
     CompositionLocalProvider(
         LocalScreenKey provides screenKey,
@@ -216,6 +403,8 @@ private fun CurrentScreen(key: String) {
         }
     }
 }
+
+private fun screenCompositionKey(prefix: String, screenKey: ScreenKey): String = prefix + screenKey
 
 @Parcelize
 object LoadingScreen : PuberScreen {
@@ -254,41 +443,87 @@ internal fun TabFlowComponent(
             }
         },
     ) {
-        val contentFocusRequester = remember { FocusRequester() }
-        Navigator(
-            screen = rootScreen,
-            onBackPressed = null,
-            key = tabFlowNavigatorKey(navigationSlotKey),
-        ) { navigator ->
-            LaunchedEffect(contentInstanceKey) {
-                replaceTabRootIfChanged(
-                    navigator = navigator,
-                    rootScreen = rootScreen,
-                    contentInstanceKey = contentInstanceKey,
-                    tabSession = tabSession,
-                )
-            }
-            TabBackHandler(navigator, tabRouter)
-            Box(
-                Modifier
-                    .focusRequester(contentFocusRequester)
-                    .focusRestorer()
-                    .focusGroup()
-            ) {
-                CurrentScreen("currentTab$scopeName")
-            }
-            TabFlowCommandRunner(navigator, tabRouter, rootRouter, contentFocusRequester)
+        TabFlowNavigator(
+            scopeName = scopeName,
+            navigationSlotKey = navigationSlotKey,
+            contentInstanceKey = contentInstanceKey,
+            rootScreen = rootScreen,
+            tabSession = tabSession,
+            tabRouter = tabRouter,
+            rootRouter = rootRouter,
+        )
+    }
+}
 
-            val stackSize = navigator.items.size
-            var lastStackSize by remember { mutableIntStateOf(stackSize) }
-            LaunchedEffect(stackSize) {
-                if (stackSize < lastStackSize) {
-                    yield()
-                    runCatching { contentFocusRequester.requestFocus() }
-                }
-                lastStackSize = stackSize
+@Composable
+private fun TabFlowNavigator(
+    scopeName: String,
+    navigationSlotKey: ScreenKey,
+    contentInstanceKey: ScreenKey,
+    rootScreen: TabRootScreen,
+    tabSession: TabFlowSession,
+    tabRouter: AppRouter,
+    rootRouter: AppRouter?,
+) {
+    val contentFocusRequester = remember { FocusRequester() }
+    val rootAnchorCaptureRegistry = LocalRootAnchorCaptureRegistry.current
+    Navigator(
+        screen = rootScreen,
+        onBackPressed = null,
+        key = tabFlowNavigatorKey(navigationSlotKey),
+    ) { navigator ->
+        val currentScreenKey = screenCompositionKey(
+            prefix = "currentTab$scopeName",
+            screenKey = navigator.lastItem.key,
+        )
+        LaunchedEffect(contentInstanceKey) {
+            replaceTabRootIfChanged(
+                navigator = navigator,
+                rootScreen = rootScreen,
+                contentInstanceKey = contentInstanceKey,
+                tabSession = tabSession,
+            )
+        }
+        TabBackHandler(navigator, tabRouter)
+        Box(
+            Modifier
+                .focusRequester(contentFocusRequester)
+                .focusRestorer()
+                .focusGroup()
+        ) {
+            CurrentScreen("currentTab$scopeName")
+        }
+        TabFlowCommandRunner(
+            navigator = navigator,
+            router = tabRouter,
+            rootRouter = rootRouter,
+            contentFocusRequester = contentFocusRequester,
+            onBeforeRootNavigate = {
+                rootAnchorCaptureRegistry?.capture(currentScreenKey)
+            },
+        )
+
+        RestoreTabContentFocusEffect(
+            stackSize = navigator.items.size,
+            contentFocusRequester = contentFocusRequester,
+        )
+    }
+}
+
+@Composable
+private fun RestoreTabContentFocusEffect(
+    stackSize: Int,
+    contentFocusRequester: FocusRequester,
+) {
+    var lastStackSize by remember { mutableIntStateOf(stackSize) }
+    LaunchedEffect(stackSize) {
+        if (stackSize < lastStackSize) {
+            yield()
+            if (!contentFocusRequester.restoreFocusedChild()) {
+                runCatching { contentFocusRequester.requestFocus() }
             }
         }
+        lastStackSize = stackSize
     }
 }
 
@@ -333,6 +568,11 @@ internal fun replaceTabRootIfChanged(
     return true
 }
 
+private const val ROOT_RETURN_ANCHOR_SETTLE_FRAMES = 3
+private const val ROOT_RETURN_FOCUS_SETTLE_IDLE_FRAMES = 2
+private const val ROOT_RETURN_FOCUS_SETTLE_MIN_FRAMES = 2
+private const val ROOT_RETURN_FOCUS_SETTLE_MAX_FRAMES = 12
+
 @Composable
 private fun TabBackHandler(navigator: Navigator, router: AppRouter) {
     // navigator.canPop is Voyager's Stack<Screen> property (size > 1),
@@ -350,6 +590,7 @@ private fun TabFlowCommandRunner(
     router: AppRouter,
     rootRouter: AppRouter?,
     contentFocusRequester: FocusRequester,
+    onBeforeRootNavigate: () -> Unit,
 ) {
     val context = LocalContext.current
     val activityNavigator = remember(context) { ActivityNavigator(context) }
@@ -362,6 +603,9 @@ private fun TabFlowCommandRunner(
             } else {
                 when (event) {
                     is Command.NavigateTo -> {
+                        if (event.screen is RootPuberScreen && rootRouter != null) {
+                            onBeforeRootNavigate()
+                        }
                         contentFocusRequester.saveFocusedChild()
                         if (event.screen is RootPuberScreen && rootRouter != null) {
                             rootRouter.navigateTo(event.screen)
@@ -370,6 +614,9 @@ private fun TabFlowCommandRunner(
                         }
                     }
                     is Command.NavigateForResult -> {
+                        if (event.screen is RootPuberScreen && rootRouter != null) {
+                            onBeforeRootNavigate()
+                        }
                         contentFocusRequester.saveFocusedChild()
                         onTabNavigateForResult(
                             event = event,

--- a/app/src/main/java/com/kino/puber/core/ui/navigation/component/FlowComponent.kt
+++ b/app/src/main/java/com/kino/puber/core/ui/navigation/component/FlowComponent.kt
@@ -92,6 +92,23 @@ fun FlowComponent(
     scopeName = scopeName,
 ) {
     val router by LocalPuberKoinScope.current!!.inject<AppRouter>()
+
+    FlowNavigator(
+        scopeName = scopeName,
+        screen = screen,
+        router = router,
+        remoteKeyHandler = remoteKeyHandler,
+    )
+    content()
+}
+
+@Composable
+private fun FlowNavigator(
+    scopeName: String,
+    screen: PuberScreen,
+    router: AppRouter,
+    remoteKeyHandler: ((android.view.KeyEvent, AppRouter, PuberScreen) -> Boolean)?,
+) {
     val contentFocusRequester = remember { FocusRequester() }
     val rootAnchorCaptureRegistry = remember { RootAnchorCaptureRegistry() }
     var rootFocusRestoreVersion by remember { mutableIntStateOf(0) }
@@ -142,7 +159,6 @@ fun FlowComponent(
             onReturned = { rootFocusRestoreVersion++ },
         )
     }
-    content()
 }
 
 private fun onBackPressed(router: AppRouter): Boolean {
@@ -280,12 +296,11 @@ internal data class LazyAnchor(
 
 internal class RootAnchorCaptureRegistry {
     private val captures = mutableMapOf<String, AnchorCapture>()
-    private val savedAnchors = mutableMapOf<String, LazyAnchor>()
-    private var pendingRestoreKey: String? = null
-    var restorePending by mutableStateOf(false)
-        private set
-    var focusRestored by mutableStateOf(false)
-        private set
+    private var pendingRestoreFrames by mutableStateOf<List<PendingRestoreFrame>>(emptyList())
+    val restorePending: Boolean
+        get() = pendingRestoreFrames.isNotEmpty()
+    val focusRestored: Boolean
+        get() = pendingRestoreFrames.lastOrNull()?.focusRestored == true
     var restoreCompletion by mutableStateOf(RootAnchorRestoreCompletion())
         private set
 
@@ -301,35 +316,40 @@ internal class RootAnchorCaptureRegistry {
 
     fun capture(key: String): Boolean {
         val anchor = captures[key]?.capture?.invoke() ?: return false
-        savedAnchors[key] = anchor
-        pendingRestoreKey = key
-        restorePending = true
-        focusRestored = false
+        pendingRestoreFrames += PendingRestoreFrame(
+            screenKey = key,
+            anchor = anchor,
+        )
         return true
     }
 
-    fun savedAnchor(key: String): LazyAnchor? = savedAnchors[key]
+    fun savedAnchor(key: String): LazyAnchor? =
+        pendingRestoreFrames.lastOrNull { it.screenKey == key }?.anchor
 
     fun markFocusRestored() {
-        if (restorePending) {
-            focusRestored = true
-        }
+        val frame = pendingRestoreFrames.lastOrNull() ?: return
+        if (frame.focusRestored) return
+        pendingRestoreFrames = pendingRestoreFrames.dropLast(1) +
+            frame.copy(focusRestored = true)
     }
 
     fun completeRestore(key: String) {
-        if (pendingRestoreKey == key) {
-            pendingRestoreKey = null
-            restorePending = false
-            focusRestored = false
-            restoreCompletion = RootAnchorRestoreCompletion(
-                screenKey = key,
-                version = restoreCompletion.version + 1,
-            )
-        }
+        if (pendingRestoreFrames.lastOrNull()?.screenKey != key) return
+        pendingRestoreFrames = pendingRestoreFrames.dropLast(1)
+        restoreCompletion = RootAnchorRestoreCompletion(
+            screenKey = key,
+            version = restoreCompletion.version + 1,
+        )
     }
 
     private class AnchorCapture(
         val capture: () -> LazyAnchor,
+    )
+
+    private data class PendingRestoreFrame(
+        val screenKey: String,
+        val anchor: LazyAnchor,
+        val focusRestored: Boolean = false,
     )
 }
 
@@ -357,7 +377,7 @@ internal fun PreserveLazyListAnchorOnRootReturn(lazyListState: LazyListState) {
     LaunchedEffect(restoreVersion, focusRestored) {
         if (restoreVersion == 0 || !focusRestored) return@LaunchedEffect
 
-        val registry = captureRegistry ?: return@LaunchedEffect
+        val registry = captureRegistry
         val savedAnchor = screenKey?.let(registry::savedAnchor)
             ?: return@LaunchedEffect
         lazyListState.awaitRestoredFocusScrollSettled()

--- a/app/src/main/java/com/kino/puber/core/ui/uikit/component/PositionFocusedItemInLazyLayout.kt
+++ b/app/src/main/java/com/kino/puber/core/ui/uikit/component/PositionFocusedItemInLazyLayout.kt
@@ -25,17 +25,24 @@ enum class DpadScrollAxis {
 fun PositionFocusedItemInLazyLayout(
     parentFraction: Float = 0.3f,
     childFraction: Float = 0f,
+    keepFullyVisibleItemInPlace: Boolean = false,
     content: @Composable () -> Unit,
 ) {
     val rapidScrollActive = remember { mutableStateOf(false) }
-    val bringIntoViewSpec = remember(parentFraction, childFraction) {
+    val bringIntoViewSpec = remember(
+        parentFraction,
+        childFraction,
+        keepFullyVisibleItemInPlace,
+    ) {
         object : BringIntoViewSpec {
             override fun calculateScrollDistance(
                 offset: Float,
                 size: Float,
                 containerSize: Float,
             ): Float {
-                if (rapidScrollActive.value && offset >= 0 && offset + size <= containerSize) {
+                val keepCurrentPosition = keepFullyVisibleItemInPlace || rapidScrollActive.value
+                val itemIsFullyVisible = offset >= 0 && offset + size <= containerSize
+                if (keepCurrentPosition && itemIsFullyVisible) {
                     return 0f
                 }
                 val initialTargetForLeadingEdge =

--- a/app/src/main/java/com/kino/puber/core/ui/uikit/component/moviesList/FocusTargetResolver.kt
+++ b/app/src/main/java/com/kino/puber/core/ui/uikit/component/moviesList/FocusTargetResolver.kt
@@ -1,0 +1,78 @@
+package com.kino.puber.core.ui.uikit.component.moviesList
+
+/**
+ * Resolves the card that should inherit focus after a row changes.
+ *
+ * The focused item is kept by identity while it remains in the new list. If
+ * it was removed, the card that now occupies its old position wins; when the
+ * removed card was last, the previous card is used instead.
+ */
+internal fun resolveFocusedItemId(
+    previousItems: List<VideoItemUIState>,
+    updatedItems: List<VideoItemUIState>,
+    focusedItemId: Int?,
+): Int? {
+    if (updatedItems.isEmpty()) return null
+    if (focusedItemId != null && updatedItems.any { it.id == focusedItemId }) {
+        return focusedItemId
+    }
+
+    val removedIndex = previousItems.indexOfFirst { it.id == focusedItemId }
+    return updatedItems.getOrNull(removedIndex)?.id
+        ?: updatedItems.getOrNull(removedIndex - 1)?.id
+        ?: updatedItems.first().id
+}
+
+internal data class FocusableRow(
+    val key: String,
+    val itemCount: Int,
+)
+
+/**
+ * Finds the closest remaining content row after its focused row becomes
+ * empty. The following row wins ties so focus continues in reading order.
+ */
+internal fun nearestNonEmptyRowKey(
+    rows: List<FocusableRow>,
+    emptyRowIndex: Int,
+): String? {
+    return rows
+        .mapIndexedNotNull { index, row ->
+            if (row.itemCount == 0) {
+                null
+            } else {
+                Triple(
+                    kotlin.math.abs(index - emptyRowIndex),
+                    if (index < emptyRowIndex) 1 else 0,
+                    row.key,
+                )
+            }
+        }
+        .minWithOrNull(compareBy<Triple<Int, Int, String>> { it.first }.thenBy { it.second })
+        ?.third
+}
+
+/**
+ * Reconciles the focused row when the published row list changes.
+ *
+ * A mapper may remove a whole row instead of publishing an empty row. In
+ * that case the old row index still identifies the best replacement: prefer
+ * the row now occupying that index, then the preceding row.
+ */
+internal fun resolveFocusedRowKey(
+    previousRows: List<FocusableRow>,
+    updatedRows: List<FocusableRow>,
+    focusedRowKey: String?,
+): String? {
+    if (updatedRows.isEmpty()) return null
+    if (focusedRowKey != null && updatedRows.any { it.key == focusedRowKey && it.itemCount > 0 }) {
+        return focusedRowKey
+    }
+
+    val oldIndex = previousRows.indexOfFirst { it.key == focusedRowKey }
+    val replacementIndex = if (oldIndex >= 0) oldIndex else 0
+    return nearestNonEmptyRowKey(
+        rows = updatedRows,
+        emptyRowIndex = replacementIndex.coerceIn(0, updatedRows.lastIndex),
+    )
+}

--- a/app/src/main/java/com/kino/puber/core/ui/uikit/component/moviesList/FocusTargetState.kt
+++ b/app/src/main/java/com/kino/puber/core/ui/uikit/component/moviesList/FocusTargetState.kt
@@ -22,6 +22,11 @@ internal class ReconciledItemFocusState(
     val onItemFocused: (Int) -> Unit,
 )
 
+private data class PendingItemFocus(
+    val itemId: Int? = null,
+    val canRestoreInactiveContent: Boolean = false,
+)
+
 @Composable
 internal fun rememberReconciledItemFocus(
     rowKey: String,
@@ -35,10 +40,13 @@ internal fun rememberReconciledItemFocus(
         mutableStateOf(initialFocusedItemId ?: items.firstOrNull()?.id)
     }
     val previousItems = remember(rowKey) { mutableStateOf(items) }
-    val pendingFocusItemId = remember(rowKey) { mutableStateOf<Int?>(null) }
+    val pendingFocus = remember(rowKey) { mutableStateOf(PendingItemFocus()) }
     val focusRequester = remember { FocusRequester() }
     val rowHasFocusRef = remember { booleanArrayOf(false) }
     val contentFocusActive = LocalContentFocusActive.current
+    if (!contentFocusActive || !isTargetRow) {
+        rowHasFocusRef[0] = false
+    }
     val onRootFocusRestored = LocalRootAnchorFocusRestored.current
     val rootAnchorRestoreCompletion = LocalRootAnchorRestoreCompletion.current
     val screenKey = LocalScreenKey.current
@@ -47,19 +55,25 @@ internal fun rememberReconciledItemFocus(
         updatedItems = items,
         focusedItemId = focusedItemId.value,
     )
+    val canRestoreInactiveContent =
+        targetItemId != null &&
+            targetItemId != focusedItemId.value &&
+            contentFocusActive &&
+            rowHasFocusRef[0]
 
     ReconcileInitialItemFocusEffect(
         initialFocusedItemId = initialFocusedItemId,
         items = items,
         focusedItemId = focusedItemId,
-        pendingFocusItemId = pendingFocusItemId,
+        pendingFocus = pendingFocus,
     )
     ReconcilePublishedItemsEffect(
         items = items,
         isTargetRow = isTargetRow,
         focusedItemId = focusedItemId,
         previousItems = previousItems,
-        pendingFocusItemId = pendingFocusItemId,
+        canRestoreInactiveContent = canRestoreInactiveContent,
+        pendingFocus = pendingFocus,
         onRowEmpty = onRowEmpty,
     )
     RequestReconciledItemFocusEffects(
@@ -67,32 +81,44 @@ internal fun rememberReconciledItemFocus(
         targetItemId = targetItemId,
         focusRequester = focusRequester,
         rowHasFocusRef = rowHasFocusRef,
-        pendingFocusItemId = pendingFocusItemId,
+        pendingFocus = pendingFocus,
         requestAfterFrame = requestAfterFrame,
         contentFocusActive = contentFocusActive,
         rootAnchorRestoreCompletion = rootAnchorRestoreCompletion,
         screenKey = screenKey,
     )
 
-    return ReconciledItemFocusState(
-        targetItemId = targetItemId,
-        focusRequester = focusRequester,
-        rowHasFocusRef = rowHasFocusRef,
-        onItemFocused = { itemId ->
-            focusedItemId.value = itemId
-            if (isTargetRow && itemId == targetItemId) {
-                onRootFocusRestored()
-            }
-        },
+    return reconciledItemFocusState(
+        targetItemId, focusRequester, rowHasFocusRef, focusedItemId, isTargetRow, onRootFocusRestored,
     )
 }
+
+private fun reconciledItemFocusState(
+    targetItemId: Int?,
+    focusRequester: FocusRequester,
+    rowHasFocusRef: BooleanArray,
+    focusedItemId: MutableState<Int?>,
+    isTargetRow: Boolean,
+    onRootFocusRestored: () -> Unit,
+) = ReconciledItemFocusState(
+    targetItemId = targetItemId,
+    focusRequester = focusRequester,
+    rowHasFocusRef = rowHasFocusRef,
+    onItemFocused = { itemId ->
+        rowHasFocusRef[0] = true
+        focusedItemId.value = itemId
+        if (isTargetRow && itemId == targetItemId) {
+            onRootFocusRestored()
+        }
+    },
+)
 
 @Composable
 private fun ReconcileInitialItemFocusEffect(
     initialFocusedItemId: Int?,
     items: List<VideoItemUIState>,
     focusedItemId: MutableState<Int?>,
-    pendingFocusItemId: MutableState<Int?>,
+    pendingFocus: MutableState<PendingItemFocus>,
 ) {
     LaunchedEffect(initialFocusedItemId) {
         if (
@@ -101,7 +127,7 @@ private fun ReconcileInitialItemFocusEffect(
             items.any { it.id == initialFocusedItemId }
         ) {
             focusedItemId.value = initialFocusedItemId
-            pendingFocusItemId.value = initialFocusedItemId
+            pendingFocus.value = PendingItemFocus(itemId = initialFocusedItemId)
         }
     }
 }
@@ -112,7 +138,8 @@ private fun ReconcilePublishedItemsEffect(
     isTargetRow: Boolean,
     focusedItemId: MutableState<Int?>,
     previousItems: MutableState<List<VideoItemUIState>>,
-    pendingFocusItemId: MutableState<Int?>,
+    canRestoreInactiveContent: Boolean,
+    pendingFocus: MutableState<PendingItemFocus>,
     onRowEmpty: () -> Unit,
 ) {
     LaunchedEffect(items) {
@@ -123,7 +150,10 @@ private fun ReconcilePublishedItemsEffect(
         )
         if (nextFocusedItemId != focusedItemId.value) {
             focusedItemId.value = nextFocusedItemId
-            pendingFocusItemId.value = nextFocusedItemId
+            pendingFocus.value = PendingItemFocus(
+                itemId = nextFocusedItemId,
+                canRestoreInactiveContent = canRestoreInactiveContent,
+            )
         }
         previousItems.value = items
         if (items.isEmpty() && isTargetRow) {
@@ -138,7 +168,7 @@ private fun RequestReconciledItemFocusEffects(
     targetItemId: Int?,
     focusRequester: FocusRequester,
     rowHasFocusRef: BooleanArray,
-    pendingFocusItemId: MutableState<Int?>,
+    pendingFocus: MutableState<PendingItemFocus>,
     requestAfterFrame: Boolean,
     contentFocusActive: Boolean,
     rootAnchorRestoreCompletion: RootAnchorRestoreCompletion,
@@ -150,10 +180,12 @@ private fun RequestReconciledItemFocusEffects(
             focusRequester.requestAfterComposition(requestAfterFrame)
         }
     }
-    LaunchedEffect(pendingFocusItemId.value, contentFocusActive) {
-        if (isTargetRow && contentFocusActive && pendingFocusItemId.value != null) {
+    LaunchedEffect(pendingFocus.value, contentFocusActive) {
+        val request = pendingFocus.value
+        val canRequestFocus = contentFocusActive || request.canRestoreInactiveContent
+        if (isTargetRow && canRequestFocus && request.itemId != null) {
             focusRequester.requestAfterComposition(requestAfterFrame)
-            pendingFocusItemId.value = null
+            pendingFocus.value = PendingItemFocus()
         }
     }
     LaunchedEffect(rootAnchorRestoreCompletion.version) {

--- a/app/src/main/java/com/kino/puber/core/ui/uikit/component/moviesList/FocusTargetState.kt
+++ b/app/src/main/java/com/kino/puber/core/ui/uikit/component/moviesList/FocusTargetState.kt
@@ -1,0 +1,256 @@
+package com.kino.puber.core.ui.uikit.component.moviesList
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.foundation.lazy.LazyListState
+import com.kino.puber.core.ui.navigation.component.LocalRootAnchorFocusRestored
+import com.kino.puber.core.ui.navigation.component.LocalRootAnchorRestoreCompletion
+import com.kino.puber.core.ui.navigation.component.LocalScreenKey
+import com.kino.puber.core.ui.navigation.component.RootAnchorRestoreCompletion
+import com.kino.puber.core.ui.uikit.component.modifier.LocalContentFocusActive
+
+internal class ReconciledItemFocusState(
+    val targetItemId: Int?,
+    val focusRequester: FocusRequester,
+    val rowHasFocusRef: BooleanArray,
+    val onItemFocused: (Int) -> Unit,
+)
+
+@Composable
+internal fun rememberReconciledItemFocus(
+    rowKey: String,
+    items: List<VideoItemUIState>,
+    isTargetRow: Boolean,
+    initialFocusedItemId: Int? = null,
+    requestAfterFrame: Boolean = false,
+    onRowEmpty: () -> Unit,
+): ReconciledItemFocusState {
+    val focusedItemId = rememberSaveable(rowKey) {
+        mutableStateOf(initialFocusedItemId ?: items.firstOrNull()?.id)
+    }
+    val previousItems = remember(rowKey) { mutableStateOf(items) }
+    val pendingFocusItemId = remember(rowKey) { mutableStateOf<Int?>(null) }
+    val focusRequester = remember { FocusRequester() }
+    val rowHasFocusRef = remember { booleanArrayOf(false) }
+    val contentFocusActive = LocalContentFocusActive.current
+    val onRootFocusRestored = LocalRootAnchorFocusRestored.current
+    val rootAnchorRestoreCompletion = LocalRootAnchorRestoreCompletion.current
+    val screenKey = LocalScreenKey.current
+    val targetItemId = resolveFocusedItemId(
+        previousItems = previousItems.value,
+        updatedItems = items,
+        focusedItemId = focusedItemId.value,
+    )
+
+    ReconcileInitialItemFocusEffect(
+        initialFocusedItemId = initialFocusedItemId,
+        items = items,
+        focusedItemId = focusedItemId,
+        pendingFocusItemId = pendingFocusItemId,
+    )
+    ReconcilePublishedItemsEffect(
+        items = items,
+        isTargetRow = isTargetRow,
+        focusedItemId = focusedItemId,
+        previousItems = previousItems,
+        pendingFocusItemId = pendingFocusItemId,
+        onRowEmpty = onRowEmpty,
+    )
+    RequestReconciledItemFocusEffects(
+        isTargetRow = isTargetRow,
+        targetItemId = targetItemId,
+        focusRequester = focusRequester,
+        rowHasFocusRef = rowHasFocusRef,
+        pendingFocusItemId = pendingFocusItemId,
+        requestAfterFrame = requestAfterFrame,
+        contentFocusActive = contentFocusActive,
+        rootAnchorRestoreCompletion = rootAnchorRestoreCompletion,
+        screenKey = screenKey,
+    )
+
+    return ReconciledItemFocusState(
+        targetItemId = targetItemId,
+        focusRequester = focusRequester,
+        rowHasFocusRef = rowHasFocusRef,
+        onItemFocused = { itemId ->
+            focusedItemId.value = itemId
+            if (isTargetRow && itemId == targetItemId) {
+                onRootFocusRestored()
+            }
+        },
+    )
+}
+
+@Composable
+private fun ReconcileInitialItemFocusEffect(
+    initialFocusedItemId: Int?,
+    items: List<VideoItemUIState>,
+    focusedItemId: MutableState<Int?>,
+    pendingFocusItemId: MutableState<Int?>,
+) {
+    LaunchedEffect(initialFocusedItemId) {
+        if (
+            initialFocusedItemId != null &&
+            initialFocusedItemId != focusedItemId.value &&
+            items.any { it.id == initialFocusedItemId }
+        ) {
+            focusedItemId.value = initialFocusedItemId
+            pendingFocusItemId.value = initialFocusedItemId
+        }
+    }
+}
+
+@Composable
+private fun ReconcilePublishedItemsEffect(
+    items: List<VideoItemUIState>,
+    isTargetRow: Boolean,
+    focusedItemId: MutableState<Int?>,
+    previousItems: MutableState<List<VideoItemUIState>>,
+    pendingFocusItemId: MutableState<Int?>,
+    onRowEmpty: () -> Unit,
+) {
+    LaunchedEffect(items) {
+        val nextFocusedItemId = resolveFocusedItemId(
+            previousItems = previousItems.value,
+            updatedItems = items,
+            focusedItemId = focusedItemId.value,
+        )
+        if (nextFocusedItemId != focusedItemId.value) {
+            focusedItemId.value = nextFocusedItemId
+            pendingFocusItemId.value = nextFocusedItemId
+        }
+        previousItems.value = items
+        if (items.isEmpty() && isTargetRow) {
+            onRowEmpty()
+        }
+    }
+}
+
+@Composable
+private fun RequestReconciledItemFocusEffects(
+    isTargetRow: Boolean,
+    targetItemId: Int?,
+    focusRequester: FocusRequester,
+    rowHasFocusRef: BooleanArray,
+    pendingFocusItemId: MutableState<Int?>,
+    requestAfterFrame: Boolean,
+    contentFocusActive: Boolean,
+    rootAnchorRestoreCompletion: RootAnchorRestoreCompletion,
+    screenKey: String?,
+) {
+    LaunchedEffect(isTargetRow, contentFocusActive) {
+        val targetCanReceiveFocus = isTargetRow && contentFocusActive && targetItemId != null
+        if (targetCanReceiveFocus && !rowHasFocusRef[0]) {
+            focusRequester.requestAfterComposition(requestAfterFrame)
+        }
+    }
+    LaunchedEffect(pendingFocusItemId.value, contentFocusActive) {
+        if (isTargetRow && contentFocusActive && pendingFocusItemId.value != null) {
+            focusRequester.requestAfterComposition(requestAfterFrame)
+            pendingFocusItemId.value = null
+        }
+    }
+    LaunchedEffect(rootAnchorRestoreCompletion.version) {
+        val matchingCompletedRestore =
+            rootAnchorRestoreCompletion.screenKey == screenKey &&
+                rootAnchorRestoreCompletion.version > 0
+        val targetCanReceiveFocus = isTargetRow && contentFocusActive && targetItemId != null
+        if (matchingCompletedRestore && targetCanReceiveFocus) {
+            focusRequester.requestAfterAnchorRestore()
+        }
+    }
+}
+
+private suspend fun FocusRequester.requestAfterAnchorRestore() {
+    repeat(ROOT_ANCHOR_FOCUS_REQUEST_ATTEMPTS) {
+        withFrameNanos { }
+        if (requestFocus()) return
+    }
+}
+
+private suspend fun FocusRequester.requestAfterComposition(awaitFrame: Boolean) {
+    if (awaitFrame) {
+        withFrameNanos { }
+    }
+    requestFocus()
+}
+
+private const val ROOT_ANCHOR_FOCUS_REQUEST_ATTEMPTS = 3
+
+internal class ReconciledRowFocusState(
+    val focusedRowKey: String?,
+    val onRowFocused: (String) -> Unit,
+    val onRowEmpty: (Int) -> Unit,
+)
+
+@Composable
+internal fun rememberReconciledRowFocus(
+    rows: List<FocusableRow>,
+    initialRowKey: String? = null,
+    resetKey: Any? = Unit,
+): ReconciledRowFocusState {
+    val focusedRowKey = rememberSaveable(resetKey) { mutableStateOf(initialRowKey) }
+    val previousRows = remember { mutableStateOf(rows) }
+    val resolvedRowKey = resolveFocusedRowKey(
+        previousRows = previousRows.value,
+        updatedRows = rows,
+        focusedRowKey = focusedRowKey.value,
+    )
+    LaunchedEffect(rows) {
+        focusedRowKey.value = resolvedRowKey
+        previousRows.value = rows
+    }
+    return ReconciledRowFocusState(
+        focusedRowKey = resolvedRowKey,
+        onRowFocused = { rowKey -> focusedRowKey.value = rowKey },
+        onRowEmpty = { rowIndex ->
+            focusedRowKey.value = nearestNonEmptyRowKey(
+                rows = rows,
+                emptyRowIndex = rowIndex,
+            )
+        },
+    )
+}
+
+internal class VideoGridFocusState(
+    val rows: List<FocusableRow>,
+    val rowFocus: ReconciledRowFocusState,
+)
+
+@Composable
+internal fun rememberVideoGridFocusState(
+    list: List<VideoGridItemUIState>,
+    initialFocusedItemId: Int?,
+    lazyListState: LazyListState,
+): VideoGridFocusState {
+    val initialColumnIndex = remember(list, initialFocusedItemId) {
+        list.indexOfFirst { gridItem ->
+            gridItem is VideoGridItemUIState.Items &&
+                gridItem.items.any { it.id == initialFocusedItemId }
+        }
+    }
+    val initialRowKey = remember(list, initialColumnIndex) {
+        (list.getOrNull(initialColumnIndex) as? VideoGridItemUIState.Items)?.rowKey
+    }
+    val rows = remember(list) {
+        list.filterIsInstance<VideoGridItemUIState.Items>()
+            .map { row -> FocusableRow(row.rowKey, row.items.size) }
+    }
+    val rowFocus = rememberReconciledRowFocus(
+        rows = rows,
+        initialRowKey = initialRowKey,
+        resetKey = initialFocusedItemId,
+    )
+    LaunchedEffect(initialColumnIndex) {
+        if (initialColumnIndex >= 0) {
+            lazyListState.scrollToItem(initialColumnIndex)
+        }
+    }
+    return VideoGridFocusState(rows = rows, rowFocus = rowFocus)
+}

--- a/app/src/main/java/com/kino/puber/core/ui/uikit/component/moviesList/VideoGridUIState.kt
+++ b/app/src/main/java/com/kino/puber/core/ui/uikit/component/moviesList/VideoGridUIState.kt
@@ -18,12 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
-import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -49,7 +44,10 @@ data class VideoGridUIState(
 @Immutable
 sealed class VideoGridItemUIState {
     data class Title(val title: String) : VideoGridItemUIState()
-    data class Items(val items: List<VideoItemUIState>) : VideoGridItemUIState()
+    data class Items(
+        val items: List<VideoItemUIState>,
+        val rowKey: String,
+    ) : VideoGridItemUIState()
 }
 
 @Composable
@@ -63,64 +61,61 @@ fun VideoGrid(
     initialFocusedItemId: Int? = null,
 ) {
     val lazyListState = rememberLazyListState()
-    val initialColumnIndex = remember(state, initialFocusedItemId) {
-        state.list.indexOfFirst { gridItem ->
-            gridItem is VideoGridItemUIState.Items &&
-                gridItem.items.any { it.id == initialFocusedItemId }
-        }
-    }
-    var focusedColumnIndex by rememberSaveable(initialFocusedItemId) {
-        mutableIntStateOf(initialColumnIndex)
-    }
-    LaunchedEffect(initialColumnIndex) {
-        if (initialColumnIndex >= 0) {
-            lazyListState.scrollToItem(initialColumnIndex)
-        }
-    }
+    val gridFocus = rememberVideoGridFocusState(
+        list = state.list,
+        initialFocusedItemId = initialFocusedItemId,
+        lazyListState = lazyListState,
+    )
 
     val showTopGradient by remember { derivedStateOf { lazyListState.firstVisibleItemScrollOffset > 0 } }
 
-    Box(modifier = modifier.fillMaxSize()) {
-        LazyColumn(
-            state = lazyListState,
-            modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(bottom = PuberTheme.Defaults.VideoItemHeight),
-        ) {
-            itemsIndexed(state.list, key = { _, item ->
-                when (item) {
-                    is VideoGridItemUIState.Title -> "title_${item.title}"
-                    is VideoGridItemUIState.Items -> "items_${item.items.first().id}"
-                }
-            }) { indexC, columnItem ->
-                when (columnItem) {
+    PositionFocusedItemInLazyLayout {
+        Box(modifier = modifier.fillMaxSize()) {
+            LazyColumn(
+                state = lazyListState,
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(bottom = PuberTheme.Defaults.VideoItemHeight),
+            ) {
+                itemsIndexed(state.list, key = { _, item ->
+                    when (item) {
+                        is VideoGridItemUIState.Title -> "title_${item.title}"
+                        is VideoGridItemUIState.Items -> "items_${item.rowKey}"
+                    }
+                }) { _, columnItem ->
+                    when (columnItem) {
 
-                    is VideoGridItemUIState.Title -> Text(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp),
-                        text = columnItem.title,
-                        style = MaterialTheme.typography.titleLarge,
-                    )
+                        is VideoGridItemUIState.Title -> Text(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp),
+                            text = columnItem.title,
+                            style = MaterialTheme.typography.titleLarge,
+                        )
 
-                    is VideoGridItemUIState.Items -> VideoGridItems(
-                        items = columnItem,
-                        columnIndex = indexC,
-                        isTargetRow = indexC == focusedColumnIndex,
-                        initialFocusedItemId = initialFocusedItemId?.takeIf { itemId ->
-                            columnItem.items.any { it.id == itemId }
-                        },
-                        onItemClick = onItemClick,
-                        onItemContextMenu = onItemContextMenu,
-                        onItemFocused = { item ->
-                            focusedColumnIndex = indexC
-                            onItemFocused(item)
-                        },
-                    )
+                        is VideoGridItemUIState.Items -> VideoGridItems(
+                            items = columnItem,
+                            isTargetRow = columnItem.rowKey == gridFocus.rowFocus.focusedRowKey,
+                            initialFocusedItemId = initialFocusedItemId?.takeIf { itemId ->
+                                columnItem.items.any { it.id == itemId }
+                            },
+                            onItemClick = onItemClick,
+                            onItemContextMenu = onItemContextMenu,
+                            onItemFocused = { item ->
+                                gridFocus.rowFocus.onRowFocused(columnItem.rowKey)
+                                onItemFocused(item)
+                            },
+                            onRowEmpty = {
+                                gridFocus.rowFocus.onRowEmpty(
+                                    gridFocus.rows.indexOfFirst { it.key == columnItem.rowKey }
+                                )
+                            },
+                        )
+                    }
                 }
             }
-        }
 
-        VideoGridTopGradient(visible = enableTopSideGradient && showTopGradient)
+            VideoGridTopGradient(visible = enableTopSideGradient && showTopGradient)
+        }
     }
 }
 
@@ -148,68 +143,57 @@ private fun BoxScope.VideoGridTopGradient(visible: Boolean) {
 @Composable
 private fun VideoGridItems(
     items: VideoGridItemUIState.Items,
-    columnIndex: Int,
     isTargetRow: Boolean,
     initialFocusedItemId: Int?,
     onItemClick: (VideoItemUIState) -> Unit,
     onItemContextMenu: ((VideoItemUIState) -> Unit)?,
     onItemFocused: (VideoItemUIState) -> Unit,
+    onRowEmpty: () -> Unit,
 ) {
+    val itemFocus = rememberReconciledItemFocus(
+        rowKey = items.rowKey,
+        items = items.items,
+        isTargetRow = isTargetRow,
+        initialFocusedItemId = initialFocusedItemId,
+        requestAfterFrame = true,
+        onRowEmpty = onRowEmpty,
+    )
     Box(
         modifier = Modifier
             .wrapContentHeight()
             .fillMaxWidth(),
     ) {
         val listState = rememberLazyListState()
-        val initialItemIndex = remember(items, initialFocusedItemId) {
-            items.items.indexOfFirst { it.id == initialFocusedItemId }
-        }
-        var focusedItemIndex by rememberSaveable(columnIndex, initialFocusedItemId) {
-            mutableIntStateOf(initialItemIndex.coerceAtLeast(0))
-        }
-
         val rowFocusRequester = remember { FocusRequester() }
-        val savedItemFocusRequester = remember { FocusRequester() }
-        LaunchedEffect(initialFocusedItemId, initialItemIndex) {
-            if (initialItemIndex >= 0) {
-                withFrameNanos { }
-                savedItemFocusRequester.requestFocus()
+        LazyRow(
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusRequester(rowFocusRequester)
+                .dpadScrollOptimization(axis = DpadScrollAxis.Horizontal)
+                .focusRestorer(itemFocus.focusRequester)
+                .onFocusChanged { itemFocus.rowHasFocusRef[0] = it.hasFocus },
+            state = listState,
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            contentPadding = PaddingValues(16.dp),
+        ) {
+            itemsIndexed(items.items, key = { _, item -> item.id }) { indexR, item ->
+                val isFallbackTarget = item.id == itemFocus.targetItemId
+                VideoGridRowItem(
+                    item = item,
+                    itemIndex = indexR,
+                    isFallbackTarget = isFallbackTarget,
+                    rowFocusRequester = rowFocusRequester,
+                    savedItemFocusRequester = itemFocus.focusRequester,
+                    onItemClick = onItemClick,
+                    onItemContextMenu = onItemContextMenu,
+                    onItemFocused = { _, focusedItem ->
+                        itemFocus.onItemFocused(focusedItem.id)
+                        onItemFocused(focusedItem)
+                    },
+                )
             }
         }
-        PositionFocusedItemInLazyLayout {
-            LazyRow(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .focusRequester(rowFocusRequester)
-                    .dpadScrollOptimization(axis = DpadScrollAxis.Horizontal)
-                    .focusRestorer(savedItemFocusRequester),
-                state = listState,
-                horizontalArrangement = Arrangement.spacedBy(16.dp),
-                contentPadding = PaddingValues(16.dp),
-            ) {
-                itemsIndexed(items.items, key = { _, item -> item.id }) { indexR, item ->
-                    val isFallbackTarget = if (isTargetRow) {
-                        indexR == focusedItemIndex
-                    } else {
-                        indexR == 0
-                    }
-                    VideoGridRowItem(
-                        item = item,
-                        itemIndex = indexR,
-                        isFallbackTarget = isFallbackTarget,
-                        rowFocusRequester = rowFocusRequester,
-                        savedItemFocusRequester = savedItemFocusRequester,
-                        onItemClick = onItemClick,
-                        onItemContextMenu = onItemContextMenu,
-                        onItemFocused = { focusedIndex, focusedItem ->
-                            focusedItemIndex = focusedIndex
-                            onItemFocused(focusedItem)
-                        },
-                    )
-                }
-            }
-            FadeGradient(listState)
-        }
+        FadeGradient(listState)
     }
 }
 

--- a/app/src/main/java/com/kino/puber/ui/feature/contentlist/content/ContentListScreenContent.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/contentlist/content/ContentListScreenContent.kt
@@ -9,7 +9,9 @@ import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
@@ -27,11 +29,14 @@ import androidx.tv.material3.Text
 import com.kino.puber.core.ui.uikit.component.VideoItemContextMenuDialog
 import com.kino.puber.core.ui.uikit.component.GenreChipBar
 import com.kino.puber.core.ui.uikit.component.HeroCarousel
+import com.kino.puber.core.ui.uikit.component.PositionFocusedItemInLazyLayout
 import com.kino.puber.core.ui.uikit.component.details.VideoItemGridDetails
 import com.kino.puber.core.ui.uikit.theme.PuberTheme
 import com.kino.puber.core.ui.uikit.component.modifier.rememberFocusRequesterOnLaunch
 import com.kino.puber.core.ui.uikit.model.CommonAction
 import com.kino.puber.core.ui.uikit.component.moviesList.VideoItemUIState
+import com.kino.puber.core.ui.uikit.component.moviesList.FocusableRow
+import com.kino.puber.core.ui.uikit.component.moviesList.nearestNonEmptyRowKey
 import com.kino.puber.core.ui.uikit.model.UIAction
 import com.kino.puber.ui.feature.contentlist.model.ContentListAction
 import com.kino.puber.ui.feature.contentlist.model.ContentListViewState
@@ -39,6 +44,7 @@ import com.kino.puber.ui.feature.contentlist.model.SectionConfig
 import com.kino.puber.ui.feature.contentlist.model.SectionState
 import com.kino.puber.ui.feature.contentlist.vm.SectionVM
 import com.kino.puber.core.di.LocalPuberKoinScope
+import com.kino.puber.core.ui.navigation.component.PreserveLazyListAnchorOnRootReturn
 import org.koin.core.qualifier.named
 
 @Composable
@@ -106,6 +112,8 @@ private fun ContentListLayout(
     onAction: (UIAction) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val lazyListState = rememberLazyListState()
+    PreserveLazyListAnchorOnRootReturn(lazyListState)
     Column(modifier = modifier) {
         if (state.showDetailPanel) {
             VideoItemGridDetails(
@@ -124,24 +132,27 @@ private fun ContentListLayout(
             )
         }
 
-        LazyColumn(
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(if (state.showDetailPanel) PuberTheme.Defaults.ContentWeight else 1f)
-                .focusRestorer()
-                .focusGroup(),
-            contentPadding = PaddingValues(bottom = PuberTheme.Defaults.HorizontalVideoItemHeight),
-        ) {
-            heroItem(state, onAction)
-            sectionItems(
-                sections = sections,
-                sectionVms = sectionVms,
-                sectionStates = sectionStates,
-                focusedSectionIndex = focusedSectionIndex,
-                onSectionFocused = onSectionFocused,
-                onContextMenu = onContextMenu,
-                onAction = onAction,
-            )
+        PositionFocusedItemInLazyLayout(keepFullyVisibleItemInPlace = true) {
+            LazyColumn(
+                state = lazyListState,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(if (state.showDetailPanel) PuberTheme.Defaults.ContentWeight else 1f)
+                    .focusRestorer()
+                    .focusGroup(),
+                contentPadding = PaddingValues(bottom = PuberTheme.Defaults.HorizontalVideoItemHeight),
+            ) {
+                heroItem(state, onAction)
+                sectionItems(
+                    sections = sections,
+                    sectionVms = sectionVms,
+                    sectionStates = sectionStates,
+                    focusedSectionIndex = focusedSectionIndex,
+                    onSectionFocused = onSectionFocused,
+                    onContextMenu = onContextMenu,
+                    onAction = onAction,
+                )
+            }
         }
     }
 }
@@ -191,6 +202,22 @@ private fun LazyListScope.sectionItems(
             onSectionFocused = onSectionFocused,
             onContextMenu = onContextMenu,
             onAction = onAction,
+            onRowEmpty = {
+                val rows = sections.mapIndexed { rowIndex, section ->
+                    val itemCount = (sectionStates[rowIndex] as? SectionState.Content)
+                        ?.items
+                        ?.size
+                        ?: 0
+                    FocusableRow(section.id, itemCount)
+                }
+                val targetKey = nearestNonEmptyRowKey(
+                    rows = rows,
+                    emptyRowIndex = index,
+                )
+                if (targetKey != null) {
+                    onSectionFocused(sections.indexOfFirst { it.id == targetKey })
+                }
+            },
         )
     }
 }
@@ -205,6 +232,7 @@ private fun LazyListScope.sectionItem(
     onSectionFocused: (Int) -> Unit,
     onContextMenu: (VideoItemUIState, SectionVM) -> Unit,
     onAction: (UIAction) -> Unit,
+    onRowEmpty: () -> Unit,
 ) {
     item(key = "title_${config.id}", contentType = "section_title") {
         Text(
@@ -244,6 +272,7 @@ private fun LazyListScope.sectionItem(
             onRetry = { sectionVm.onAction(CommonAction.RetryClicked) },
             onLoadMore = { sectionVm.onAction(CommonAction.LoadMore) },
             onShowAll = rememberedOnShowAll,
+            onRowEmpty = onRowEmpty,
         )
     }
 }

--- a/app/src/main/java/com/kino/puber/ui/feature/contentlist/content/SectionRow.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/contentlist/content/SectionRow.kt
@@ -17,11 +17,7 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -38,11 +34,11 @@ import androidx.tv.material3.Text
 import com.kino.puber.core.ui.uikit.component.DpadScrollAxis
 import com.kino.puber.core.ui.uikit.component.FadeGradient
 import com.kino.puber.core.ui.uikit.component.LoadMoreHandler
-import com.kino.puber.core.ui.uikit.component.PositionFocusedItemInLazyLayout
 import com.kino.puber.core.ui.uikit.component.dpadScrollOptimization
 import com.kino.puber.R
 import com.kino.puber.core.ui.uikit.component.moviesList.VideoItemHorizontal
 import com.kino.puber.core.ui.uikit.component.moviesList.VideoItemUIState
+import com.kino.puber.core.ui.uikit.component.moviesList.rememberReconciledItemFocus
 import com.kino.puber.core.ui.uikit.theme.PuberTheme
 import com.kino.puber.ui.feature.contentlist.model.SectionConfig
 import com.kino.puber.ui.feature.contentlist.model.SectionState
@@ -59,9 +55,16 @@ internal fun SectionRowContent(
     onRetry: () -> Unit,
     onLoadMore: () -> Unit,
     onShowAll: (() -> Unit)? = null,
+    onRowEmpty: () -> Unit = {},
 ) {
     val contentFocusRequester = remember { FocusRequester() }
     val hasFocusRef = remember { booleanArrayOf(false) }
+
+    LaunchedEffect(state, isTargetRow) {
+        if (state is SectionState.Empty && isTargetRow) {
+            onRowEmpty()
+        }
+    }
 
     Box(modifier = Modifier.onFocusChanged { hasFocusRef[0] = it.hasFocus }) {
         when (val s = state) {
@@ -76,13 +79,16 @@ internal fun SectionRowContent(
                     state = s,
                     isTargetRow = isTargetRow,
                     shouldRequestInitialFocus = hasFocusRef[0],
+                    rowHasFocusRef = hasFocusRef,
                     contentFocusRequester = contentFocusRequester,
+                    rowKey = config.id,
                     onItemClick = onItemClick,
                     onItemContextMenu = onItemContextMenu,
                     onItemFocused = onItemFocused,
                     onSectionFocused = onSectionFocused,
                     onLoadMore = onLoadMore,
                     onShowAll = onShowAll,
+                    onRowEmpty = onRowEmpty,
                 )
             }
         }
@@ -94,54 +100,56 @@ private fun ContentSectionCards(
     state: SectionState.Content,
     isTargetRow: Boolean,
     shouldRequestInitialFocus: Boolean,
+    rowHasFocusRef: BooleanArray,
     contentFocusRequester: FocusRequester,
+    rowKey: String,
     onItemClick: (VideoItemUIState) -> Unit,
     onItemContextMenu: (VideoItemUIState) -> Unit,
     onItemFocused: (VideoItemUIState) -> Unit,
     onSectionFocused: () -> Unit,
     onLoadMore: () -> Unit,
     onShowAll: (() -> Unit)?,
+    onRowEmpty: () -> Unit,
 ) {
     val listState = rememberLazyListState()
-    val savedItemFocusRequester = remember { FocusRequester() }
-    var focusedItemIndex by rememberSaveable { mutableIntStateOf(0) }
+    val emptyRowHandler = onRowEmpty.takeIf { onShowAll == null } ?: {}
+    val itemFocus = rememberReconciledItemFocus(
+        rowKey = rowKey,
+        items = state.items,
+        isTargetRow = isTargetRow,
+        onRowEmpty = emptyRowHandler,
+    )
+
     Box(
         modifier = Modifier
             .wrapContentHeight()
             .fillMaxWidth(),
     ) {
-        PositionFocusedItemInLazyLayout {
-            LazyRow(
+        LazyRow(
                 state = listState,
                 modifier = Modifier
                     .fillMaxWidth()
                     .graphicsLayer { clip = false }
                     .focusRequester(contentFocusRequester)
                     .dpadScrollOptimization(axis = DpadScrollAxis.Horizontal)
-                    .focusRestorer(savedItemFocusRequester),
+                    .focusRestorer(itemFocus.focusRequester),
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
                 contentPadding = PaddingValues(16.dp),
             ) {
                 itemsIndexed(state.items, key = { _, item -> item.id }) { index, item ->
-                    val isFallbackTarget = if (isTargetRow) {
-                        index == focusedItemIndex
-                    } else {
-                        index == 0
-                    }
-                    val focusModifier = remember(index, item.id) {
-                        Modifier.onFocusChanged { focusState ->
-                            if (focusState.isFocused) {
-                                focusedItemIndex = index
-                                onSectionFocused()
-                                onItemFocused(item)
-                            }
+                    val isFallbackTarget = item.id == itemFocus.targetItemId
+                    val focusModifier = Modifier.onFocusChanged { focusState ->
+                        if (focusState.isFocused) {
+                            onSectionFocused()
+                            itemFocus.onItemFocused(item.id)
+                            onItemFocused(item)
                         }
                     }
                     val clickCallback = remember(item.id) { { onItemClick(item) } }
                     VideoItemHorizontal(
                         modifier = Modifier
                             .then(
-                                if (isFallbackTarget) Modifier.focusRequester(savedItemFocusRequester)
+                                if (isFallbackTarget) Modifier.focusRequester(itemFocus.focusRequester)
                                 else Modifier
                             )
                             .then(focusModifier),
@@ -170,14 +178,13 @@ private fun ContentSectionCards(
                         }
                     }
                 }
-            }
-            FadeGradient(listState)
         }
+        FadeGradient(listState)
     }
 
     LaunchedEffect(state.items.firstOrNull()?.id) {
         if (shouldRequestInitialFocus) {
-            runCatching { savedItemFocusRequester.requestFocus() }
+            runCatching { itemFocus.focusRequester.requestFocus() }
                 .recoverCatching { contentFocusRequester.requestFocus() }
         }
     }

--- a/app/src/main/java/com/kino/puber/ui/feature/details/component/DetailsScreenPreview.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/details/component/DetailsScreenPreview.kt
@@ -126,21 +126,23 @@ private val previewEpisodes = VideoGridUIState(
     list = listOf(
         VideoGridItemUIState.Title("1 сезон, 8 серий"),
         VideoGridItemUIState.Items(
-            listOf(
+            items = listOf(
                 VideoItemUIState(1, "1. Чужой в деревне", "", "", showTitle = true),
                 VideoItemUIState(2, "2. Молоко с доставкой", "", "", showTitle = true),
                 VideoItemUIState(3, "3. Трактористы", "", "", showTitle = true),
                 VideoItemUIState(4, "4. Большой брат", "", "", showTitle = true),
-            )
+            ),
+            rowKey = "season_1",
         ),
         VideoGridItemUIState.Title("2 сезон, 8 серий"),
         VideoGridItemUIState.Items(
-            listOf(
+            items = listOf(
                 VideoItemUIState(5, "1. Новые горизонты", "", "", showTitle = true),
                 VideoItemUIState(6, "2. Код деревни", "", "", showTitle = true),
                 VideoItemUIState(7, "3. Извинигород", "", "", showTitle = true),
                 VideoItemUIState(8, "4. Дед-Код", "", "", showTitle = true),
-            )
+            ),
+            rowKey = "season_2",
         ),
     )
 )

--- a/app/src/main/java/com/kino/puber/ui/feature/details/model/DetailsScreenUIMapper.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/details/model/DetailsScreenUIMapper.kt
@@ -74,7 +74,12 @@ internal class DetailsScreenUIMapper(
                 )
             )
             val items = episodes.map { episode -> mapEpisode(season.number, episodes, episode) }
-            gridItems.add(VideoGridItemUIState.Items(items))
+            gridItems.add(
+                VideoGridItemUIState.Items(
+                    items = items,
+                    rowKey = "season_${season.number}",
+                )
+            )
         }
         return VideoGridUIState(list = gridItems)
     }

--- a/app/src/main/java/com/kino/puber/ui/feature/favorites/model/FavoriteItemUIMapper.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/favorites/model/FavoriteItemUIMapper.kt
@@ -33,7 +33,12 @@ internal class FavoriteItemUIMapper(
                     if (groupedItems.size > 1) {
                         add(VideoGridItemUIState.Title(typeMapper.map(type)))
                     }
-                    add(VideoGridItemUIState.Items(videoItemUIMapper.mapShortItemList(items).mapSaved()))
+                    add(
+                        VideoGridItemUIState.Items(
+                            items = videoItemUIMapper.mapShortItemList(items).mapSaved(),
+                            rowKey = "favorites_${type.name}",
+                        )
+                    )
                 }
             },
         )

--- a/app/src/main/java/com/kino/puber/ui/feature/history/component/HistoryScreenContent.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/history/component/HistoryScreenContent.kt
@@ -485,7 +485,9 @@ private fun HistoryTopTabsPreviewHost(state: HistoryViewState) {
             isSelected = true,
         ),
     )
-    val tabFocusRequesters = remember { List(tabs.size) { FocusRequester() } }
+    val tabFocusRequesters = remember {
+        tabs.associate { it.type to FocusRequester() }
+    }
 
     Column(modifier = Modifier.fillMaxSize()) {
         TopTabBar(

--- a/app/src/main/java/com/kino/puber/ui/feature/home/component/HomeScreenContent.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/home/component/HomeScreenContent.kt
@@ -11,19 +11,18 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.focus.onFocusChanged
@@ -49,7 +48,12 @@ import com.kino.puber.core.ui.uikit.component.VideoItemContextMenuDialog
 import com.kino.puber.core.ui.uikit.component.dpadScrollOptimization
 import com.kino.puber.core.ui.uikit.component.moviesList.VideoItemHorizontal
 import com.kino.puber.core.ui.uikit.component.moviesList.VideoItemUIState
+import com.kino.puber.core.ui.uikit.component.moviesList.FocusableRow
+import com.kino.puber.core.ui.uikit.component.moviesList.ReconciledRowFocusState
 import com.kino.puber.core.ui.uikit.component.onTvContextMenuKey
+import com.kino.puber.core.ui.uikit.component.moviesList.rememberReconciledItemFocus
+import com.kino.puber.core.ui.uikit.component.moviesList.rememberReconciledRowFocus
+import com.kino.puber.core.ui.navigation.component.PreserveLazyListAnchorOnRootReturn
 import com.kino.puber.core.ui.uikit.model.CommonAction
 import com.kino.puber.core.ui.uikit.model.UIAction
 import com.kino.puber.ui.feature.home.model.HomeAction
@@ -62,6 +66,7 @@ internal fun HomeScreenContent(
     onAction: (UIAction) -> Unit,
     onHeroClick: (Int) -> Unit,
     onCollectionClick: (Int, String) -> Unit,
+    lazyListState: LazyListState = rememberLazyListState(),
 ) {
     Box(Modifier.fillMaxSize()) {
         when (state) {
@@ -83,6 +88,7 @@ internal fun HomeScreenContent(
                     onAction = onAction,
                     onHeroClick = onHeroClick,
                     onCollectionClick = onCollectionClick,
+                    lazyListState = lazyListState,
                 )
             }
         }
@@ -152,16 +158,24 @@ private fun HomeContent(
     onAction: (UIAction) -> Unit,
     onHeroClick: (Int) -> Unit,
     onCollectionClick: (Int, String) -> Unit,
+    lazyListState: LazyListState,
 ) {
-    var focusedSectionIndex by rememberSaveable { mutableIntStateOf(0) }
     var focusedTarget by remember(state.heroItems, state.sections) {
         mutableStateOf(state.defaultFocusedTarget())
     }
     var contextMenuItem by remember { mutableStateOf<VideoItemUIState?>(null) }
+    val rows = remember(state.sections) {
+        state.sections.map { row ->
+            FocusableRow(row.type.name, row.items.size)
+        }
+    }
+    val rowFocus = rememberReconciledRowFocus(rows)
+    PreserveLazyListAnchorOnRootReturn(lazyListState)
 
-    PositionFocusedItemInLazyLayout {
+    PositionFocusedItemInLazyLayout(keepFullyVisibleItemInPlace = true) {
         Box(Modifier.fillMaxSize()) {
             LazyColumn(
+                state = lazyListState,
                 modifier = Modifier
                     .fillMaxSize()
                     .focusRestorer()
@@ -197,44 +211,14 @@ private fun HomeContent(
                         )
                     }
                 }
-
-                state.sections.forEachIndexed { index, section ->
-                    item(key = "section_${section.type.name}") {
-                        Column {
-                            Text(
-                                text = section.title,
-                                style = MaterialTheme.typography.titleLarge,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 16.dp, vertical = 8.dp),
-                            )
-                            HomeSectionRow(
-                                items = section.items,
-                                isTargetRow = index == focusedSectionIndex,
-                                onSectionFocused = { focusedSectionIndex = index },
-                                onItemClick = { item ->
-                                    if (section.type == HomeSectionType.Collections) {
-                                        onCollectionClick(item.id, item.title)
-                                    } else {
-                                        onAction(CommonAction.ItemSelected(item))
-                                    }
-                                },
-                                onItemContextMenu = if (section.type == HomeSectionType.Collections) {
-                                    null
-                                } else {
-                                    { item -> contextMenuItem = item }
-                                },
-                                onItemFocused = { item ->
-                                    focusedTarget = if (section.type == HomeSectionType.Collections) {
-                                        HomeFocusedTarget.Collection(id = item.id, title = item.title)
-                                    } else {
-                                        HomeFocusedTarget.Video(item)
-                                    }
-                                }
-                            )
-                        }
-                    }
-                }
+                homeSections(
+                    state = state,
+                    rowFocus = rowFocus,
+                    onAction = onAction,
+                    onCollectionClick = onCollectionClick,
+                    onFocusedTarget = { focusedTarget = it },
+                    onContextMenuItem = { contextMenuItem = it },
+                )
             }
             VideoItemContextMenuDialog(
                 item = contextMenuItem,
@@ -245,40 +229,97 @@ private fun HomeContent(
     }
 }
 
+private fun LazyListScope.homeSections(
+    state: HomeViewState.Content,
+    rowFocus: ReconciledRowFocusState,
+    onAction: (UIAction) -> Unit,
+    onCollectionClick: (Int, String) -> Unit,
+    onFocusedTarget: (HomeFocusedTarget) -> Unit,
+    onContextMenuItem: (VideoItemUIState) -> Unit,
+) {
+    state.sections.forEachIndexed { index, section ->
+        item(key = "section_${section.type.name}") {
+            Column {
+                Text(
+                    text = section.title,
+                    style = MaterialTheme.typography.titleLarge,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+                HomeSectionRow(
+                    rowKey = section.type.name,
+                    items = section.items,
+                    isTargetRow = section.type.name == rowFocus.focusedRowKey,
+                    onSectionFocused = { rowFocus.onRowFocused(section.type.name) },
+                    onItemClick = { item ->
+                        if (section.type == HomeSectionType.Collections) {
+                            onCollectionClick(item.id, item.title)
+                        } else {
+                            onAction(CommonAction.ItemSelected(item))
+                        }
+                    },
+                    onItemContextMenu = if (section.type == HomeSectionType.Collections) {
+                        null
+                    } else {
+                        onContextMenuItem
+                    },
+                    onItemFocused = { item ->
+                        onFocusedTarget(
+                            if (section.type == HomeSectionType.Collections) {
+                                HomeFocusedTarget.Collection(id = item.id, title = item.title)
+                            } else {
+                                HomeFocusedTarget.Video(item)
+                            }
+                        )
+                    },
+                    onRowEmpty = { rowFocus.onRowEmpty(index) },
+                )
+            }
+        }
+    }
+}
+
 @Composable
-private fun HomeSectionRow(
+internal fun HomeSectionRow(
+    rowKey: String,
     items: List<VideoItemUIState>,
     isTargetRow: Boolean,
     onSectionFocused: () -> Unit,
     onItemClick: (VideoItemUIState) -> Unit,
     onItemContextMenu: ((VideoItemUIState) -> Unit)?,
     onItemFocused: (VideoItemUIState) -> Unit,
+    onRowEmpty: () -> Unit,
 ) {
     val listState = rememberLazyListState()
-    val savedItemFocusRequester = remember { FocusRequester() }
-    var focusedItemIndex by rememberSaveable { mutableIntStateOf(0) }
+    val itemFocus = rememberReconciledItemFocus(
+        rowKey = rowKey,
+        items = items,
+        isTargetRow = isTargetRow,
+        onRowEmpty = onRowEmpty,
+    )
 
     LazyRow(
         state = listState,
         modifier = Modifier
             .graphicsLayer { clip = false }
             .dpadScrollOptimization(axis = DpadScrollAxis.Horizontal)
-            .focusRestorer(savedItemFocusRequester),
+            .focusRestorer(itemFocus.focusRequester),
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         contentPadding = PaddingValues(horizontal = 16.dp),
     ) {
         itemsIndexed(items = items, key = { _, item -> item.id }) { index, item ->
-            val isFocusTarget = if (isTargetRow) index == focusedItemIndex else index == 0
+            val isFocusTarget = item.id == itemFocus.targetItemId
             VideoItemHorizontal(
                 modifier = Modifier
                     .then(
-                        if (isFocusTarget) Modifier.focusRequester(savedItemFocusRequester)
+                        if (isFocusTarget) Modifier.focusRequester(itemFocus.focusRequester)
                         else Modifier
                     )
                     .onFocusChanged {
                         if (it.isFocused) {
-                            focusedItemIndex = index
                             onSectionFocused()
+                            itemFocus.onItemFocused(item.id)
                             onItemFocused(item)
                         }
                     },

--- a/app/src/main/java/com/kino/puber/ui/feature/main/toptabs/TopTabBar.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/main/toptabs/TopTabBar.kt
@@ -35,15 +35,16 @@ import com.adamglin.phosphoricons.duotone.GearSix
 import com.adamglin.phosphoricons.duotone.MagnifyingGlass
 import com.kino.puber.core.ui.uikit.component.onTvContextMenuKey
 import com.kino.puber.ui.feature.main.model.MainTab
+import com.kino.puber.ui.feature.main.model.TabType
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 internal fun TopTabBar(
     tabs: List<MainTab>,
     selectedIndex: Int,
-    tabFocusRequesters: List<FocusRequester>,
+    tabFocusRequesters: Map<TabType, FocusRequester>,
     onContentFocusRequested: () -> Unit,
-    onTabFocused: (Int) -> Unit,
+    onTabFocused: (TabType) -> Unit,
     onTabClick: () -> Unit,
     onTabContextMenu: (Int) -> Unit,
     onSearchClick: () -> Unit,
@@ -68,9 +69,9 @@ internal fun TopTabBar(
             selectedTabIndex = selectedIndex,
             modifier = tabRowModifier
                 .focusRestorer {
-                    tabFocusRequesters.getOrElse(selectedIndex) {
-                        tabFocusRequesters.firstOrNull() ?: FocusRequester.Default
-                    }
+                    val selectedTabType = tabs.getOrNull(selectedIndex)?.type
+                    tabFocusRequesters[selectedTabType] ?: tabFocusRequesters.values.firstOrNull()
+                        ?: FocusRequester.Default
                 }
                 .weight(1f),
         ) {
@@ -78,10 +79,10 @@ internal fun TopTabBar(
                 key(tab.type) {
                     Tab(
                         selected = index == selectedIndex,
-                        onFocus = { onTabFocused(index) },
+                        onFocus = { onTabFocused(tab.type) },
                         onClick = onTabClick,
                         modifier = Modifier
-                            .focusRequester(tabFocusRequesters[index])
+                            .focusRequester(tabFocusRequesters[tab.type] ?: FocusRequester.Default)
                             .onTvContextMenuKey { onTabContextMenu(index) }
                             .onDownKey(onContentFocusRequested),
                     ) {

--- a/app/src/main/java/com/kino/puber/ui/feature/main/toptabs/TopTabBarPreview.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/main/toptabs/TopTabBarPreview.kt
@@ -27,7 +27,9 @@ private val previewTabs = listOf(
 @Preview(name = "TopTabBar — Home selected", device = TV_1080p)
 @Composable
 private fun TopTabBarHomePreview() = PuberTheme {
-    val tabFocusRequesters = remember { List(previewTabs.size) { FocusRequester() } }
+    val tabFocusRequesters = remember {
+        previewTabs.associate { it.type to FocusRequester() }
+    }
     TopTabBar(
         tabs = previewTabs,
         selectedIndex = 0,
@@ -44,7 +46,9 @@ private fun TopTabBarHomePreview() = PuberTheme {
 @Preview(name = "TopTabBar — History selected", device = TV_1080p)
 @Composable
 private fun TopTabBarHistoryPreview() = PuberTheme {
-    val tabFocusRequesters = remember { List(previewTabs.size) { FocusRequester() } }
+    val tabFocusRequesters = remember {
+        previewTabs.associate { it.type to FocusRequester() }
+    }
     TopTabBar(
         tabs = previewTabs,
         selectedIndex = previewTabs.lastIndex,

--- a/app/src/main/java/com/kino/puber/ui/feature/main/toptabs/TopTabFocusIntent.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/main/toptabs/TopTabFocusIntent.kt
@@ -1,0 +1,136 @@
+package com.kino.puber.ui.feature.main.toptabs
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.focus.FocusRequester
+import com.kino.puber.core.ui.uikit.component.TvDialogFocusRestorer
+import com.kino.puber.ui.feature.main.model.MainTab
+import com.kino.puber.ui.feature.main.model.MainViewState
+import com.kino.puber.ui.feature.main.model.TabType
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+internal data class TopTabFocusIntent(
+    val focusedTab: TabType?,
+    val token: Int = 0,
+) {
+    fun focus(tab: TabType): TopTabFocusIntent {
+        return copy(
+            focusedTab = tab,
+            token = token + 1,
+        )
+    }
+
+    fun reconcile(
+        visibleTabs: List<TabType>,
+        selectedTab: TabType,
+    ): TopTabFocusIntent {
+        if (focusedTab in visibleTabs) return this
+
+        return copy(
+            focusedTab = selectedTab.takeIf(visibleTabs::contains)
+                ?: visibleTabs.firstOrNull(),
+            token = token + 1,
+        )
+    }
+
+    fun isLatest(token: Int): Boolean = this.token == token
+}
+
+internal class TopTabFocusState(
+    val focusedTabType: TabType?,
+    val focusIntentToken: Int,
+    val selectedIndex: Int,
+    val focusRequesters: Map<TabType, FocusRequester>,
+    val dialogFocusRestorer: TvDialogFocusRestorer,
+    val onTabFocused: (TabType) -> Unit,
+)
+
+@Composable
+internal fun rememberTopTabFocusState(
+    state: MainViewState,
+    tabRowFocus: FocusRequester,
+): TopTabFocusState {
+    val coroutineScope = rememberCoroutineScope()
+    val focusRequesters = remember { mutableMapOf<TabType, FocusRequester>() }
+        .also { requesters ->
+            state.tabs.forEach { tab ->
+                requesters.getOrPut(tab.type) { FocusRequester() }
+            }
+        }
+    val selectedTabType = state.selectedTab
+        .takeIf { selected -> state.tabs.any { it.type == selected } }
+        ?: state.tabs.firstOrNull()?.type
+    val focusedTabType = rememberSaveable { mutableStateOf(selectedTabType) }
+    val focusIntentToken = rememberSaveable { mutableIntStateOf(0) }
+    val currentFocusedTabType by rememberUpdatedState(focusedTabType.value)
+    val currentFocusRequesters by rememberUpdatedState(focusRequesters)
+    val dialogFocusRestorer = remember(tabRowFocus, coroutineScope) {
+        TvDialogFocusRestorer(
+            onDialogOpening = { tabRowFocus.saveFocusedChild() },
+            onDialogClosed = {
+                coroutineScope.launch {
+                    delay(TOP_TAB_CHILD_FOCUS_DELAY_MS)
+                    currentFocusRequesters[currentFocusedTabType]?.requestFocus()
+                        ?: tabRowFocus.requestFocus()
+                }
+            },
+        )
+    }
+    ReconcileTopTabFocusEffect(
+        tabs = state.tabs,
+        selectedTab = state.selectedTab,
+        focusedTabType = focusedTabType,
+        focusIntentToken = focusIntentToken,
+    )
+    val selectedIndex = state.tabs.indexOfFirst { it.type == focusedTabType.value }
+        .takeIf { it >= 0 }
+        ?: state.tabs.indexOfFirst { it.type == selectedTabType }.coerceAtLeast(0)
+    return TopTabFocusState(
+        focusedTabType = focusedTabType.value,
+        focusIntentToken = focusIntentToken.intValue,
+        selectedIndex = selectedIndex,
+        focusRequesters = focusRequesters,
+        dialogFocusRestorer = dialogFocusRestorer,
+        onTabFocused = { tabType ->
+            val nextIntent = TopTabFocusIntent(
+                focusedTab = focusedTabType.value,
+                token = focusIntentToken.intValue,
+            ).focus(tabType)
+            focusedTabType.value = nextIntent.focusedTab
+            focusIntentToken.intValue = nextIntent.token
+        },
+    )
+}
+
+@Composable
+private fun ReconcileTopTabFocusEffect(
+    tabs: List<MainTab>,
+    selectedTab: TabType,
+    focusedTabType: androidx.compose.runtime.MutableState<TabType?>,
+    focusIntentToken: androidx.compose.runtime.MutableIntState,
+) {
+    LaunchedEffect(tabs.map(MainTab::type), selectedTab) {
+        val currentIntent = TopTabFocusIntent(
+            focusedTab = focusedTabType.value,
+            token = focusIntentToken.intValue,
+        )
+        val nextIntent = currentIntent.reconcile(
+            visibleTabs = tabs.map(MainTab::type),
+            selectedTab = selectedTab,
+        )
+        if (nextIntent != currentIntent) {
+            focusedTabType.value = nextIntent.focusedTab
+            focusIntentToken.intValue = nextIntent.token
+        }
+    }
+}
+
+private const val TOP_TAB_CHILD_FOCUS_DELAY_MS = 16L

--- a/app/src/main/java/com/kino/puber/ui/feature/main/toptabs/TopTabMainContent.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/main/toptabs/TopTabMainContent.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
@@ -28,6 +29,8 @@ import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalFocusManager
 import com.kino.puber.core.ui.navigation.TabRouter
+import com.kino.puber.core.ui.navigation.component.LocalRootAnchorRestorePending
+import com.kino.puber.core.ui.navigation.component.LocalRootFocusRestoreVersion
 import com.kino.puber.core.ui.navigation.component.TabAppRouterHolder
 import com.kino.puber.core.ui.navigation.component.PuberCurrentTab
 import com.kino.puber.core.ui.navigation.component.TabComponent
@@ -39,8 +42,10 @@ import com.kino.puber.core.ui.uikit.component.modifier.LocalContentFocusActive
 import com.kino.puber.core.ui.uikit.model.CommonAction
 import com.kino.puber.core.ui.uikit.model.UIAction
 import com.kino.puber.ui.feature.main.model.MainAction
+import com.kino.puber.ui.feature.main.model.MainTab
 import com.kino.puber.ui.feature.main.model.MainViewState
 import com.kino.puber.ui.feature.main.model.TabType
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -57,53 +62,45 @@ internal fun TopTabMainContent(
     val tabRowFocus = remember { FocusRequester() }
     val contentFocus = remember { FocusRequester() }
     val focusManager = LocalFocusManager.current
-    val coroutineScope = rememberCoroutineScope()
-    val tabFocusRequesters = remember(state.tabs.size) {
-        List(state.tabs.size) { FocusRequester() }
-    }
-    val selectedIndex = state.tabs.indexOfFirst { it.isSelected }.coerceAtLeast(0)
-
-    var focusedTabIndex by rememberSaveable { mutableIntStateOf(selectedIndex) }
+    val rootFocusRestoreVersion = LocalRootFocusRestoreVersion.current
+    val rootAnchorRestorePending = LocalRootAnchorRestorePending.current
+    val skipInitialFocus = remember { rootAnchorRestorePending }
+    val tabFocusState = rememberTopTabFocusState(state, tabRowFocus)
+    val tabFocusRequesters = tabFocusState.focusRequesters
+    val focusedTabType = tabFocusState.focusedTabType
     var lastFocusedRegion by rememberSaveable { mutableStateOf(TopTabFocusedRegion.Tabs) }
     var isContentFocused by remember { mutableStateOf(false) }
     var contextMenuTabIndex by remember { mutableStateOf<Int?>(null) }
     var refreshFocusRequestVersion by rememberSaveable { mutableIntStateOf(0) }
-    val currentFocusedTabIndex by rememberUpdatedState(focusedTabIndex)
-    val currentTabFocusRequesters by rememberUpdatedState(tabFocusRequesters)
-    val tabDialogFocusRestorer = remember(tabRowFocus, coroutineScope) {
-        TvDialogFocusRestorer(
-            onDialogOpening = { tabRowFocus.saveFocusedChild() },
-            onDialogClosed = {
-                coroutineScope.launch {
-                    delay(CONTENT_CHILD_FOCUS_DELAY_MS)
-                    currentTabFocusRequesters.getOrNull(currentFocusedTabIndex)?.requestFocus()
-                        ?: tabRowFocus.requestFocus()
-                }
-            },
-        )
-    }
-
-    SyncSelectedTabEffect(selectedIndex) { focusedTabIndex = selectedIndex }
     DelayedTabSelectionEffect(
-        state = state,
-        focusedTabIndex = focusedTabIndex,
-        selectedIndex = selectedIndex,
+        tabs = state.tabs,
+        focusedTabType = focusedTabType,
+        selectedTab = state.selectedTab,
+        focusIntentToken = tabFocusState.focusIntentToken,
         onAction = onAction,
     )
     InitialTabFocusEffect(
-        focusedTabIndex = focusedTabIndex,
+        focusedTabType = focusedTabType,
         tabFocusRequesters = tabFocusRequesters,
         tabRowFocus = tabRowFocus,
         contentFocus = contentFocus,
         focusManager = focusManager,
         lastFocusedRegion = lastFocusedRegion,
+        skipInitialFocus = skipInitialFocus,
+    )
+    RootReturnContentFocusEffect(
+        restoreVersion = rootFocusRestoreVersion,
+        onRestore = {
+            lastFocusedRegion = TopTabFocusedRegion.Content
+            isContentFocused = true
+        },
     )
     RefreshContentFocusEffect(
         requestVersion = refreshFocusRequestVersion,
         contentFocus = contentFocus,
         focusManager = focusManager,
     )
-    val isOnHome = state.tabs.getOrNull(focusedTabIndex)?.type == TabType.Home
+    val isOnHome = focusedTabType == TabType.Home
 
     TopTabBackHandler(
         enabled = isContentFocused || !isOnHome,
@@ -112,7 +109,7 @@ internal fun TopTabMainContent(
         tabRowFocus = tabRowFocus,
         tabFocusRequesters = tabFocusRequesters,
         onTabsFocused = { lastFocusedRegion = TopTabFocusedRegion.Tabs },
-        onHomeFocused = { focusedTabIndex = it },
+        onHomeFocused = tabFocusState.onTabFocused,
         onAction = onAction,
     )
 
@@ -126,14 +123,16 @@ internal fun TopTabMainContent(
             Unit
         }
 
-        CompositionLocalProvider(LocalTvDialogFocusRestorer provides tabDialogFocusRestorer) {
+        CompositionLocalProvider(
+            LocalTvDialogFocusRestorer provides tabFocusState.dialogFocusRestorer
+        ) {
             Column(Modifier.fillMaxSize()) {
                 TopTabBar(
                     tabs = state.tabs,
-                    selectedIndex = focusedTabIndex,
+                    selectedIndex = tabFocusState.selectedIndex,
                     tabFocusRequesters = tabFocusRequesters,
                     onContentFocusRequested = requestContentFocus,
-                    onTabFocused = { index -> focusedTabIndex = index },
+                    onTabFocused = tabFocusState.onTabFocused,
                     onTabClick = requestContentFocus,
                     onTabContextMenu = { index -> contextMenuTabIndex = index },
                     onSearchClick = onSearchClick,
@@ -204,42 +203,56 @@ private fun RefreshContentFocusEffect(
 }
 
 @Composable
-private fun SyncSelectedTabEffect(selectedIndex: Int, onSelectedIndexChanged: (Int) -> Unit) {
-    LaunchedEffect(selectedIndex) {
-        onSelectedIndexChanged(selectedIndex)
+private fun RootReturnContentFocusEffect(
+    restoreVersion: Int,
+    onRestore: () -> Unit,
+) {
+    LaunchedEffect(restoreVersion) {
+        if (restoreVersion == 0) return@LaunchedEffect
+        withFrameNanos { }
+        onRestore()
     }
 }
 
 @Composable
 private fun DelayedTabSelectionEffect(
-    state: MainViewState,
-    focusedTabIndex: Int,
-    selectedIndex: Int,
+    tabs: List<MainTab>,
+    focusedTabType: TabType?,
+    selectedTab: TabType,
+    focusIntentToken: Int,
     onAction: (UIAction) -> Unit,
 ) {
-    LaunchedEffect(focusedTabIndex) {
-        if (focusedTabIndex != selectedIndex) {
-            delay(TAB_SELECTION_DELAY_MS)
-            state.tabs.getOrNull(focusedTabIndex)?.let { tab ->
-                onAction(CommonAction.ItemSelected(tab))
-            }
+    val latestSelectedTab by rememberUpdatedState(selectedTab)
+    val latestFocusIntentToken by rememberUpdatedState(focusIntentToken)
+    LaunchedEffect(focusedTabType, focusIntentToken) {
+        val tab = tabs.firstOrNull { it.type == focusedTabType } ?: return@LaunchedEffect
+        if (tab.type == latestSelectedTab) return@LaunchedEffect
+
+        delay(TAB_SELECTION_DELAY_MS)
+        if (!TopTabFocusIntent(focusedTabType, latestFocusIntentToken).isLatest(focusIntentToken)) {
+            return@LaunchedEffect
+        }
+        if (tab.type != latestSelectedTab) {
+            onAction(CommonAction.ItemSelected(tab))
         }
     }
 }
 
 @Composable
 private fun InitialTabFocusEffect(
-    focusedTabIndex: Int,
-    tabFocusRequesters: List<FocusRequester>,
+    focusedTabType: TabType?,
+    tabFocusRequesters: Map<TabType, FocusRequester>,
     tabRowFocus: FocusRequester,
     contentFocus: FocusRequester,
     focusManager: FocusManager,
     lastFocusedRegion: TopTabFocusedRegion,
+    skipInitialFocus: Boolean,
 ) {
     LaunchedEffect(Unit) {
+        if (skipInitialFocus) return@LaunchedEffect
         delay(INITIAL_TAB_FOCUS_DELAY_MS)
         when (lastFocusedRegion) {
-            TopTabFocusedRegion.Tabs -> tabFocusRequesters.getOrNull(focusedTabIndex)?.requestFocus()
+            TopTabFocusedRegion.Tabs -> tabFocusRequesters[focusedTabType]?.requestFocus()
                 ?: tabRowFocus.requestFocus()
             TopTabFocusedRegion.Content -> restoreContentChildFocus(
                 contentFocus = contentFocus,
@@ -275,9 +288,9 @@ private fun TopTabBackHandler(
     isContentFocused: Boolean,
     state: MainViewState,
     tabRowFocus: FocusRequester,
-    tabFocusRequesters: List<FocusRequester>,
+    tabFocusRequesters: Map<TabType, FocusRequester>,
     onTabsFocused: () -> Unit,
-    onHomeFocused: (Int) -> Unit,
+    onHomeFocused: (TabType) -> Unit,
     onAction: (UIAction) -> Unit,
 ) {
     BackHandler(enabled = enabled) {
@@ -298,15 +311,15 @@ private fun TopTabBackHandler(
 
 private fun focusHomeTab(
     state: MainViewState,
-    tabFocusRequesters: List<FocusRequester>,
-    onHomeFocused: (Int) -> Unit,
+    tabFocusRequesters: Map<TabType, FocusRequester>,
+    onHomeFocused: (TabType) -> Unit,
     onAction: (UIAction) -> Unit,
 ) {
     val homeIndex = state.tabs.indexOfFirst { it.type == TabType.Home }.coerceAtLeast(0)
     state.tabs.getOrNull(homeIndex)?.let { homeTab ->
-        onHomeFocused(homeIndex)
+        onHomeFocused(homeTab.type)
         onAction(CommonAction.ItemSelected(homeTab))
-        tabFocusRequesters.getOrNull(homeIndex)?.requestFocus()
+        tabFocusRequesters[homeTab.type]?.requestFocus()
     }
 }
 
@@ -337,6 +350,35 @@ private fun ColumnScope.TopTabContentBox(
     Box(
         Modifier
             .weight(1f)
+            .topTabContentFocusBehavior(
+                contentFocus = contentFocus,
+                tabRowFocus = tabRowFocus,
+                coroutineScope = coroutineScope,
+                focusManager = focusManager,
+                onExitToTabs = onExitToTabs,
+                onFocused = onFocused,
+            )
+            .focusRestorer()
+            .focusGroup()
+    ) {
+        CompositionLocalProvider(
+            LocalTvDialogFocusRestorer provides contentDialogFocusRestorer
+        ) {
+            PuberCurrentTab()
+        }
+    }
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+private fun Modifier.topTabContentFocusBehavior(
+    contentFocus: FocusRequester,
+    tabRowFocus: FocusRequester,
+    coroutineScope: CoroutineScope,
+    focusManager: FocusManager,
+    onExitToTabs: () -> Unit,
+    onFocused: () -> Unit,
+): Modifier {
+    return this
             .focusRequester(contentFocus)
             .onFocusChanged { focusState ->
                 if (focusState.hasFocus) {
@@ -345,7 +387,9 @@ private fun ColumnScope.TopTabContentBox(
                 if (focusState.isFocused) {
                     coroutineScope.launch {
                         delay(CONTENT_CHILD_FOCUS_DELAY_MS)
-                        focusManager.moveFocus(FocusDirection.Down)
+                        if (!contentFocus.restoreFocusedChild()) {
+                            focusManager.moveFocus(FocusDirection.Down)
+                        }
                     }
                 }
             }
@@ -368,15 +412,6 @@ private fun ColumnScope.TopTabContentBox(
                     }
                 }
             }
-            .focusRestorer()
-            .focusGroup()
-    ) {
-        CompositionLocalProvider(
-            LocalTvDialogFocusRestorer provides contentDialogFocusRestorer
-        ) {
-            PuberCurrentTab()
-        }
-    }
 }
 
 private const val TAB_SELECTION_DELAY_MS = 300L

--- a/app/src/main/java/com/kino/puber/ui/feature/player/component/PlayerPreview.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/player/component/PlayerPreview.kt
@@ -67,21 +67,23 @@ private val previewEpisodes = VideoGridUIState(
     list = listOf(
         VideoGridItemUIState.Title("1 сезон, 10 серий"),
         VideoGridItemUIState.Items(
-            listOf(
+            items = listOf(
                 VideoItemUIState(1, "1. Привет фром Марс", "", "", showTitle = true),
                 VideoItemUIState(2, "2. Как мы поезд пропустили", "", "", showTitle = true),
                 VideoItemUIState(3, "3. Не шутите с плутонцами!", "", "", showTitle = true),
                 VideoItemUIState(4, "4. Как не надо спасать мир", "", "", showTitle = true),
-            )
+            ),
+            rowKey = "season_1",
         ),
         VideoGridItemUIState.Title("2 сезон, 10 серий"),
         VideoGridItemUIState.Items(
-            listOf(
+            items = listOf(
                 VideoItemUIState(11, "1. Венеровский централ", "", "", showTitle = true),
                 VideoItemUIState(12, "2. Космический мусор", "", "", showTitle = true),
                 VideoItemUIState(13, "3. Извинигород", "", "", showTitle = true),
                 VideoItemUIState(14, "4. Дед-Код", "", "", showTitle = true),
-            )
+            ),
+            rowKey = "season_2",
         ),
     )
 )

--- a/app/src/main/java/com/kino/puber/ui/feature/player/model/PlayerUIMapper.kt
+++ b/app/src/main/java/com/kino/puber/ui/feature/player/model/PlayerUIMapper.kt
@@ -137,7 +137,12 @@ internal class PlayerUIMapper(
                     isSeasonWatched = isSeasonWatched,
                 )
             } ?: emptyList()
-            gridItems.add(VideoGridItemUIState.Items(items))
+            gridItems.add(
+                VideoGridItemUIState.Items(
+                    items = items,
+                    rowKey = "season_${season.number}",
+                )
+            )
         }
         return VideoGridUIState(list = gridItems)
     }

--- a/app/src/test/kotlin/com/kino/puber/core/ui/navigation/component/RootAnchorCaptureRegistryTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/core/ui/navigation/component/RootAnchorCaptureRegistryTest.kt
@@ -1,0 +1,53 @@
+package com.kino.puber.core.ui.navigation.component
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class RootAnchorCaptureRegistryTest {
+
+    @Test
+    fun captureAndCompletionAreScopedToTheExactScreenKey() {
+        val registry = RootAnchorCaptureRegistry()
+        registry.register("screen-a") { LazyAnchor(index = 2, offset = 545) }
+        registry.register("screen-b") { LazyAnchor(index = 4, offset = 24) }
+
+        assertTrue(registry.capture("screen-a"))
+        assertEquals(LazyAnchor(index = 2, offset = 545), registry.savedAnchor("screen-a"))
+        assertEquals(null, registry.savedAnchor("screen-b"))
+        assertTrue(registry.restorePending)
+        assertFalse(registry.focusRestored)
+
+        registry.completeRestore("screen-b")
+        assertTrue(registry.restorePending)
+        assertEquals(RootAnchorRestoreCompletion(), registry.restoreCompletion)
+
+        registry.markFocusRestored()
+        assertTrue(registry.focusRestored)
+
+        registry.completeRestore("screen-a")
+        assertFalse(registry.restorePending)
+        assertFalse(registry.focusRestored)
+        assertEquals(
+            RootAnchorRestoreCompletion(screenKey = "screen-a", version = 1),
+            registry.restoreCompletion,
+        )
+    }
+
+    @Test
+    fun staleUnregisterCannotRemoveTheLatestRegistrationForTheSameScreen() {
+        val registry = RootAnchorCaptureRegistry()
+        val unregisterFirst = registry.register("screen") {
+            LazyAnchor(index = 1, offset = 10)
+        }
+        registry.register("screen") {
+            LazyAnchor(index = 3, offset = 30)
+        }
+
+        unregisterFirst()
+
+        assertTrue(registry.capture("screen"))
+        assertEquals(LazyAnchor(index = 3, offset = 30), registry.savedAnchor("screen"))
+    }
+}

--- a/app/src/test/kotlin/com/kino/puber/core/ui/navigation/component/RootAnchorCaptureRegistryTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/core/ui/navigation/component/RootAnchorCaptureRegistryTest.kt
@@ -29,6 +29,7 @@ internal class RootAnchorCaptureRegistryTest {
         registry.completeRestore("screen-a")
         assertFalse(registry.restorePending)
         assertFalse(registry.focusRestored)
+        assertEquals(null, registry.savedAnchor("screen-a"))
         assertEquals(
             RootAnchorRestoreCompletion(screenKey = "screen-a", version = 1),
             registry.restoreCompletion,
@@ -49,5 +50,71 @@ internal class RootAnchorCaptureRegistryTest {
 
         assertTrue(registry.capture("screen"))
         assertEquals(LazyAnchor(index = 3, offset = 30), registry.savedAnchor("screen"))
+    }
+
+    @Test
+    fun nestedCapturesRestoreEachScreenInLifoOrder() {
+        val registry = RootAnchorCaptureRegistry()
+        registry.register("screen-a") { LazyAnchor(index = 2, offset = 20) }
+        registry.register("screen-b") { LazyAnchor(index = 4, offset = 40) }
+
+        assertTrue(registry.capture("screen-a"))
+        assertTrue(registry.capture("screen-b"))
+        assertTrue(registry.restorePending)
+        assertFalse(registry.focusRestored)
+
+        registry.markFocusRestored()
+        assertTrue(registry.focusRestored)
+
+        registry.completeRestore("screen-a")
+        assertTrue(registry.restorePending)
+        assertTrue(registry.focusRestored)
+        assertEquals(RootAnchorRestoreCompletion(), registry.restoreCompletion)
+
+        registry.completeRestore("screen-b")
+        assertTrue(registry.restorePending)
+        assertFalse(registry.focusRestored)
+        assertEquals(null, registry.savedAnchor("screen-b"))
+        assertEquals(LazyAnchor(index = 2, offset = 20), registry.savedAnchor("screen-a"))
+        assertEquals(
+            RootAnchorRestoreCompletion(screenKey = "screen-b", version = 1),
+            registry.restoreCompletion,
+        )
+
+        registry.markFocusRestored()
+        assertTrue(registry.focusRestored)
+
+        registry.completeRestore("screen-a")
+        assertFalse(registry.restorePending)
+        assertFalse(registry.focusRestored)
+        assertEquals(null, registry.savedAnchor("screen-a"))
+        assertEquals(
+            RootAnchorRestoreCompletion(screenKey = "screen-a", version = 2),
+            registry.restoreCompletion,
+        )
+    }
+
+    @Test
+    fun sameKeyCapturesConsumeOnlyTheCompletedFrameAnchor() {
+        val registry = RootAnchorCaptureRegistry()
+        var anchor = LazyAnchor(index = 1, offset = 10)
+        registry.register("screen") { anchor }
+
+        assertTrue(registry.capture("screen"))
+        anchor = LazyAnchor(index = 3, offset = 30)
+        assertTrue(registry.capture("screen"))
+        assertEquals(LazyAnchor(index = 3, offset = 30), registry.savedAnchor("screen"))
+
+        registry.markFocusRestored()
+        registry.completeRestore("screen")
+
+        assertTrue(registry.restorePending)
+        assertEquals(LazyAnchor(index = 1, offset = 10), registry.savedAnchor("screen"))
+
+        registry.markFocusRestored()
+        registry.completeRestore("screen")
+
+        assertFalse(registry.restorePending)
+        assertEquals(null, registry.savedAnchor("screen"))
     }
 }

--- a/app/src/test/kotlin/com/kino/puber/core/ui/navigation/component/RootAnchorCaptureRegistryTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/core/ui/navigation/component/RootAnchorCaptureRegistryTest.kt
@@ -23,7 +23,7 @@ internal class RootAnchorCaptureRegistryTest {
         assertTrue(registry.restorePending)
         assertEquals(RootAnchorRestoreCompletion(), registry.restoreCompletion)
 
-        registry.markFocusRestored()
+        registry.markFocusRestored("screen-a")
         assertTrue(registry.focusRestored)
 
         registry.completeRestore("screen-a")
@@ -63,7 +63,7 @@ internal class RootAnchorCaptureRegistryTest {
         assertTrue(registry.restorePending)
         assertFalse(registry.focusRestored)
 
-        registry.markFocusRestored()
+        registry.markFocusRestored("screen-b")
         assertTrue(registry.focusRestored)
 
         registry.completeRestore("screen-a")
@@ -81,7 +81,7 @@ internal class RootAnchorCaptureRegistryTest {
             registry.restoreCompletion,
         )
 
-        registry.markFocusRestored()
+        registry.markFocusRestored("screen-a")
         assertTrue(registry.focusRestored)
 
         registry.completeRestore("screen-a")
@@ -105,16 +105,64 @@ internal class RootAnchorCaptureRegistryTest {
         assertTrue(registry.capture("screen"))
         assertEquals(LazyAnchor(index = 3, offset = 30), registry.savedAnchor("screen"))
 
-        registry.markFocusRestored()
+        registry.markFocusRestored("screen")
         registry.completeRestore("screen")
 
         assertTrue(registry.restorePending)
         assertEquals(LazyAnchor(index = 1, offset = 10), registry.savedAnchor("screen"))
 
-        registry.markFocusRestored()
+        registry.markFocusRestored("screen")
         registry.completeRestore("screen")
 
         assertFalse(registry.restorePending)
         assertEquals(null, registry.savedAnchor("screen"))
+    }
+
+    @Test
+    fun multiPopBackToDiscardsSkippedFramesBeforeRestoringTheReturnedScreen() {
+        val registry = RootAnchorCaptureRegistry()
+        registry.register("screen-a") { LazyAnchor(index = 1, offset = 10) }
+        registry.register("screen-b") { LazyAnchor(index = 2, offset = 20) }
+
+        assertTrue(registry.capture("screen-a"))
+        assertTrue(registry.capture("screen-b"))
+
+        registry.reconcilePendingRestore("screen-a")
+
+        assertTrue(registry.restorePending)
+        assertEquals(LazyAnchor(index = 1, offset = 10), registry.savedAnchor("screen-a"))
+        assertEquals(null, registry.savedAnchor("screen-b"))
+
+        registry.markFocusRestored("screen-b")
+        assertFalse(registry.focusRestored)
+
+        registry.markFocusRestored("screen-a")
+        assertTrue(registry.focusRestored)
+        registry.completeRestore("screen-a")
+
+        assertFalse(registry.restorePending)
+        assertEquals(
+            RootAnchorRestoreCompletion(screenKey = "screen-a", version = 1),
+            registry.restoreCompletion,
+        )
+    }
+
+    @Test
+    fun unrelatedNewRootReplacementClearsObsoletePendingFrames() {
+        val registry = RootAnchorCaptureRegistry()
+        registry.register("screen-a") { LazyAnchor(index = 1, offset = 10) }
+
+        assertTrue(registry.capture("screen-a"))
+
+        registry.reconcilePendingRestore("unrelated-screen")
+
+        assertFalse(registry.restorePending)
+        assertFalse(registry.focusRestored)
+        assertEquals(null, registry.savedAnchor("screen-a"))
+
+        registry.markFocusRestored("screen-a")
+        registry.completeRestore("screen-a")
+
+        assertEquals(RootAnchorRestoreCompletion(), registry.restoreCompletion)
     }
 }

--- a/app/src/test/kotlin/com/kino/puber/core/ui/uikit/component/moviesList/FocusTargetResolverTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/core/ui/uikit/component/moviesList/FocusTargetResolverTest.kt
@@ -1,0 +1,122 @@
+package com.kino.puber.core.ui.uikit.component.moviesList
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class FocusTargetResolverTest {
+
+    @Test
+    fun focusedFirstItemFallsThroughToTheItemAtTheRemovedIndex() {
+        assertEquals(
+            2,
+            resolveFocusedItemId(
+                previousItems = items(1, 2, 3),
+                updatedItems = items(2, 3),
+                focusedItemId = 1,
+            ),
+        )
+    }
+
+    @Test
+    fun focusedMiddleItemFallsThroughToTheRightNeighbor() {
+        assertEquals(
+            3,
+            resolveFocusedItemId(
+                previousItems = items(1, 2, 3, 4),
+                updatedItems = items(1, 3, 4),
+                focusedItemId = 2,
+            ),
+        )
+    }
+
+    @Test
+    fun focusedLastItemFallsBackToThePreviousItem() {
+        assertEquals(
+            2,
+            resolveFocusedItemId(
+                previousItems = items(1, 2, 3),
+                updatedItems = items(1, 2),
+                focusedItemId = 3,
+            ),
+        )
+    }
+
+    @Test
+    fun removingOnlyItemLeavesNoItemTarget() {
+        assertEquals(
+            null,
+            resolveFocusedItemId(
+                previousItems = items(1),
+                updatedItems = emptyList(),
+                focusedItemId = 1,
+            ),
+        )
+    }
+
+    @Test
+    fun emptyRowSelectsTheNearestRemainingRow() {
+        assertEquals(
+            "row_after",
+            nearestNonEmptyRowKey(
+                rows = listOf(
+                    FocusableRow("row_before", 2),
+                    FocusableRow("row_empty", 0),
+                    FocusableRow("row_after", 2),
+                ),
+                emptyRowIndex = 1,
+            ),
+        )
+    }
+
+    @Test
+    fun removingFocusedRowSelectsTheRowNowAtItsIndex() {
+        assertEquals(
+            "row_after",
+            resolveFocusedRowKey(
+                previousRows = rows("row_before", "row_removed", "row_after"),
+                updatedRows = rows("row_before", "row_after"),
+                focusedRowKey = "row_removed",
+            ),
+        )
+    }
+
+    @Test
+    fun removingTheOnlyFocusedRowSelectsTheRemainingContentRow() {
+        assertEquals(
+            "row_after",
+            resolveFocusedRowKey(
+                previousRows = rows("row_removed", "row_after"),
+                updatedRows = rows("row_after"),
+                focusedRowKey = "row_removed",
+            ),
+        )
+    }
+
+    @Test
+    fun removingFocusedLastRowSelectsThePreviousContentRow() {
+        assertEquals(
+            "row_before",
+            resolveFocusedRowKey(
+                previousRows = rows("row_before", "row_removed"),
+                updatedRows = rows("row_before"),
+                focusedRowKey = "row_removed",
+            ),
+        )
+    }
+
+    private fun items(vararg ids: Int): List<VideoItemUIState> {
+        return ids.map { id ->
+            VideoItemUIState(
+                id = id,
+                title = "Item $id",
+                imageUrl = "",
+                bigImageUrl = "",
+                showTitle = true,
+            )
+        }
+    }
+
+    private fun rows(vararg keys: String): List<FocusableRow> {
+        return keys.map { FocusableRow(key = it, itemCount = 1) }
+    }
+}

--- a/app/src/test/kotlin/com/kino/puber/ui/feature/main/toptabs/TopTabFocusIntentTest.kt
+++ b/app/src/test/kotlin/com/kino/puber/ui/feature/main/toptabs/TopTabFocusIntentTest.kt
@@ -1,0 +1,45 @@
+package com.kino.puber.ui.feature.main.toptabs
+
+import com.kino.puber.ui.feature.main.model.TabType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class TopTabFocusIntentTest {
+
+    @Test
+    fun selectedStateDoesNotReplaceAStillVisibleFocusedTab() {
+        val intent = TopTabFocusIntent(TabType.Movies).focus(TabType.Series)
+
+        val reconciled = intent.reconcile(
+            visibleTabs = listOf(TabType.Home, TabType.Movies, TabType.Series),
+            selectedTab = TabType.Movies,
+        )
+
+        assertEquals(TabType.Series, reconciled.focusedTab)
+        assertEquals(intent.token, reconciled.token)
+    }
+
+    @Test
+    fun removedFocusedTabFallsBackToSelectedVisibleTab() {
+        val intent = TopTabFocusIntent(TabType.Series).focus(TabType.Series)
+
+        val reconciled = intent.reconcile(
+            visibleTabs = listOf(TabType.Home, TabType.Movies),
+            selectedTab = TabType.Movies,
+        )
+
+        assertEquals(TabType.Movies, reconciled.focusedTab)
+        assertTrue(reconciled.token > intent.token)
+    }
+
+    @Test
+    fun staleDelayedSelectionTokenIsRejectedAfterAnotherTabGetsFocus() {
+        val firstIntent = TopTabFocusIntent(TabType.Movies).focus(TabType.Movies)
+        val latestIntent = firstIntent.focus(TabType.Series)
+
+        assertFalse(latestIntent.isLatest(firstIntent.token))
+        assertTrue(latestIntent.isLatest(latestIntent.token))
+    }
+}


### PR DESCRIPTION
## Summary
- Restore focus to the correct neighboring card when the focused item is removed.
- Stabilize TV tab and vertical navigation focus/viewport restoration across Details-to-Back flows.
- Reconcile root focus anchors to the actual BackTo/NewRoot destination, discarding skipped or obsolete frames.

## Compliance Review
Final Compliance Review passed with no violations. The final task diff is limited to FlowComponent.kt and RootAnchorCaptureRegistryTest.kt; repository contracts, specifications, workflow files, and evidence artifacts are unchanged.

## Verification
- RootAnchorCaptureRegistryTest passed 6/6, including multi-pop BackTo and unrelated NewRoot replacement regressions.
- Full `:app:testDevDebugUnitTest` passed 568/568.
- `:app:compileDevDebugKotlin` and `:app:compileDevDebugAndroidTestKotlin` passed.
- `git diff --check` passed.
- Fresh Android TV stage smoke passed rapid tab convergence, Home and Films Details-to-Back focus/viewport restoration, Home and Films Down-to-end/Right/Up containment, package liveness, and the mobile evidence audit (56 files). The emulator lock was released.
- An isolated forced replay of the task branch onto refreshed `origin/master` completed cleanly with a matching final tree.

## Skipped checks / blockers
None.