### PR TITLE
Release 1.7.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
     alias(libs.plugins.androidx.baselineprofile)
 }
 
-val currentVersion = "1.6.0"
+val currentVersion = "1.7.0"
 
 /**
  * Reads CLIENT_SECRET from local.properties or system environment variable


### PR DESCRIPTION
## Summary
- Bump the application version from 1.6.0 to 1.7.0 for the next minor release.
- Keep the release tag unpublished until this PR is merged.

## Compliance Review
Compliance Review passed with no direct violations. The change is limited to `app/build.gradle.kts`, is based on fetched `origin/master`, and the release branch is exactly one commit ahead of that base.

## Verification
- `./tools/agentw :app:compileDevDebugKotlin` — PASS (`BUILD SUCCESSFUL`)
- `git diff --check` — PASS

## Release context
- Release branch: `release/1.7.0`
- Release version: `1.7.0`
- Intended tag after merge: `v1.7.0`

## Known skipped checks
Local production signing inputs are unavailable, so production packaging was not locally proven. This is explicitly nonblocking for the version-bump PR under the release procedure.